### PR TITLE
Adopt branch-first agent workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ __pycache__/
 .env
 /graphify-out/
 /.pi-subagents/
+/.pi/subagents/
 /site/node_modules/
 /site/dist/
 /site/.astro/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,56 @@
 # Splinterm Agent Guardrails
 
+## 0. Branch-First Repository Workflow
+
+### 0.1 Main Worktree Is Coordination-Only
+
+The repository-root worktree on `main` is reserved for fetch, status inspection,
+review, approved integration, and release operations. Do not begin task-file
+mutations or task commits there; approved integration and release-boundary
+commits remain permitted.
+
+Before the first edit for an authorized task:
+
+* Fetch the current remote state.
+* Create a short-lived branch from the reviewed `origin/main` base.
+* Create or use a dedicated worktree for that branch.
+* Confirm the branch and worktree path before editing.
+
+Use milestone-oriented names such as `plan/0039-searchable-keybindings`,
+`feat/0039-binding-help-search`, `fix/font-reload-race`, or
+`docs/configuration-font-sync`. Do not use one long-lived branch for all of a
+release program.
+
+If pre-existing changes are found on `main`, partition and preserve them before
+creating the task worktree. Never sweep unrelated tracked or untracked files
+into the new branch, stash, commit, move, or delete them without establishing
+ownership. If ownership cannot be established, do not alter the changes; stop
+and obtain an ownership decision.
+
+### 0.2 One Writer Per Branch and Worktree
+
+One writer owns each task branch and worktree. Read-only scouting, review, and
+validation may inspect that worktree. Review fixes return to the same writer and
+branch by default.
+
+Concurrent writers still require the approval in Section 1.2 and separate
+branches and worktrees. Branch isolation does not authorize uncontrolled
+parallel edits. Serialize dependent milestones and work that overlaps known
+convergence points such as `wayland.rs`, `keymap.rs`, `action_menu.rs`, or
+`TODO.md`.
+
+### 0.3 Pull Request and Merge Boundary
+
+Each coherent branch must pass its owning plan's focused checks, the appropriate
+non-graphical boundary, actual-diff inspection, `git diff --check`, and required
+independent review before merge. Record exact validation and residual risks in
+the pull request.
+
+Prefer squash merge so `main` receives one coherent milestone commit. Delete the
+merged task branch and remove its worktree after verifying the merge. Releases,
+candidates, tags, and publication remain `main`-only and retain their separate
+approval requirements.
+
 ## 1. Cost and Delegation Stop-Loss
 
 ### 1.1 Routine Subagent Authorization

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,10 +15,12 @@ Keep the repository-root `main` worktree coordination-only. Create a short-lived
 branch and dedicated sibling worktree before editing:
 
 ```bash
+root=$PWD
+worktree=../splinterm-worktrees/0039-binding-help
 git fetch origin
-git worktree add ../splinterm-worktrees/0039-binding-help \
+git worktree add "$worktree" \
   -b feat/0039-binding-help-search origin/main
-cd ../splinterm-worktrees/0039-binding-help
+cd "$worktree"
 ```
 
 Use `plan/…`, `feat/…`, `fix/…`, `docs/…`, or `release/…` names with one coherent
@@ -32,8 +34,10 @@ Open a pull request only after focused validation, actual-diff inspection,
 Prefer squash merge. After the merge is verified:
 
 ```bash
-git worktree remove ../splinterm-worktrees/0039-binding-help
-git branch -d feat/0039-binding-help-search
+cd "$root"
+git worktree remove "$worktree"
+# A verified squash merge does not make the branch tip an ancestor of main.
+git branch -D feat/0039-binding-help-search
 ```
 
 Do not publish releases from task branches. Release candidates and promotion

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,36 @@ Read [`docs/status.md`](docs/status.md) for current product scope and
 protocol boundaries. Plans, spikes, benchmarks, and retained artifacts are
 historical evidence; do not rewrite them merely to match current marketing.
 
+## Branch and worktree workflow
+
+Keep the repository-root `main` worktree coordination-only. Create a short-lived
+branch and dedicated sibling worktree before editing:
+
+```bash
+git fetch origin
+git worktree add ../splinterm-worktrees/0039-binding-help \
+  -b feat/0039-binding-help-search origin/main
+cd ../splinterm-worktrees/0039-binding-help
+```
+
+Use `plan/…`, `feat/…`, `fix/…`, `docs/…`, or `release/…` names with one coherent
+milestone per branch. One writer owns each branch/worktree; dependent or
+overlapping milestones remain serial. Read-only review may inspect the same
+worktree, while intentionally concurrent writers require separate worktrees and
+explicit approval under [`AGENTS.md`](AGENTS.md).
+
+Open a pull request only after focused validation, actual-diff inspection,
+`git diff --check`, and the independent review required by the owning plan.
+Prefer squash merge. After the merge is verified:
+
+```bash
+git worktree remove ../splinterm-worktrees/0039-binding-help
+git branch -d feat/0039-binding-help-search
+```
+
+Do not publish releases from task branches. Release candidates and promotion
+remain bound to reviewed commits on `main`.
+
 ## Standard validation
 
 Use the narrowest tier that proves the current boundary; do not run every tier

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,8 +18,8 @@ branch and dedicated sibling worktree before editing:
 root=$PWD
 worktree=../splinterm-worktrees/0039-binding-help
 git fetch origin
-git worktree add "$worktree" \
-  -b feat/0039-binding-help-search origin/main
+git worktree add --no-track -b feat/0039-binding-help-search \
+  "$worktree" origin/main
 cd "$worktree"
 ```
 
@@ -31,6 +31,13 @@ explicit approval under [`AGENTS.md`](AGENTS.md).
 
 Open a pull request only after focused validation, actual-diff inspection,
 `git diff --check`, and the independent review required by the owning plan.
+Publish the exact task branch with an upstream of the same name, then open the
+pull request:
+
+```bash
+git push --set-upstream origin HEAD
+```
+
 Prefer squash merge. After the merge is verified:
 
 ```bash

--- a/site/src/content/docs/docs/development/index.md
+++ b/site/src/content/docs/docs/development/index.md
@@ -5,6 +5,25 @@ description: Build, test, and understand the Splinterm workspace without mixing 
 
 Splinterm is a Rust workspace with separate crates for the graphical client, daemon, domain model, protocol, relay, MCP adapter, PTY boundary, and Foot-derived terminal kernel.
 
+## Branch-first development
+
+Keep the root `main` checkout for coordination and releases. Make each coherent
+plan, feature, fix, or documentation milestone on a short-lived branch in a
+dedicated sibling worktree:
+
+```bash
+git fetch origin
+git worktree add ../splinterm-worktrees/my-change \
+  -b feat/my-change origin/main
+```
+
+One writer owns each worktree. Dependent or overlapping changes remain serial;
+read-only review may inspect the task worktree. Validate and review the actual
+diff before opening a pull request, prefer squash merge, then remove the merged
+worktree and branch. Release candidates and publication originate only from
+reviewed `main` commits. See the repository's `CONTRIBUTING.md` and `AGENTS.md`
+for the complete workflow and agent-specific stop-loss rules.
+
 ## Standard validation
 
 Run from the repository root:

--- a/site/src/content/docs/docs/development/index.md
+++ b/site/src/content/docs/docs/development/index.md
@@ -13,13 +13,14 @@ dedicated sibling worktree:
 
 ```bash
 git fetch origin
-git worktree add ../splinterm-worktrees/my-change \
-  -b feat/my-change origin/main
+git worktree add --no-track -b feat/my-change \
+  ../splinterm-worktrees/my-change origin/main
 ```
 
 One writer owns each worktree. Dependent or overlapping changes remain serial;
 read-only review may inspect the task worktree. Validate and review the actual
-diff before opening a pull request, prefer squash merge, then remove the merged
+diff, then publish the task branch with `git push --set-upstream origin HEAD`
+before opening a pull request. Prefer squash merge, then remove the merged
 worktree and branch. Release candidates and publication originate only from
 reviewed `main` commits. See the repository's `CONTRIBUTING.md` and `AGENTS.md`
 for the complete workflow and agent-specific stop-loss rules.


### PR DESCRIPTION
## Problem

Agents have been mutating the root `main` checkout directly, leaving task work and unrelated local files in one worktree.

## Change

- reserve the root `main` worktree for coordination, approved integration, and releases;
- require short-lived task branches in sibling worktrees before edits;
- preserve one writer per branch/worktree and existing approval stop-losses;
- document PR, squash-merge, cleanup, and main-only release boundaries;
- ignore generated `.pi/subagents/` artifacts.

## Validation

- `git diff --check`
- `(cd site && npm ci --ignore-scripts && npm run validate)`
  - Astro: 0 errors, warnings, or hints
  - link checker: 560 links across 19 pages

## Review

Fresh read-only review initially rejected ambiguous integration wording and the missing unknown-ownership stop condition. Both findings were fixed in `AGENTS.md`; no other blocker remained.

## Residual risk

No runtime behavior changes. GitHub branch protection and squash-only merge settings are configured separately at the repository level.