### PR TITLE
Plan the 0.2 product program

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -186,6 +186,24 @@ This milestone is not an alpha3 blocker, but it is planned before `1.0`.
 - [x] Perform separately approved guarded packaged graphical acceptance for the
   Splinterm-owned, opt-in Omarchy screensaver integration.
 
+## 0.2.0 persistence expansion and upgrade handoff
+
+- [ ] Complete [Plan 0037](docs/plans/0037-0.2-persistence-and-upgrade-handoff.md).
+- [ ] Approve precise persistence lifetime vocabulary, the in-place re-exec ADR,
+  and a separate privacy decision before any durable terminal archive work.
+- [ ] Prove an adoptable Linux PTY session preserves PID, process group, session,
+  one-reader ownership, reaping, signaling, ordered I/O, and bounded rollback.
+- [ ] Define bounded terminal checkpoint, descriptor, handoff, and rollback ABIs
+  with exact parser continuation, corruption rejection, and migration tests.
+- [ ] Add a daemon handoff coordinator that fences authority, adopts atomically,
+  reconnects clients by full resnapshot, and fault-injects every rollback edge.
+- [ ] Make launcher and packaging UX distinguish matching, compatible, blocked,
+  bootstrap, destructive-fallback, downgrade, and interrupted upgrade states.
+- [ ] Keep recipe-only reboot restore as the default; gate optional archives on
+  reviewed retention, deletion, export, trusted-read, and privacy policy.
+- [ ] Record serial workspace, package, identity, rollback, architecture,
+  security/privacy, release, and separately approved graphical evidence.
+
 ## 0.2.0 live Omarchy system-font synchronization
 
 - [ ] Complete [Plan 0038](docs/plans/0038-0.2-live-omarchy-font-sync.md).

--- a/TODO.md
+++ b/TODO.md
@@ -185,3 +185,74 @@ This milestone is not an alpha3 blocker, but it is planned before `1.0`.
   extracted package.
 - [x] Perform separately approved guarded packaged graphical acceptance for the
   Splinterm-owned, opt-in Omarchy screensaver integration.
+
+## 0.2.0 live Omarchy system-font synchronization
+
+- [ ] Complete [Plan 0038](docs/plans/0038-0.2-live-omarchy-font-sync.md).
+- [ ] Follow Omarchy's fontconfig `monospace` family live only when
+  `main.font` is unset; preserve explicit Splinterm font authority.
+- [ ] Stage and publish complete renderer font generations transactionally,
+  retaining the last valid generation when resolution or validation fails.
+- [ ] Rebuild font-derived caches and Window geometry coherently while
+  preserving topology, focus, history, output DPI, configured size/policy,
+  padding, and runtime zoom.
+- [ ] Emit at most one final PTY resize per affected live Splint and never
+  restart the daemon, shell, or Window for a valid family change.
+- [ ] Add precedence, fingerprint, coalescing, rollback, cache-retirement,
+  geometry, resize-count, performance, and separately approved graphical tests.
+
+## 0.2.0 searchable keybindings and Lair controls
+
+- [ ] Complete [Plan 0039](docs/plans/0039-0.2-searchable-keybindings-and-lair-controls.md).
+- [ ] Add bounded deterministic fuzzy search to the effective keybinding-help
+  display across action labels, configuration names, shortcuts, sources, and
+  closed keywords.
+- [ ] Keep search editing modal and terminal-safe, with stable ranking,
+  clear-then-close Escape behavior, bounded navigation, and a calm no-match state.
+- [ ] Make Save, pin-toggle, Preview, and Restore current Lair closed bindable
+  actions using the existing lifecycle targeting, availability, and confirmation
+  paths.
+- [ ] Add reviewed collision-free `omarchy-tmux` defaults while preserving every
+  existing Lair shortcut and strict custom-overlay support.
+- [ ] Prove registry, help, CLI inspection, command-palette shortcut projection,
+  keyboard dispatch, and lifecycle behavior cannot drift.
+
+## Maintainability and architecture follow-up
+
+Track the findings from the
+[2026-08-14 code-size and architecture review](docs/reviews/2026-08-14-code-size-and-architecture.md).
+These are changeability improvements, not evidence of a blocker-level system
+redesign or a mandate to reduce security, protocol, oracle, or regression
+coverage.
+
+- [ ] Extract the secure policy loader, typed representation, validation, and
+  normalized inspection API into a narrow shared crate used by `splinterd` and
+  `splinterm`; initially retain the daemon API as a compatibility wrapper and
+  preserve every ownership, permission, size, shape, and semantic check.
+- [ ] Decompose daemon request execution into private access, topology,
+  history/search, control, and terminal-action handlers while preserving one
+  exhaustive top-level `Request` match and the centralized authorization and
+  resource tables.
+- [ ] Refactor the Wayland update and draw pipelines into explicit private phases
+  for update reduction, frame reconciliation, SHM/backing synchronization,
+  overlay composition, and commit finalization while preserving Wayland object
+  ownership and the atomic acquire/damage/commit sequence.
+- [ ] Split topology-manager command handling into picker,
+  creation/materialization, Lair lifecycle, Dojo lifecycle, and tab lifecycle
+  handlers while retaining one serialized manager loop and typed outcomes.
+- [ ] Move automation-client DTO projection, events/subscriptions, image
+  transport/cache, and connection framing/cancellation into private modules,
+  re-exporting the existing public API unchanged.
+- [ ] Add a canonical exhaustive `AuditOperation::as_str()` to
+  `splinterm-protocol` and remove the duplicate automation-client and MCP string
+  mappings.
+- [ ] Conservatively extract repeated MCP mutation preflight, revision, and
+  response plumbing while keeping the closed tool-name match visibly exhaustive
+  and authoritative.
+- [ ] Document a review rule requiring a cohesion, security, or generated-table
+  rationale for new functions over roughly 200–300 lines; use it to prevent new
+  orchestration hotspots rather than mechanically splitting existing code.
+- [ ] If retained evidence becomes a material clone or navigation problem,
+  evaluate Git LFS or versioned external object storage with checked manifests,
+  immutable provenance, offline behavior, and tooling migration defined before
+  moving any artifact.

--- a/docs/plans/0037-0.2-persistence-and-upgrade-handoff.md
+++ b/docs/plans/0037-0.2-persistence-and-upgrade-handoff.md
@@ -138,7 +138,7 @@ new splinterd generation, same PID
   -> validates and adopts every checkpoint + descriptor
   -> resumes PTY draining before accepting clients
   -> publishes a new daemon generation
-  -> makes stale-inode local Windows relaunch the installed adjacent client
+  -> makes stale-inode local Windows relaunch the pinned forward client image
   -> lets the new local processes and reauthenticated remote clients resnapshot
 ```
 
@@ -170,13 +170,16 @@ The installed candidate must support an offline preflight command that validates
 its executable identity, checkpoint schema, helper adjacency, state directory,
 resource bounds, and rollback contract without touching live PTYs. The old
 running daemon must open the candidate once with no-follow and owner/mode checks,
-validate its device, inode, digest, and package adjacency, run compatibility
-preflight against that exact open image, and retain the descriptor through
-quiescence. The final forward handoff must execute that same approved descriptor
-with `execveat(..., AT_EMPTY_PATH)`; it must never resolve the package pathname a
-second time. Replacement, deletion, or mismatch of the pathname after pinning is
-therefore harmless, while inability to preflight or execute the pinned image
-cancels the handoff without touching live PTYs.
+open the exact adjacent `splinterm` client as its trusted-UI pair, validate both
+device/inode/digest identities and package adjacency, run compatibility preflight
+against that exact pair, and retain both descriptors through quiescence. The
+final forward handoff must execute the approved daemon descriptor with
+`execveat(..., AT_EMPTY_PATH)` and bind trusted-UI authority to the paired client
+descriptor recorded in the manifest; stale local Windows relaunch through that
+pinned client image rather than resolving the package pathname again.
+Replacement, deletion, or mismatch of either pathname after pinning is therefore
+harmless, while inability to preflight or execute the pinned pair cancels the
+handoff without touching live PTYs.
 
 A compatible private client protocol does not imply a compatible handoff schema.
 
@@ -194,8 +197,9 @@ runtime object. It must identify, without terminal-body logging:
 - terminal revision, history generation, and checkpoint format;
 - retained image metadata/body descriptor disposition;
 - durable-state generation already committed;
-- validated forward-candidate descriptor and immutable identity; and
-- rollback executable descriptor and rollback manifest location.
+- validated forward daemon/client descriptor pair and immutable identities;
+- validated rollback daemon/client descriptor pair and immutable identities; and
+- rollback manifest location.
 
 Every count, string, descriptor slot, body, and aggregate byte size requires a
 hard bound. Duplicate IDs or descriptors, missing PTYs, changed child identity,
@@ -241,9 +245,10 @@ At minimum, preserve:
   distinct cloned reader is intentionally adopted;
 - any descriptor required for exact image continuity;
 - the sealed checkpoint manifest;
-- the exact validated candidate-image descriptor as the only forward exec
-  target;
-- an open descriptor for the old daemon image as the rollback target; and
+- the exact validated candidate daemon/client descriptor pair as the only
+  forward exec and trusted local-client relaunch authority;
+- open descriptors for the old daemon and its matching trusted client as the
+  rollback pair; and
 - either the listener or a guarded socket-recreation capability.
 
 No client socket, consent capability, policy grant, clipboard object, arbitrary
@@ -275,7 +280,8 @@ The coordinator must then:
    after which no cooperative rollback to the pre-exec checkpoint is permitted;
 9. resume PTY draining and publish the already staged generation without another
    fallible adoption step before reopening ordinary admission; and
-10. require stale-inode local Windows to close and relaunch the installed client,
+10. require stale-inode local Windows to close and relaunch the pinned forward
+    client image,
    while newly trusted local processes and reauthenticated remote clients obtain
    a full authoritative resnapshot.
 
@@ -298,8 +304,9 @@ Daemon-lifetime security authority does not silently cross generations.
 - Consent grants, pending prompts, transfer requests, and audit cursors expire.
 - Existing packaged graphical clients whose executable inode no longer matches
   the new daemon cannot regain trusted-UI authority by reconnecting. They close
-  only after daemon adoption is published, relaunch the installed adjacent
-  `splinterm`, and let that new process establish trusted identity and resnapshot.
+  only after daemon adoption is published, relaunch the pinned forward
+  `splinterm` descriptor, and let that new process establish trusted identity and
+  resnapshot.
 - A bounded identity-transfer mechanism would require separate review and is not
   the `0.2.0` baseline.
 - Controller ownership defaults to released unless a separately reviewed
@@ -318,14 +325,16 @@ quiescence step cancels the handoff and resumes the old generation unchanged.
 
 To reduce the risk after exec:
 
-1. the old daemon opens and fully validates the candidate image, runs preflight
-   against that exact descriptor, and uses the same descriptor as the sole
-   `execveat(..., AT_EMPTY_PATH)` forward target;
+1. the old daemon opens and fully validates the candidate daemon/client pair,
+   runs preflight against those exact descriptors, uses the daemon descriptor as
+   the sole `execveat(..., AT_EMPTY_PATH)` forward target, and gives only the
+   paired client descriptor trusted local relaunch authority;
 2. the old daemon opens `/proc/self/exe` as the authoritative old-image inode,
-   even when the package pathname already names a newer binary, and preserves
-   that descriptor explicitly;
-3. the rollback manifest records the validated old helper identity or forbids
-   every new spawn until the installed adjacent helper is proven compatible;
+   even when the package pathname already names a newer binary, and pairs it
+   with the exact validated old client image retained from daemon startup or an
+   approved rollback bundle;
+3. handoff is blocked unless both forward and rollback daemon/client pairs are
+   complete, immutable, mutually compatible, and executable by descriptor;
 4. the new image completes all fallible adoption and publication staging before
    taking input, reading a post-checkpoint PTY byte, or publishing readiness;
 5. if adoption fails before that first PTY read, it invokes the rollback image by
@@ -543,8 +552,11 @@ change.
   adoption;
 - prove `/proc/self/exe` rollback after the installed path has been replaced,
   including deleted-old-image and adjacent-helper mismatch cases;
-- prove replacing or deleting the candidate pathname after preflight cannot
-  change the pinned forward image and that only the validated descriptor runs;
+- prove replacing or deleting either candidate pathname after preflight cannot
+  change the pinned forward daemon/client pair, trusted-UI authority, or exact
+  descriptors executed;
+- prove rollback cannot select a client image newer than or incompatible with
+  the pinned old daemon generation;
 - measure the no-reader interval and output ordering under sustained output; and
 - record why a replacement sibling daemon is insufficient without a broker.
 
@@ -576,8 +588,9 @@ accepted fixture matrix.
 
 - add preflight, quiescence, exec adoption, rollback, and generation publication;
 - fence mutations, input, resize, control transfer, consent, and subscriptions;
-- relaunch stale-inode local Windows through the installed adjacent client and
-  let new trusted local processes plus reauthenticated remote clients resnapshot;
+- relaunch stale-inode local Windows through the pinned forward client descriptor
+  and let new trusted local processes plus reauthenticated remote clients
+  resnapshot;
 - reset daemon-lifetime authority and reload persistent policy;
 - emit bounded correlated diagnostics for every phase and failure; and
 - prove old clients cannot act after generation replacement.
@@ -641,7 +654,8 @@ Also require:
   candidate crash/hang with the documented non-continuity result;
 - repeated package upgrade/rollback in an isolated user service, including
   stale-inode local Window relaunch and trusted-identity re-establishment;
-- daemon/client build and inode identity evidence;
+- forward and rollback daemon/client descriptor-pair build, inode, digest,
+  adjacency, relaunch, and trusted-authority evidence;
 - no staged files and a clean canonical Foot checkout;
 - fresh read-only architecture, lifecycle, security/privacy, and release reviews;
   and

--- a/docs/plans/0037-0.2-persistence-and-upgrade-handoff.md
+++ b/docs/plans/0037-0.2-persistence-and-upgrade-handoff.md
@@ -138,7 +138,8 @@ new splinterd generation, same PID
   -> validates and adopts every checkpoint + descriptor
   -> resumes PTY draining before accepting clients
   -> publishes a new daemon generation
-  -> asks clients to reconnect/resnapshot
+  -> makes stale-inode local Windows relaunch the installed adjacent client
+  -> lets the new local processes and reauthenticated remote clients resnapshot
 ```
 
 ### Bootstrap boundary
@@ -268,12 +269,17 @@ The coordinator must then:
 5. bound the period in which no userspace reader drains a PTY;
 6. preserve exact byte ordering across the checkpoint boundary;
 7. resume PTY draining before reopening ordinary admission; and
-8. force every client to reconnect and obtain a full authoritative resnapshot.
+8. require stale-inode local Windows to close and relaunch the installed client,
+   while newly trusted local processes and reauthenticated remote clients obtain
+   a full authoritative resnapshot.
 
 A child may continue producing output during exec. The handoff must complete
 within a measured deadline short enough that the kernel PTY buffer does not
 become the persistence mechanism. Timeout before exec returns to the old
-running generation. Timeout after exec invokes rollback.
+running generation. A cooperative timeout after exec invokes rollback only
+while the candidate remains alive and capable of running the rollback handler;
+an abrupt crash, `SIGKILL`, or wedged runtime belongs to the daemon-crash row of
+the lifetime matrix and has no `0.2.0` live-continuity guarantee.
 
 ### Authority reset
 
@@ -282,7 +288,12 @@ Daemon-lifetime security authority does not silently cross generations.
 - Persistent policy is reloaded and revalidated by the new binary.
 - Automation connections disconnect and must reauthenticate.
 - Consent grants, pending prompts, transfer requests, and audit cursors expire.
-- Graphical clients reconnect and re-establish trusted executable identity.
+- Existing packaged graphical clients whose executable inode no longer matches
+  the new daemon cannot regain trusted-UI authority by reconnecting. They close
+  only after daemon adoption is published, relaunch the installed adjacent
+  `splinterm`, and let that new process establish trusted identity and resnapshot.
+- A bounded identity-transfer mechanism would require separate review and is not
+  the `0.2.0` baseline.
 - Controller ownership defaults to released unless a separately reviewed
   same-client reconnection token can be proven safe and bounded.
 - Audit records report handoff start, adoption, rollback, and final outcome
@@ -314,10 +325,20 @@ To reduce the risk after exec:
 6. if both adoption and rollback fail, systemd reports a failed service and the
    diagnostics must state that live-process continuity is no longer guaranteed.
 
-No implementation may claim transactional migration until a fault-injection
-matrix proves failure at every boundary either leaves the old generation live or
-successfully rolls it back. A successful exec without successful adoption is
-not a successful upgrade.
+Post-exec rollback is cooperative, not process-failure recovery. If the candidate
+crashes, is killed, or wedges before its rollback handler runs, the original PID
+and child-parent/reaping authority are already gone. A minimal guardian could
+retain duplicate PTY and image descriptors, but it cannot recreate that
+parenthood; guaranteeing continuity across this interval requires a separately
+approved persistent broker/subreaper architecture and is outside the baseline
+in-place handoff.
+
+The implementation must minimize and measure this destructive interval, perform
+all representable validation before exec, fault-inject every handled pre-exec and
+cooperative post-exec failure, and report abrupt post-exec failure as daemon
+crash without claiming live continuity. A successful exec without successful
+adoption is not a successful upgrade, and `0.2.0` must not call the migration
+fully transactional.
 
 ## Package and launcher behavior
 
@@ -541,14 +562,17 @@ accepted fixture matrix.
 
 - add preflight, quiescence, exec adoption, rollback, and generation publication;
 - fence mutations, input, resize, control transfer, consent, and subscriptions;
-- reconnect local and remote graphical clients with full resnapshot;
+- relaunch stale-inode local Windows through the installed adjacent client and
+  let new trusted local processes plus reauthenticated remote clients resnapshot;
 - reset daemon-lifetime authority and reload persistent policy;
 - emit bounded correlated diagnostics for every phase and failure; and
 - prove old clients cannot act after generation replacement.
 
-**Gate:** fault injection at every pre-exec and post-exec boundary preserves the
-old generation or completes rollback; no partial generation becomes
-addressable.
+**Gate:** every pre-exec failure preserves the old generation, every handled
+post-exec adoption failure either completes cooperative rollback or stays
+non-addressable, stale local client inodes never regain trusted authority, and
+abrupt candidate crash/hang evidence is reported against the explicit
+non-continuity boundary rather than mislabeled as recoverable.
 
 ### Milestone 4 — package, launcher, and upgrade UX
 
@@ -597,8 +621,10 @@ git diff --check
 Also require:
 
 - handoff fault injection under idle, sustained output, resize, image, search,
-  multiple controllers, and process-exit races;
-- repeated package upgrade/rollback in an isolated user service;
+  multiple controllers, process-exit races, cooperative adoption failure, and
+  abrupt candidate crash/hang with the documented non-continuity result;
+- repeated package upgrade/rollback in an isolated user service, including
+  stale-inode local Window relaunch and trusted-identity re-establishment;
 - daemon/client build and inode identity evidence;
 - no staged files and a clean canonical Foot checkout;
 - fresh read-only architecture, lifecycle, security/privacy, and release reviews;

--- a/docs/plans/0037-0.2-persistence-and-upgrade-handoff.md
+++ b/docs/plans/0037-0.2-persistence-and-upgrade-handoff.md
@@ -268,8 +268,14 @@ The coordinator must then:
 4. continue draining PTY output until the actor-linearized checkpoint boundary;
 5. bound the period in which no userspace reader drains a PTY;
 6. preserve exact byte ordering across the checkpoint boundary;
-7. resume PTY draining before reopening ordinary admission; and
-8. require stale-inode local Windows to close and relaunch the installed client,
+7. in the candidate, complete every fallible checkpoint/descriptor adoption,
+   terminal restoration, listener recreation, policy load, and publication
+   staging before reading one post-checkpoint PTY byte;
+8. mark an irreversible adoption commit immediately before the first PTY read,
+   after which no cooperative rollback to the pre-exec checkpoint is permitted;
+9. resume PTY draining and publish the already staged generation without another
+   fallible adoption step before reopening ordinary admission; and
+10. require stale-inode local Windows to close and relaunch the installed client,
    while newly trusted local processes and reauthenticated remote clients obtain
    a full authoritative resnapshot.
 
@@ -277,8 +283,10 @@ A child may continue producing output during exec. The handoff must complete
 within a measured deadline short enough that the kernel PTY buffer does not
 become the persistence mechanism. Timeout before exec returns to the old
 running generation. A cooperative timeout after exec invokes rollback only
-while the candidate remains alive and capable of running the rollback handler;
-an abrupt crash, `SIGKILL`, or wedged runtime belongs to the daemon-crash row of
+while the candidate remains alive, remains before the first post-checkpoint PTY
+read, and can run the rollback handler. Once any new PTY byte is consumed, the
+candidate may not restore the older checkpoint; an abrupt crash, `SIGKILL`,
+wedged runtime, or failure after that commit belongs to the daemon-crash row of
 the lifetime matrix and has no `0.2.0` live-continuity guarantee.
 
 ### Authority reset
@@ -318,12 +326,16 @@ To reduce the risk after exec:
    that descriptor explicitly;
 3. the rollback manifest records the validated old helper identity or forbids
    every new spawn until the installed adjacent helper is proven compatible;
-4. the new image validates all inherited descriptors and checkpoint sections
-   before taking input or publishing readiness;
-5. if adoption fails, it invokes the rollback image by descriptor with
-   `execveat(..., AT_EMPTY_PATH)` and the same PTYs and rollback manifest; and
-6. if both adoption and rollback fail, systemd reports a failed service and the
-   diagnostics must state that live-process continuity is no longer guaranteed.
+4. the new image completes all fallible adoption and publication staging before
+   taking input, reading a post-checkpoint PTY byte, or publishing readiness;
+5. if adoption fails before that first PTY read, it invokes the rollback image by
+   descriptor with `execveat(..., AT_EMPTY_PATH)` and the unchanged PTYs and
+   rollback manifest;
+6. after the first PTY read, cooperative rollback to the pre-exec checkpoint is
+   forbidden and no later adoption/publication step may be fallible; and
+7. if either pre-read rollback or committed adoption fails, systemd reports a
+   failed service and diagnostics state that live-process continuity is no longer
+   guaranteed.
 
 Post-exec rollback is cooperative, not process-failure recovery. If the candidate
 crashes, is killed, or wedges before its rollback handler runs, the original PID
@@ -334,11 +346,13 @@ approved persistent broker/subreaper architecture and is outside the baseline
 in-place handoff.
 
 The implementation must minimize and measure this destructive interval, perform
-all representable validation before exec, fault-inject every handled pre-exec and
-cooperative post-exec failure, and report abrupt post-exec failure as daemon
-crash without claiming live continuity. A successful exec without successful
-adoption is not a successful upgrade, and `0.2.0` must not call the migration
-fully transactional.
+all representable validation before exec, complete every remaining fallible
+adoption step before the first new PTY read, and fault-inject every handled
+pre-exec and pre-read post-exec failure. Tests must prove rollback never follows
+consumption of unjournaled post-checkpoint bytes. Abrupt or post-commit failure is
+reported as daemon crash without claiming live continuity. A successful exec
+without successful adoption is not a successful upgrade, and `0.2.0` must not
+call the migration fully transactional.
 
 ## Package and launcher behavior
 
@@ -569,10 +583,11 @@ accepted fixture matrix.
 - prove old clients cannot act after generation replacement.
 
 **Gate:** every pre-exec failure preserves the old generation, every handled
-post-exec adoption failure either completes cooperative rollback or stays
-non-addressable, stale local client inodes never regain trusted authority, and
-abrupt candidate crash/hang evidence is reported against the explicit
-non-continuity boundary rather than mislabeled as recoverable.
+post-exec failure before the first new PTY read either completes cooperative
+rollback or stays non-addressable, no rollback can discard consumed PTY bytes,
+stale local client inodes never regain trusted authority, and post-commit
+candidate crash/hang evidence is reported against the explicit non-continuity
+boundary rather than mislabeled as recoverable.
 
 ### Milestone 4 — package, launcher, and upgrade UX
 
@@ -621,8 +636,9 @@ git diff --check
 Also require:
 
 - handoff fault injection under idle, sustained output, resize, image, search,
-  multiple controllers, process-exit races, cooperative adoption failure, and
-  abrupt candidate crash/hang with the documented non-continuity result;
+  multiple controllers, process-exit races, cooperative pre-read adoption
+  failure, attempted rollback after PTY consumption, and abrupt post-commit
+  candidate crash/hang with the documented non-continuity result;
 - repeated package upgrade/rollback in an isolated user service, including
   stale-inode local Window relaunch and trusted-identity re-establishment;
 - daemon/client build and inode identity evidence;

--- a/docs/plans/0037-0.2-persistence-and-upgrade-handoff.md
+++ b/docs/plans/0037-0.2-persistence-and-upgrade-handoff.md
@@ -167,7 +167,15 @@ The launcher must not infer safety from `ping` alone. The running daemon reports
 
 The installed candidate must support an offline preflight command that validates
 its executable identity, checkpoint schema, helper adjacency, state directory,
-resource bounds, and rollback contract without touching live PTYs.
+resource bounds, and rollback contract without touching live PTYs. The old
+running daemon must open the candidate once with no-follow and owner/mode checks,
+validate its device, inode, digest, and package adjacency, run compatibility
+preflight against that exact open image, and retain the descriptor through
+quiescence. The final forward handoff must execute that same approved descriptor
+with `execveat(..., AT_EMPTY_PATH)`; it must never resolve the package pathname a
+second time. Replacement, deletion, or mismatch of the pathname after pinning is
+therefore harmless, while inability to preflight or execute the pinned image
+cancels the handoff without touching live PTYs.
 
 A compatible private client protocol does not imply a compatible handoff schema.
 
@@ -184,7 +192,8 @@ runtime object. It must identify, without terminal-body logging:
 - controller and subscription disposition;
 - terminal revision, history generation, and checkpoint format;
 - retained image metadata/body descriptor disposition;
-- durable-state generation already committed; and
+- durable-state generation already committed;
+- validated forward-candidate descriptor and immutable identity; and
 - rollback executable descriptor and rollback manifest location.
 
 Every count, string, descriptor slot, body, and aggregate byte size requires a
@@ -231,6 +240,8 @@ At minimum, preserve:
   distinct cloned reader is intentionally adopted;
 - any descriptor required for exact image continuity;
 - the sealed checkpoint manifest;
+- the exact validated candidate-image descriptor as the only forward exec
+  target;
 - an open descriptor for the old daemon image as the rollback target; and
 - either the listener or a guarded socket-recreation capability.
 
@@ -288,16 +299,19 @@ quiescence step cancels the handoff and resumes the old generation unchanged.
 
 To reduce the risk after exec:
 
-1. the old daemon opens `/proc/self/exe` as the authoritative old-image inode,
+1. the old daemon opens and fully validates the candidate image, runs preflight
+   against that exact descriptor, and uses the same descriptor as the sole
+   `execveat(..., AT_EMPTY_PATH)` forward target;
+2. the old daemon opens `/proc/self/exe` as the authoritative old-image inode,
    even when the package pathname already names a newer binary, and preserves
    that descriptor explicitly;
-2. the rollback manifest records the validated old helper identity or forbids
+3. the rollback manifest records the validated old helper identity or forbids
    every new spawn until the installed adjacent helper is proven compatible;
-3. the new image validates all inherited descriptors and checkpoint sections
+4. the new image validates all inherited descriptors and checkpoint sections
    before taking input or publishing readiness;
-4. if adoption fails, it invokes the rollback image by descriptor with
+5. if adoption fails, it invokes the rollback image by descriptor with
    `execveat(..., AT_EMPTY_PATH)` and the same PTYs and rollback manifest; and
-5. if both adoption and rollback fail, systemd reports a failed service and the
+6. if both adoption and rollback fail, systemd reports a failed service and the
    diagnostics must state that live-process continuity is no longer guaranteed.
 
 No implementation may claim transactional migration until a fault-injection
@@ -494,6 +508,8 @@ change.
   adoption;
 - prove `/proc/self/exe` rollback after the installed path has been replaced,
   including deleted-old-image and adjacent-helper mismatch cases;
+- prove replacing or deleting the candidate pathname after preflight cannot
+  change the pinned forward image and that only the validated descriptor runs;
 - measure the no-reader interval and output ordering under sustained output; and
 - record why a replacement sibling daemon is insufficient without a broker.
 

--- a/docs/plans/0037-0.2-persistence-and-upgrade-handoff.md
+++ b/docs/plans/0037-0.2-persistence-and-upgrade-handoff.md
@@ -1,0 +1,651 @@
+# Plan 0037: 0.2.0 persistence expansion and PTY upgrade handoff
+
+- **Status:** Proposed for `0.2.0`; product, architecture, and privacy decisions require review before implementation
+- **Date:** 2026-08-14
+- **Product authority:** Persistence guarantees must name the exact lifetime they survive; upgrade continuity is not daemon-crash or reboot process resurrection
+- **Depends on:** Linux PTY ownership from [ADR 0002](../adr/0002-linux-pty-backend.md), persistent multiplexing from [ADR 0006](../adr/0006-multiplexing-lifecycle.md), durable Lair/Dojo topology from [Plan 0018](0018-lair-dojo-topology-migration.md), saved workspace recipes from [Plan 0034](0034-alpha3-saved-lair-layouts.md), and bounded client diagnostics from [Plan 0030](0030-client-diagnostic-logging.md)
+- **Amends if accepted:** the current daemon-restart and persisted-body exclusions in [the PRD](../PRD.md), [architecture.md](../architecture.md), and [headless.md](../headless.md)
+
+## Decision
+
+Propose persistence as a first-class `0.2.0` product program with separate,
+honestly named guarantees:
+
+1. **View continuity** keeps daemon-owned work alive when graphical clients
+   disconnect. This is the existing baseline.
+2. **Upgrade continuity** preserves live local Splint processes and PTYs across a
+   planned, compatible `splinterd` binary replacement through a guarded in-place
+   `execve` handoff. This is the primary `0.2.0` runtime feature.
+3. **Workspace restoration** preserves validated topology and launch recipes
+   across daemon loss and reboot. Existing explicit restore remains the safe
+   baseline.
+4. **Reboot archive restoration**, if the privacy decision is accepted, may
+   additionally preserve a bounded opt-in terminal checkpoint so a restored
+   Dojo can display its last known screen/history before the user explicitly
+   starts new processes.
+5. **Crash continuity** through a persistent PTY broker remains a separately
+   gated research track. It is not required for `0.2.0` and must not be implied
+   by upgrade continuity.
+
+A full host reboot still ends every local process and kernel PTY. `0.2.0` may
+restore an understandable workspace and terminal archive after reboot, but it
+must never label newly launched processes as resumed incarnations.
+
+## Why this belongs in 0.2.0
+
+Splinterm currently keeps shells, layouts, terminal state, and scrollback alive
+when a Window disappears, but package upgrades stop at a much sharper boundary:
+
+- the package may replace `/usr/bin/splinterd` while an older daemon inode keeps
+  running;
+- the launcher restarts only when protocol negotiation fails, so a stale but
+  protocol-compatible daemon remains active;
+- a service restart intentionally terminates every daemon-owned process;
+- durable topology survives, but every loaded leaf becomes exited/restorable;
+- the diagnostic and package language cannot currently distinguish a safe live
+  handoff from a destructive restart; and
+- users reasonably read “persistent terminal substrate” more broadly than the
+  implemented Window-detach lifetime.
+
+The `0.2.0` proposal should deepen the defining product property rather than add
+an unrelated surface feature. The change also establishes precise vocabulary
+before broader distribution makes upgrade behavior harder to change.
+
+## Persistence contract
+
+### Supported lifetime matrix
+
+| Boundary | `0.1.x` behavior | Proposed `0.2.0` behavior | Same process? | Same terminal incarnation? |
+|---|---|---|---:|---:|
+| Window/client close | Live daemon work remains | Unchanged | Yes | Yes |
+| Graphical client crash | Live daemon work remains | Unchanged, with clearer recovery diagnostics | Yes | Yes |
+| Compatible planned daemon upgrade | Running old daemon remains stale or restart ends work | Guarded in-place handoff to installed daemon | Yes | Yes |
+| Incompatible planned daemon upgrade | Restart required | Refuse silent migration; preview destructive fallback | Only if a reviewed migration exists | Only if migration succeeds |
+| User logout without lingering | User manager stops daemon and work | Unchanged unless administrator explicitly enables lingering | No | No |
+| User logout with lingering | Daemon may remain | Unchanged; handoff remains available | Yes | Yes |
+| Daemon crash | Processes currently end with daemon cleanup/loss | Metadata and optional checkpoint recovery only | No guarantee | No guarantee |
+| Full reboot or host loss | Validated recipes remain restorable | Recipes plus optional bounded terminal archive | No | No |
+
+### Required user-visible states
+
+The existing Live, Detached, Saved, Restorable, Pinned, and Disposable states
+remain. `0.2.0` adds runtime/recovery qualifiers rather than replacing them:
+
+- **Upgrade ready** — the running daemon and installed daemon are the same build
+  identity.
+- **Upgrade available** — the installed daemon differs and advertises a
+  compatible handoff contract.
+- **Upgrade blocked** — active work exists but no safe compatible handoff is
+  available.
+- **Handoff in progress** — mutations and new controllers are temporarily
+  fenced while the daemon generation changes.
+- **Recovered archive** — durable terminal presentation exists, but no live
+  process exists.
+- **Restorable recipe** — validated launch metadata may create a new
+  incarnation after explicit approval.
+
+“Resumed” is reserved for the same live process and PTY surviving a compatible
+handoff. Reboot restoration must use “restored,” “recovered,” or “relaunched.”
+
+## Planned upgrade architecture
+
+### Chosen direction: guarded in-place re-exec
+
+For `0.2.0`, preserve the existing daemon PID and parent/child relationships by
+replacing the running daemon image with the installed daemon through
+`execve`/`execveat`.
+
+Linux preserves the daemon PID, child parenthood, and explicitly inheritable
+file descriptors across exec. Splinterm can therefore preserve:
+
+- each PTY master;
+- child PID, session ID, process-group ID, and incarnation;
+- the daemon's ability to reap its existing children;
+- the owner-only listening endpoint or enough authority to recreate it without
+  exposing a second daemon; and
+- a versioned checkpoint of canonical topology and terminal actor state.
+
+This is preferable to starting an unrelated replacement daemon because a new
+sibling process cannot become the existing shells' parent. `pidfd` can observe a
+non-child, but it does not recreate ordinary child-reaping authority. A
+multi-process PTY broker can solve that more generally, but it is a larger
+ownership change and should not be smuggled into the first upgrade milestone.
+
+The current runtime type is not adoptable as-is: `LinuxPtySession` owns a
+`std::process::Child`, while the actor separately owns a cloned PTY reader in an
+`AsyncFd`. Rust objects disappear across exec, and `Child` cannot be reconstructed
+for an already-running child. Before handoff work proceeds, `splinterm-pty` must
+provide a reviewed adoptable session representation built from a validated child
+PID/process-group/session identity and owned PTY descriptor set, with direct
+`waitpid`-style reaping and process-group signaling. The design must choose one
+canonical master descriptor ownership model or record both master and cloned
+reader slots explicitly; it may not duplicate readers accidentally.
+
+### Handoff participants
+
+```text
+new splinterm launcher/client
+  -> detects installed/running build mismatch
+  -> asks old splinterd to inspect handoff compatibility
+
+old splinterd generation
+  -> fences mutations and input ownership transitions
+  -> checkpoints topology + terminal actors
+  -> preserves explicit PTY/listener/rollback descriptors
+  -> execs the installed splinterd image
+
+new splinterd generation, same PID
+  -> validates and adopts every checkpoint + descriptor
+  -> resumes PTY draining before accepting clients
+  -> publishes a new daemon generation
+  -> asks clients to reconnect/resnapshot
+```
+
+### Bootstrap boundary
+
+The first handoff-capable release cannot retroactively teach a pre-handoff
+`0.1.x` daemon to migrate itself. The upgrade into the first `0.2.0` build may
+therefore require one final destructive restart, with exact active-Splint count
+and confirmation. Once a handoff-capable daemon is running, later compatible
+`0.2.x` upgrades may use live migration.
+
+Packaging and documentation must state this bootstrap boundary explicitly.
+
+## Handoff contract
+
+### Build and schema negotiation
+
+The launcher must not infer safety from `ping` alone. The running daemon reports:
+
+- daemon build version and immutable build identity;
+- private protocol range;
+- handoff protocol range;
+- supported checkpoint schema range;
+- installed daemon device/inode and digest as observed by the running daemon;
+- active Lair/Dojo/Splint counts; and
+- whether every live runtime is currently handoff-eligible.
+
+The installed candidate must support an offline preflight command that validates
+its executable identity, checkpoint schema, helper adjacency, state directory,
+resource bounds, and rollback contract without touching live PTYs.
+
+A compatible private client protocol does not imply a compatible handoff schema.
+
+### Versioned handoff manifest
+
+Use a bounded, versioned manifest carried in a sealed memfd or an owner-only
+runtime object. It must identify, without terminal-body logging:
+
+- daemon generation and topology revision;
+- stable Lair, Dojo, and Splint IDs;
+- live incarnation and exact PTY descriptor slot;
+- child PID, process group, session identity, and last observed exit state;
+- current cell/pixel size and foreground process group when available;
+- controller and subscription disposition;
+- terminal revision, history generation, and checkpoint format;
+- retained image metadata/body descriptor disposition;
+- durable-state generation already committed; and
+- rollback executable descriptor and rollback manifest location.
+
+Every count, string, descriptor slot, body, and aggregate byte size requires a
+hard bound. Duplicate IDs or descriptors, missing PTYs, changed child identity,
+unsupported parser state, or a partially valid manifest must fail the complete
+handoff before authority is published.
+
+### Canonical terminal checkpoint
+
+Preserving only the visible grid is insufficient. Future bytes depend on parser
+and terminal modes that are not recoverable from a screenshot. `LiveSnapshot`
+is a presentation projection and must never become the handoff format.
+Terminal-checkpoint v1 requires a bounded canonical serialize/restore API owned
+by `splinterm-terminal`, including an explicit restore constructor and
+byte-exact parser-continuation contract. A compatible handoff must either
+preserve or versionably encode all canonical state required for exact continued
+parsing, including:
+
+- normal and alternate grids;
+- cursor, saved cursor, margins, tab stops, modes, palettes, charset/parser
+  state, titles, hyperlinks, and relevant protocol state;
+- bounded scrollback, stable row IDs, terminal revision, and history generation;
+- image placements and any retained bodies covered by the accepted image
+  continuity contract;
+- accepted user-write and terminal-reply queues with their current offsets;
+- incomplete PTY read/parser input and synchronized-publication state; and
+- child EOF/exit observation state at the checkpoint boundary.
+
+The checkpoint format is an internal handoff ABI, not the public automation
+schema. It still needs explicit compatibility and migration tests because a
+broken checkpoint can corrupt live work.
+
+### Descriptor discipline
+
+All descriptors remain close-on-exec by default. Immediately before handoff,
+the old daemon clears `FD_CLOEXEC` only for an allowlisted set and records every
+inherited slot in the manifest. The new generation closes every unclaimed slot
+before serving clients.
+
+At minimum, preserve:
+
+- the exact adoptable PTY descriptor set per eligible live Splint, with the
+  manifest declaring whether one master is re-registered for async reads or a
+  distinct cloned reader is intentionally adopted;
+- any descriptor required for exact image continuity;
+- the sealed checkpoint manifest;
+- an open descriptor for the old daemon image as the rollback target; and
+- either the listener or a guarded socket-recreation capability.
+
+No client socket, consent capability, policy grant, clipboard object, arbitrary
+file, or unrelated child descriptor survives implicitly.
+
+### Quiescence and output continuity
+
+The handoff coordinator must issue a dedicated command through each live actor.
+That command establishes the sole linearization point among PTY reads, accepted
+user writes, terminal-generated reply writes, resize, parser mutation,
+synchronized publication, child exit/EOF observation, and checkpoint capture.
+At that point the actor must serialize or completely drain both write queues and
+their offsets, record the PTY read disposition, and reject handoff if any
+ordering-relevant state is not representable.
+
+The coordinator must then:
+
+1. reject or queue new structural mutations before checkpoint capture;
+2. freeze controller transfer and new input admission at a generation fence;
+3. define whether every pre-fence input byte is written or serialized before any
+   post-adoption output can be published;
+4. continue draining PTY output until the actor-linearized checkpoint boundary;
+5. bound the period in which no userspace reader drains a PTY;
+6. preserve exact byte ordering across the checkpoint boundary;
+7. resume PTY draining before reopening ordinary admission; and
+8. force every client to reconnect and obtain a full authoritative resnapshot.
+
+A child may continue producing output during exec. The handoff must complete
+within a measured deadline short enough that the kernel PTY buffer does not
+become the persistence mechanism. Timeout before exec returns to the old
+running generation. Timeout after exec invokes rollback.
+
+### Authority reset
+
+Daemon-lifetime security authority does not silently cross generations.
+
+- Persistent policy is reloaded and revalidated by the new binary.
+- Automation connections disconnect and must reauthenticate.
+- Consent grants, pending prompts, transfer requests, and audit cursors expire.
+- Graphical clients reconnect and re-establish trusted executable identity.
+- Controller ownership defaults to released unless a separately reviewed
+  same-client reconnection token can be proven safe and bounded.
+- Audit records report handoff start, adoption, rollback, and final outcome
+  without terminal or input bodies.
+
+The same Splint incarnation may survive while connection-owned authority does
+not.
+
+## Failure and rollback
+
+The old generation remains authoritative until the final exec boundary. Before
+exec, any failed preflight, checkpoint, persistence write, identity check, or
+quiescence step cancels the handoff and resumes the old generation unchanged.
+
+To reduce the risk after exec:
+
+1. the old daemon opens `/proc/self/exe` as the authoritative old-image inode,
+   even when the package pathname already names a newer binary, and preserves
+   that descriptor explicitly;
+2. the rollback manifest records the validated old helper identity or forbids
+   every new spawn until the installed adjacent helper is proven compatible;
+3. the new image validates all inherited descriptors and checkpoint sections
+   before taking input or publishing readiness;
+4. if adoption fails, it invokes the rollback image by descriptor with
+   `execveat(..., AT_EMPTY_PATH)` and the same PTYs and rollback manifest; and
+5. if both adoption and rollback fail, systemd reports a failed service and the
+   diagnostics must state that live-process continuity is no longer guaranteed.
+
+No implementation may claim transactional migration until a fault-injection
+matrix proves failure at every boundary either leaves the old generation live or
+successfully rolls it back. A successful exec without successful adoption is
+not a successful upgrade.
+
+## Package and launcher behavior
+
+AUR/ALPM install scriptlets must not attempt to restart arbitrary users'
+`systemd --user` services. They run outside the target user's reliable session
+context and cannot safely decide whether active terminal work may end.
+
+The package should:
+
+- install the daemon and user unit normally under `/usr`;
+- rely on the distribution's user-unit daemon-reload hook;
+- print the bootstrap/destructive-restart warning when upgrading from a release
+  without handoff support; and
+- never enable lingering, start a user service, or execute saved commands.
+
+The handoff-capable launcher replaces the existing stale-protocol automatic
+restart path; the old and new behaviors must not coexist as competing fallbacks.
+Only an idle daemon may restart automatically. The `0.1.x` bootstrap boundary or
+any incompatible active upgrade requires an explicit destructive confirmation
+that reports the exact active-Splint count.
+
+The user-session launcher should:
+
+1. compare the running daemon's build/executable identity with the installed
+   daemon;
+2. launch directly when they match;
+3. offer or perform a compatible handoff according to an explicit user setting;
+4. restart automatically only when the daemon is idle and no live Splint can be
+   lost;
+5. refuse silent mixed-generation graphical launch when handoff is required but
+   unavailable; and
+6. display an exact destructive fallback preview when the user chooses restart.
+
+Recommended commands:
+
+```text
+splinterm service status
+splinterm service upgrade          # interactive by default
+splinterm service upgrade --check  # no mutation
+splinterm service restart          # explicit destructive fallback
+```
+
+Machine output for inspection may expose build IDs, schema ranges, counts, and
+outcomes, but never terminal bodies or inheritable descriptor details.
+
+## Reboot restoration expansion
+
+### Baseline retained behavior
+
+Saved Lairs remain durable recipes. Startup loads leaves as exited/restorable,
+and no saved command runs until an explicit restore or relaunch action. Exact
+argv boundaries, cwd validation, proportional layout, and confirmation rules
+from Plan 0034 remain authoritative.
+
+### Proposed opt-in terminal archive
+
+`0.2.0` may add **Archive terminal state with saved Lair** as a separate,
+default-off persistence choice. This is a product/privacy decision because it
+reverses the current rule that durable state excludes terminal grids and
+scrollback bodies.
+
+If accepted, the archive must be:
+
+- explicitly enabled per Lair or through an owner-controlled default;
+- owner-only, bounded per Splint, per Lair, and globally;
+- written atomically in a separate versioned store from topology recipes;
+- unavailable through every existing private/public protocol operation,
+  automation observation/search endpoint, audit path, package script, crash
+  summary/upload, and machine output;
+- labeled with capture time, terminal generation, truncation, and whether image
+  bodies were omitted;
+- deletable independently from the saved recipe;
+- never interpreted as shell input, authority, or an executable command; and
+- displayed as historical/recovered content until a new incarnation begins.
+
+Any non-trusted-human archive read API requires a separate ADR, versioned schema,
+closed policy scope, and privacy review; this proposal grants no such access.
+Acceptance also requires explicit amendments to FR-PERSIST-05 and Plan 0034
+before any terminal body is written durably.
+
+Encryption at rest is not claimed merely because files are mode `0600`. Optional
+application-level encryption requires a separate key-management decision; the
+proposal must not invent a key stored beside the ciphertext.
+
+### Restored Dojo experience
+
+After reboot or unrecoverable daemon loss, opening a saved archived Dojo should:
+
+1. reconstruct the durable tree without spawning processes;
+2. render archived panes with an unmistakable **Recovered — process not
+   running** state;
+3. retain historical navigation only within the captured bounded archive;
+4. preview exact relaunch recipes and missing/non-restorable leaves;
+5. let the user relaunch one Splint, one Dojo, or the Lair under the existing
+   confirmation rules; and
+6. allocate new incarnations and fresh terminal generations for every launched
+   process.
+
+The archive remains available after relaunch unless the user deletes it or a
+reviewed retention policy expires it. Live output must never be merged into old
+history without an explicit generation boundary.
+
+## Crash continuity research track
+
+A persistent PTY broker can preserve live processes if `splinterd` crashes or is
+fully restarted, but it changes the ownership model more deeply than planned
+upgrade handoff.
+
+A broker design would make a small long-lived process the original parent and
+master-PTY owner for one or more Splints. Replaceable daemon generations would
+attach over an authenticated Unix socket. The broker would need to:
+
+- remain the single PTY reader or implement an atomic reader lease;
+- continuously drain and bound replay bytes while no daemon is attached;
+- own child reaping, resize, signals, and shutdown escalation;
+- authenticate same-account daemon generations by executable identity;
+- transfer descriptors with `SCM_RIGHTS` only under an acknowledged ownership
+  protocol, if direct master access remains necessary; and
+- avoid becoming an unbounded second terminal emulator or hidden authority
+  service.
+
+Before adoption, a spike must compare:
+
+1. in-place exec only;
+2. one stable broker for all Splints;
+3. one minimal broker per Splint; and
+4. broker-owned byte transport versus direct PTY descriptor transfer.
+
+`pidfd_getfd` is not the normal handoff protocol. It is Linux-specific,
+permission-gated duplication from a still-live process and does not create
+parent/reaping authority.
+
+Crash continuity is accepted only if its additional process, memory, protocol,
+packaging, shutdown, and security costs are bounded and justified by observed
+need. It must not delay safe planned-upgrade continuity by default.
+
+## Security and privacy requirements
+
+- Only the installed adjacent trusted client may request a human upgrade
+  handoff; automation requires a separate closed policy scope if ever exposed.
+- Candidate and rollback executables require no-follow, owner/mode,
+  device/inode, digest, and package-adjacency validation.
+- Handoff manifests and archive files are owner-only and never follow symlinks.
+- Descriptor manifests reject duplicates, unknown slots, truncation, and excess
+  ancillary data.
+- Terminal/checkpoint bodies never enter argv, environment, journal, audit,
+  crash summaries, or protocol errors.
+- A stale client generation cannot input, resize, mutate, or reclaim control
+  after the handoff fence.
+- Restore and relaunch never derive commands from terminal content, `/proc`,
+  titles, foreground process names, shell history, or archived bytes.
+- Remote graphical sessions may reconnect after a remote daemon handoff, but the
+  local client cannot initiate a remote package upgrade unless a separately
+  reviewed remote administration contract exists.
+
+## Resource and performance requirements
+
+Define measured budgets before implementation acceptance:
+
+- maximum handoff manifest and terminal-checkpoint bytes;
+- maximum pause without PTY draining;
+- p50/p95 handoff duration for 1, 8, 32, and maximum supported live Splints;
+- peak old/new generation RSS during checkpoint and adoption;
+- maximum archive bytes per Splint, Lair, and account;
+- archive write amplification and startup indexing cost;
+- bounded rollback duration; and
+- maximum client reconnect/resnapshot burst.
+
+No acceptance result may obtain continuity by widening PTY, queue, scrollback,
+image, connection, or shutdown limits without an explicit reviewed budget
+change.
+
+## Delivery milestones
+
+### Milestone 1 — contract, ADRs, and Linux spike
+
+- approve persistence vocabulary and the supported lifetime matrix;
+- write an ADR for in-place daemon re-exec and a separate privacy decision for
+  durable terminal archives;
+- refactor or spike an adoptable Linux PTY session that reconstructs runtime
+  authority from validated PID/PGID/session identity and explicit owned PTY FDs
+  rather than attempting to recreate `std::process::Child`;
+- decide and prove the master/cloned-reader adoption model has exactly one PTY
+  reader;
+- build a Linux-only spike proving one shell PID/session/process group and
+  bidirectional PTY stream survive old -> new -> rollback exec;
+- prove direct child reaping and process-group signaling still work after
+  adoption;
+- prove `/proc/self/exe` rollback after the installed path has been replaced,
+  including deleted-old-image and adjacent-helper mismatch cases;
+- measure the no-reader interval and output ordering under sustained output; and
+- record why a replacement sibling daemon is insufficient without a broker.
+
+**Gate:** the adoptable session API preserves exact process/PTY identity,
+child-reaping authority, one-reader ownership, and ordered I/O across successful
+adoption and rollback without unsafe descriptor leakage.
+
+### Milestone 2 — checkpoint and descriptor ABI
+
+- define bounded handoff schema v1 and rollback schema;
+- add a bounded canonical `splinterm-terminal` checkpoint/restore API;
+- serialize/deserialize the complete canonical terminal state needed for exact
+  continued parsing; reject unsupported state before exec;
+- add an actor handoff command that linearizes PTY reads, both write queues and
+  offsets, resize, parser/reply state, synchronized publication, and child
+  exit/EOF observation;
+- add descriptor allowlist/claim/close enforcement;
+- add property, corruption, truncation, duplicate-ID/FD, oversized, and schema
+  migration tests; and
+- add exact terminal continuation fixtures that split every supported
+  escape/control sequence at every byte boundary, including synchronized updates
+  and supported image protocol state.
+
+**Gate:** uninterrupted and handed-off runs produce equivalent final terminal
+state, revisions, history, image disposition, and child exit status across the
+accepted fixture matrix.
+
+### Milestone 3 — daemon coordinator and client recovery
+
+- add preflight, quiescence, exec adoption, rollback, and generation publication;
+- fence mutations, input, resize, control transfer, consent, and subscriptions;
+- reconnect local and remote graphical clients with full resnapshot;
+- reset daemon-lifetime authority and reload persistent policy;
+- emit bounded correlated diagnostics for every phase and failure; and
+- prove old clients cannot act after generation replacement.
+
+**Gate:** fault injection at every pre-exec and post-exec boundary preserves the
+old generation or completes rollback; no partial generation becomes
+addressable.
+
+### Milestone 4 — package, launcher, and upgrade UX
+
+- expose build/handoff compatibility inspection;
+- detect deleted or mismatched running daemon executables;
+- replace the stale-protocol automatic restart path with idle-only restart,
+  compatible handoff, blocked upgrade, and explicitly confirmed destructive
+  fallback paths;
+- document the first `0.1.x` -> `0.2.0` bootstrap boundary;
+- update AUR package messages without attempting root-context user-service
+  restarts; and
+- validate clean install, matching build, compatible upgrade, incompatible
+  upgrade, rollback, downgrade, and interrupted transaction cases.
+
+**Gate:** no package or launcher path silently destroys active work or silently
+continues an unsupported mixed generation.
+
+### Milestone 5 — reboot restoration and optional archive
+
+- retain existing recipe-only restore as the default;
+- amend FR-PERSIST-05 and Plan 0034 through explicit product/privacy approval
+  before writing archive code;
+- resolve retention, deletion, export, and trusted-human read authority before
+  writing archive code;
+- if accepted, add bounded owner-only archive schema, retention, deletion, and
+  recovered-pane presentation;
+- prove startup and picker display execute nothing;
+- allocate new incarnations on every relaunch; and
+- keep archived and live generations visibly and structurally distinct.
+
+**Gate:** reboot restoration is useful without suggesting process survival,
+executing saved content, exposing terminal bodies, or losing the saved recipe
+when archive decode fails.
+
+### Milestone 6 — coherent validation and release evidence
+
+Run focused tests after each milestone, then one serial coherent validation:
+
+```bash
+cargo fmt --all --check
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+cargo test --workspace --all-targets --all-features -- --test-threads=1
+git diff --check
+```
+
+Also require:
+
+- handoff fault injection under idle, sustained output, resize, image, search,
+  multiple controllers, and process-exit races;
+- repeated package upgrade/rollback in an isolated user service;
+- daemon/client build and inode identity evidence;
+- no staged files and a clean canonical Foot checkout;
+- fresh read-only architecture, lifecycle, security/privacy, and release reviews;
+  and
+- separately approved guarded graphical acceptance for visible reconnect,
+  blocked-upgrade, recovered-archive, and destructive-fallback flows.
+
+## Explicitly outside `0.2.0`
+
+- claiming that local processes or kernel PTYs survive reboot or host failure;
+- general CRIU checkpoint/restore support;
+- VM snapshot orchestration;
+- automatic execution of saved or archived terminal content;
+- inferring foreground applications or shell state for relaunch;
+- transparent migration between machines;
+- durable consent grants, controller leases, automation connections, or audit
+  cursors across daemon generations;
+- unrestricted machine access to archived terminal bodies;
+- a public stable handoff ABI for third-party daemon implementations; and
+- crash continuity unless the broker research track receives a separate accepted
+  plan and does not compromise the `0.2.0` gates.
+
+## Open product and architecture decisions
+
+1. Is `0.2.0` a compatibility promise for all later `0.2.x` handoffs, or may
+   individual upgrades still require an explicit destructive boundary?
+2. Should compatible handoff occur automatically on launch, or require one
+   confirmation whenever live Splints exist?
+3. Is bounded terminal archive persistence default-off per Lair, globally
+   configurable, or deferred entirely?
+4. Which terminal/image state is required for exact continuation, and which
+   unsupported state blocks handoff rather than degrading silently?
+5. Must the listening socket FD survive exec, or should clients reconnect to a
+   recreated socket after the old endpoint is atomically withdrawn?
+6. Can a safe same-human client reconnection token preserve controller ownership,
+   or should all controllers always be released?
+7. How long must the rollback image remain executable, and how does packaging
+   preserve downgrade provenance without trusting a writable path?
+8. Does remote daemon upgrade administration belong in this program or remain an
+   operator-owned SSH workflow?
+9. What measured failure rate or user need would justify moving the PTY broker
+   from research into the supported architecture?
+
+These decisions require ADR or product approval before implementation changes
+public lifecycle, privacy, or compatibility claims.
+
+## Acceptance
+
+This proposal is accepted for `0.2.0` planning only when:
+
+- upgrade, crash, logout, and reboot persistence are described as distinct
+  guarantees;
+- in-place exec has a credible bounded rollback path and does not hand-wave full
+  terminal actor state;
+- package behavior does not restart user services from root scriptlets;
+- reboot restoration never claims same-process continuity or automatic command
+  replay;
+- any durable terminal-body storage has an explicit privacy and retention
+  decision;
+- broker-based crash continuity remains separately scoped;
+- implementation milestones have measurable failure, resource, security, and
+  compatibility gates; and
+- fresh independent review has no unresolved blocker.
+
+This plan does not authorize implementation, installation, daemon replacement,
+graphical testing, pushing, release publication, or AUR publication.

--- a/docs/plans/0038-0.2-live-omarchy-font-sync.md
+++ b/docs/plans/0038-0.2-live-omarchy-font-sync.md
@@ -98,8 +98,10 @@ generation-owned resource model:
 6. invalidate font-, shaping-, glyph-, prepared-row-, picker-, overlay-, and
    chrome-text caches by generation;
 7. rebuild all visible and retained pane frames from canonical terminal state;
-8. reconcile Window/grid geometry and emit at most one final PTY resize per
-   affected Splint; and
+8. reconcile each Window's geometry, but let only the Window holding the
+   Splint's controller/resize authority emit at most one final PTY resize;
+   observer Windows redraw for their own DPI and metrics without resizing the
+   shared PTY or acquiring control; and
 9. release old font resources only after no prepared frame or paint operation can
    reference them.
 
@@ -120,7 +122,14 @@ palette-style repaint:
 - recompute the largest valid terminal grid from the new cell metrics and
   existing padding/chrome;
 - keep split ratios and focused Splint stable;
-- send each changed live PTY one final rows/columns and pixel-size update;
+- send each changed live PTY one final rows/columns and pixel-size update only
+  from its current controller/resize authority;
+- make observer Windows reconcile and redraw locally without sending PTY resize,
+  requesting control, or transferring resize authority solely because a font
+  generation changed;
+- if a Splint has no current controller, retain its canonical PTY grid until the
+  existing control policy assigns one rather than making font reconciliation an
+  acquisition path;
 - avoid transient resize generations while candidate fonts are still staging;
 - preserve historical viewport anchors and copy-mode selection by stable row and
   cell identity where still valid; and

--- a/docs/plans/0038-0.2-live-omarchy-font-sync.md
+++ b/docs/plans/0038-0.2-live-omarchy-font-sync.md
@@ -1,0 +1,246 @@
+# Plan 0038: 0.2.0 live Omarchy system-font synchronization
+
+- **Status:** Proposed for `0.2.0`; product and renderer architecture require review before implementation
+- **Date:** 2026-08-14
+- **Product authority:** An explicit Splinterm font remains user-owned; native Omarchy discovery applies only when no explicit font override is configured
+- **Depends on:** [ADR 0004](../adr/0004-font-and-cpu-renderer.md), the existing native Omarchy palette watcher, and the current fontconfig-backed renderer
+- **Amends if accepted:** the immutable process-wide renderer-resource decision in ADR 0004 and the configuration guide's Omarchy integration contract
+
+## Decision
+
+Propose live handling of `omarchy font set <name>` for `0.2.0`.
+
+When `main.font` is unset, Splinterm should follow Omarchy's canonical system
+monospace choice through fontconfig and apply a valid family/style change to every
+open Splinterm Window without restarting the daemon, shell, or Window. When
+`main.font` is explicitly configured, that value remains authoritative and an
+Omarchy system-font change must not replace it.
+
+The Omarchy command changes the font family, not a global terminal font-size
+contract. Splinterm therefore retains its configured font size, sizing policy,
+padding, per-Window output DPI, and runtime zoom across a system-font update.
+Live size, sizing-policy, and padding reload may be designed separately, but
+must not be implied by this feature.
+
+## Current gap
+
+`0.1.x` watches the active Omarchy theme directory and reloads valid palette,
+selection, alpha, blur, and accent changes. It fingerprints `foot.ini` and
+`colors.toml`, but intentionally parses only appearance roles from those files.
+
+Omarchy's `omarchy-font-set` writes the selected family to the user's fontconfig
+`monospace` alias and updates supported terminal configs. Splinterm currently:
+
+- defaults to an explicit JetBrains Mono pattern rather than a discovered
+  Omarchy system-font authority;
+- does not watch or re-resolve the fontconfig `monospace` result;
+- installs immutable process-wide `RendererResources` once; and
+- reloads only keymap and prefix timing through the current configuration-reload
+  action.
+
+Consequently, a running Window does not adopt an Omarchy system-font change.
+
+## Authority and configuration precedence
+
+The effective primary-font authority must be explicit in resolved configuration:
+
+1. an explicit `main.font` pattern in Splinterm configuration;
+2. otherwise, native Omarchy system-font discovery through the fontconfig
+   `monospace` alias on the validated Omarchy target; and
+3. a documented safe fallback only when native discovery is unavailable at
+   startup.
+
+The implementation must retain whether `main.font` was explicitly supplied; it
+may not infer authority by comparing the resolved value with the current
+default. An explicit `main.font=monospace` remains an explicit user choice, but
+may naturally resolve to the system family when deliberately reloaded.
+
+A failed live resolution must retain the complete last valid font generation.
+It must not partially replace regular, bold, italic, bold-italic, CJK, or emoji
+faces and must not fall back silently to a different primary family.
+
+## Change detection
+
+Treat fontconfig's effective resolved identity as the source of truth, not a
+copied font name from Foot configuration. The watcher should use bounded polling
+consistent with the existing theme watcher and compare a stable resolved
+fingerprint containing at least:
+
+- requested authority and pattern;
+- resolved regular/bold/italic/bold-italic file paths and face indices;
+- file device/inode/size/mtime identity;
+- resolved family and style; and
+- the ordered configured fallback identities that affect rendering.
+
+Watching only `~/.config/fontconfig/fonts.conf` is insufficient because includes,
+package upgrades, cache refreshes, or font-file replacement can change the
+resolved result. Conversely, any file event that leaves the effective fingerprint
+unchanged must produce no renderer generation.
+
+Resolution and font-file loading must run outside the Wayland dispatch path. A
+burst of intermediate or malformed updates should coalesce, report one bounded
+diagnostic, and retain the last valid generation until a coherent replacement
+is ready.
+
+## Transactional renderer update
+
+Replace the current one-shot immutable font-resource assumption with a reviewed,
+generation-owned resource model:
+
+1. resolve and validate the complete candidate face/fallback set off the dispatch
+   path;
+2. stage owned font bytes, indices, style advances, metrics, and required raster
+   policy without mutating the active renderer;
+3. reject the complete candidate if any required face or metric contract fails;
+4. publish one new font generation atomically to the Window;
+5. preserve output DPI and runtime zoom while recomputing effective font size and
+   cell metrics;
+6. invalidate font-, shaping-, glyph-, prepared-row-, picker-, overlay-, and
+   chrome-text caches by generation;
+7. rebuild all visible and retained pane frames from canonical terminal state;
+8. reconcile Window/grid geometry and emit at most one final PTY resize per
+   affected Splint; and
+9. release old font resources only after no prepared frame or paint operation can
+   reference them.
+
+Terminal snapshots and scrollback remain canonical; font resources and prepared
+pixels remain disposable client presentation state. `splinterd` and the public
+protocol gain no fontconfig, font-file, or renderer ownership.
+
+The update must not reset runtime font zoom. A user who has zoomed two steps
+remains two steps from the newly resolved base font.
+
+## Geometry policy
+
+A font-family change can alter cell width, height, baseline, and glyph bearings.
+The update therefore requires one coherent geometry transaction rather than a
+palette-style repaint:
+
+- preserve the Window's current logical outer size when representable;
+- recompute the largest valid terminal grid from the new cell metrics and
+  existing padding/chrome;
+- keep split ratios and focused Splint stable;
+- send each changed live PTY one final rows/columns and pixel-size update;
+- avoid transient resize generations while candidate fonts are still staging;
+- preserve historical viewport anchors and copy-mode selection by stable row and
+  cell identity where still valid; and
+- reject or clamp through existing bounded geometry policy when the new metrics
+  cannot represent the current surface.
+
+The plan must define behavior for an open modal, active IME preedit, synchronized
+terminal update, in-progress frame, and detached/inactive pane before graphical
+implementation begins.
+
+## Milestones
+
+### Milestone 1 — authority and detection
+
+- represent explicit versus native font authority in resolved configuration;
+- resolve Omarchy's system monospace family through fontconfig;
+- define the effective multi-face/fallback fingerprint;
+- add bounded coalescing detection and rejection diagnostics; and
+- document that Omarchy supplies family authority while Splinterm retains size.
+
+**Gate:** repeated identical resolution emits no update, one valid Omarchy family
+change emits one generation, and malformed or missing candidates retain the last
+valid generation.
+
+### Milestone 2 — replaceable renderer generations
+
+- amend ADR 0004 with safe generation ownership and retirement;
+- stage and validate complete font resources off the dispatch path;
+- make every font-derived cache key or invalidation path generation-aware;
+- preserve per-Window DPI, alpha, and zoom state; and
+- prove old resources cannot be released while referenced.
+
+**Gate:** concurrent preparation and publication cannot mix faces, metrics, cache
+entries, or pixels from different font generations.
+
+### Milestone 3 — Window and terminal reconciliation
+
+- deliver font updates through the existing typed Window update architecture;
+- atomically publish resources, recompute geometry, rebuild panes and chrome,
+  and schedule one coherent redraw;
+- send no more than one final resize per changed live Splint;
+- preserve focus, topology, scrollback position, copy-mode state, and zoom; and
+- define modal and IME reconciliation behavior.
+
+**Gate:** a font change neither restarts nor detaches shells, loses terminal
+history, resets zoom, retargets focus, nor exposes a partial frame.
+
+### Milestone 4 — documentation and release evidence
+
+- update README, configuration, status, roadmap, and troubleshooting language;
+- add unit and integration coverage for explicit override precedence, native
+  discovery, coalescing, rollback, style/fallback replacement, cache retirement,
+  geometry, and PTY resize counts;
+- benchmark resolution, staging, memory peak, redraw, and repeated-change cost;
+- run the coherent non-graphical workspace validation; and
+- perform separately approved guarded graphical acceptance for one system-font
+  change and rollback on an invalid candidate.
+
+**Gate:** release documentation says exactly which Omarchy font behavior is live,
+which settings remain Splinterm-owned, and what happens on rejection.
+
+## Validation requirements
+
+Focused implementation tests must cover:
+
+- explicit `main.font` ignoring native Omarchy changes;
+- unset `main.font` following a changed `monospace` resolution;
+- regular/bold/italic/bold-italic and fallback identity changes;
+- unchanged effective identity after a watched-file change;
+- font file replacement at the same path;
+- missing, unreadable, malformed, non-monospace, or metric-incompatible faces;
+- rapid A -> invalid -> B and A -> B -> A update bursts;
+- multiple panes/tabs, hidden panes, detached views, copy mode, modal UI, and IME;
+- pixel- and point-sized configurations at integer and fractional output scales;
+- runtime zoom preservation and reset behavior after the update;
+- exact resize-event count and final rows/columns/pixel dimensions;
+- old-generation cache/resource retirement under in-flight rendering; and
+- bounded CPU, memory, file-descriptor, and diagnostic behavior.
+
+The coherent non-graphical gate remains:
+
+```bash
+cargo fmt --all --check
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+cargo test --workspace --all-targets --all-features -- --test-threads=1
+git diff --check
+```
+
+Graphical testing requires the repository's separate guarded approval and must
+use the pinned Foot oracle without translating comparison images, widening
+tolerances, or regenerating references.
+
+## Explicitly outside this feature
+
+- changing Omarchy-owned files or requiring changes to `omarchy-font-set`;
+- treating the active theme's `foot.ini` font line as more authoritative than
+  fontconfig's system monospace alias;
+- overriding an explicit Splinterm font;
+- inventing a global Omarchy terminal font-size contract;
+- live reload of arbitrary Splinterm sizing, padding, shell, scrollback, cursor,
+  pane-chrome, or keymap configuration as a side effect;
+- daemon or public-protocol font ownership; and
+- changing the pinned Foot 1.27.0 oracle or accepted exactness policy.
+
+## Acceptance
+
+This proposal is accepted for `0.2.0` planning when:
+
+- explicit and native font authority have deterministic precedence;
+- the effective source is Omarchy's fontconfig monospace selection;
+- valid updates are atomic and invalid updates preserve the last valid font;
+- renderer resource replacement has safe generation ownership and bounded cache
+  invalidation;
+- geometry and PTY resize reconciliation are single-transaction and preserve
+  terminal/topology state;
+- family changes retain Splinterm-owned size, sizing policy, padding, DPI, and
+  runtime zoom;
+- non-graphical validation and fresh architecture/rendering review have no
+  unresolved blockers; and
+- guarded graphical testing is separately approved and recorded.
+
+This plan does not authorize implementation, live configuration changes,
+graphical testing, installation, publishing, or release publication.

--- a/docs/plans/0039-0.2-searchable-keybindings-and-lair-controls.md
+++ b/docs/plans/0039-0.2-searchable-keybindings-and-lair-controls.md
@@ -1,0 +1,237 @@
+# Plan 0039: 0.2.0 searchable keybinding help and complete Lair controls
+
+- **Status:** Proposed for `0.2.0`; default chord choices require review before implementation
+- **Date:** 2026-08-14
+- **Product authority:** Binding help describes the effective resolved keymap, and keyboard activation uses the same closed typed actions and availability rules as the command palette
+- **Depends on:** [Plan 0027](0027-configurable-keymaps-and-dojo-presets.md), [Plan 0033](0033-alpha3-command-palette-and-keymap-closure.md), and [Plan 0034](0034-alpha3-saved-lair-layouts.md)
+
+## Decision
+
+Make the in-Window keybinding display searchable with bounded deterministic fuzzy
+matching, and make every ordinary current-Lair lifecycle control available through
+the configurable keymap.
+
+The result should let a user open **Show Keybindings**, type a concept such as
+`lair restore`, `split right`, `copy`, or an approximate spelling, and immediately
+see the relevant effective shortcuts. It should also let users bind Save, Pin or
+Unpin, Preview, and Restore Lair without routing through the command palette.
+
+## Current gap
+
+The binding-help overlay currently projects every resolved binding plus copy-mode
+local keys into one read-only paged list. It supports arrows, Home/End,
+PageUp/PageDown, and Escape, but has no query editor or filtering.
+
+The keymap already exposes these Lair actions:
+
+- New Lair;
+- Choose Lair;
+- Rename Current Lair;
+- Previous/Next Lair; and
+- Terminate Current Lair with confirmation.
+
+Saved-Lair lifecycle commands exist in the trusted command palette, but Save,
+Pin, Unpin, Preview, and Restore do not have `ActionId` entries and cannot be
+bound by a strict keymap overlay.
+
+## Search contract
+
+Binding help gains one owned bounded query editor. Typing filters and ranks rows
+against normalized searchable fields:
+
+- human action label;
+- stable action configuration name, such as `lair.restore`;
+- rendered shortcut, such as `Prefix Shift+O`;
+- binding source/profile; and
+- curated closed keywords from action metadata.
+
+Matching must be deterministic, case-insensitive, Unicode-safe, and bounded. Use
+this rank order:
+
+1. exact full-field match;
+2. prefix match;
+3. contiguous substring match;
+4. ordered token match across fields; and
+5. ordered fuzzy subsequence with explicit gap and boundary scoring.
+
+Ties retain resolved-keymap order. Empty input restores the complete list. A
+query that matches nothing shows one calm empty state rather than stale rows.
+The matcher must not execute regex, shell expansion, callbacks, plugins, or
+terminal-controlled text.
+
+Search input follows the same owned-field safety rules as the command palette:
+
+- terminal input, paste, pointer activation, and IME commit cannot leak into the
+  focused Splint while help is open;
+- Backspace edits, `Ctrl+U` clears, and Escape clears a non-empty query before a
+  second Escape closes the overlay;
+- Up/Down and PageUp/PageDown move only within filtered results;
+- query changes reset selection to the highest-ranked result; and
+- the query remains capped by the existing bounded editor byte/scalar policy.
+
+A small shared fuzzy-ranking utility may serve binding help and the command
+palette, but this plan does not authorize changing command-palette catalog,
+availability, or dispatch semantics.
+
+## Complete bindable Lair controls
+
+Add closed typed actions for the current Lair:
+
+| Action | Configuration name | Availability and behavior |
+|---|---|---|
+| Save current Lair | `lair.save` | Disposable only; persist the current validated layout |
+| Toggle current Lair pin | `lair.pin-toggle` | Disposable/Saved -> Pinned; Pinned -> Saved |
+| Preview saved Lair | `lair.preview` | Saved or Pinned only; open the existing body-free preview |
+| Restore saved Lair | `lair.restore` | Saved or Pinned with restorable leaves; preserve existing preview/confirmation rules |
+
+These actions must dispatch through the same typed topology commands,
+exact-target capture, retention checks, confirmation, and stale-target handling
+as their command-palette equivalents. Keyboard activation must not create a
+parallel lifecycle implementation.
+
+`lair.pin-toggle` is intentionally one contextual action so one chord remains
+stable as the Lair moves between Saved and Pinned. Help and command-palette labels
+must describe the effective operation without changing the stable action ID.
+
+## Proposed built-in shortcuts
+
+Retain every current Lair shortcut. Add these mnemonic `omarchy-tmux` defaults,
+subject to a complete collision and upstream-parity audit:
+
+| Shortcut | Action |
+|---|---|
+| `Prefix Shift+S` | Save current Lair |
+| `Prefix Shift+F` | Toggle current Lair pin/favorite state |
+| `Prefix Shift+V` | Preview saved Lair |
+| `Prefix Shift+O` | Restore saved Lair |
+
+The default `splinterm` profile does not need new chords if they would make its
+non-prefix surface noisy; all four actions must still be legal in strict custom
+overlays and visible in keymap inspection. If any proposed `omarchy-tmux` chord
+conflicts with the checked-in Omarchy reference or an existing action, choose a
+reviewed replacement rather than shadowing or silently removing either binding.
+
+No default direct chord is added for destructive Lair termination; its existing
+confirmed prefix action remains authoritative.
+
+## Registry and display coherence
+
+Move searchable action labels and keywords toward one closed metadata authority
+shared by keymap inspection, binding help, and command-palette shortcut
+projection. Add drift invariants proving:
+
+- every bindable action has a unique stable configuration name;
+- every resolved binding appears exactly once in unfiltered help;
+- every new Lair action has typed keyboard dispatch;
+- palette and keyboard paths produce equivalent topology commands and
+  availability decisions;
+- primary shortcut labels come from the effective resolved keymap; and
+- no configuration or terminal content can register labels, keywords, or code.
+
+Copy-mode local rows remain searchable informational rows, but are not promoted
+to globally bindable actions by this plan.
+
+## Milestones
+
+### Milestone 1 — searchable binding-help model
+
+- add bounded query/editor state and filtered-row identity;
+- implement deterministic fuzzy scoring and stable ordering;
+- index labels, action IDs, shortcuts, sources, and curated keywords;
+- define clear/close and keyboard navigation behavior; and
+- add exact, prefix, substring, token, fuzzy, typo, Unicode, empty, and no-match
+  tests.
+
+**Gate:** the same query and resolved keymap always produce the same bounded
+ordered rows, selection, and viewport.
+
+### Milestone 2 — binding-help input and rendering
+
+- render the query and empty state within the existing overlay;
+- route text editing, IME, clipboard, pointer, and navigation through owned modal
+  input boundaries;
+- preserve responsive compact layout and resolved shortcut/source display; and
+- invalidate only the necessary overlay text/layout caches.
+
+**Gate:** no help interaction emits PTY input or activates an action, and every
+filtered row remains readable and navigable at supported compact sizes.
+
+### Milestone 3 — Lair action closure
+
+- add the four bindable action IDs and parser names;
+- route them through existing exact-target topology behavior;
+- add proposed `omarchy-tmux` defaults after collision/parity review;
+- expose effective shortcuts in help, CLI keymap inspection, and the command
+  palette; and
+- add strict-overlay, availability, stale-target, retention-transition,
+  confirmation, and dispatch-equivalence tests.
+
+**Gate:** all ordinary current-Lair controls are discoverable and bindable, while
+destructive and restore behavior retains existing confirmation and execution
+boundaries.
+
+### Milestone 4 — documentation and release evidence
+
+- update configuration, quickstart, keymap tables, status, and roadmap;
+- record the final default chord table and any rejected conflicts;
+- run coherent non-graphical validation; and
+- perform separately approved guarded graphical acceptance for fuzzy help search
+  and representative Save/Pin/Preview/Restore shortcuts.
+
+## Validation
+
+Focused tests must cover:
+
+- queries by action label, config name, shortcut, source, category, keyword, and
+  approximate spelling;
+- stable ranking, tie order, query limits, grapheme editing, no-match state, and
+  selection/viewport clamping;
+- Escape clear-then-close, Backspace, `Ctrl+U`, navigation, pointer isolation,
+  paste, IME, and physical-key repeat/release;
+- both built-in profiles and representative strict custom overlays;
+- Save, pin-toggle in every retention state, Preview, Restore, and rejected
+  availability;
+- exact target identity after topology changes and stale targets;
+- keyboard/palette command equivalence and resolved shortcut labels; and
+- exhaustive registry, parser, help, dispatch, and documentation drift checks.
+
+The coherent non-graphical gate remains:
+
+```bash
+cargo fmt --all --check
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+cargo test --workspace --all-targets --all-features -- --test-threads=1
+git diff --check
+```
+
+Graphical validation requires separate approval under the repository's guarded
+window-testing policy.
+
+## Explicitly outside this feature
+
+- arbitrary shell-command or plugin-defined bindings;
+- terminal-controlled help rows, labels, keywords, or callbacks;
+- executing an action directly from binding help;
+- fuzzy matching over terminal history or process content;
+- automatic restore or command execution on startup, search, preview, or pin;
+- bypassing existing confirmation for restore or termination;
+- numeric Lair-selection rows without a separate product decision; and
+- replacing the command palette or Dojo/Lair chooser with binding help.
+
+## Acceptance
+
+This proposal is accepted for `0.2.0` planning when:
+
+- binding help has bounded deterministic fuzzy search over effective resolved
+  bindings and closed metadata;
+- owned modal input cannot reach the terminal;
+- Save, pin-toggle, Preview, and Restore are legal typed keymap actions;
+- keyboard and palette paths share availability, targeting, confirmation, and
+  topology dispatch;
+- final built-in chords pass collision and Omarchy-reference review;
+- registry and display drift tests are exhaustive; and
+- non-graphical validation and fresh keymap/UI review have no unresolved
+  blockers.
+
+This plan does not authorize implementation, graphical testing, installation,
+publishing, or release publication.

--- a/docs/reviews/2026-08-14-code-size-and-architecture.md
+++ b/docs/reviews/2026-08-14-code-size-and-architecture.md
@@ -1,0 +1,277 @@
+# Code Size and Architecture Review
+
+Date: 2026-08-14
+
+## Scope
+
+This review evaluates whether Splinterm contains excessive or unnecessarily
+duplicated code, whether its structure supports local changes, and whether the
+documented system design still matches the implementation.
+
+The review covered workspace and crate manifests, the architecture document,
+source and repository size, large files and functions, exact cross-file clone
+signals, crate dependencies, implementation boundaries, recent change
+concentration, and the standard non-graphical validation boundary. Two fresh
+read-only reviewers independently checked the architectural and code-size
+findings.
+
+The existing `graphify-out/` graph was consulted as supporting evidence only. It
+covers 21 files rather than the complete current repository, so its centrality
+results were not treated as authoritative.
+
+## Executive verdict
+
+The system design remains fundamentally sound. Major crate, transport,
+authority, and graphical boundaries are intentional, documented, and reflected
+in the dependency graph.
+
+The repository does not show broad copy-and-paste growth or an obvious surplus
+of production code. Its main maintainability risk is concentrated orchestration:
+a small number of very large dispatch, update, and rendering functions have
+become mandatory edit and review points for otherwise separate behavior.
+
+Summary:
+
+- Architecture: sound, with one narrow client-to-daemon dependency to correct.
+- Test and security discipline: strong.
+- Cross-file duplication: low.
+- Local changeability: good at crate boundaries, mixed inside orchestration
+  modules.
+- Primary risk: oversized request, event-reduction, drawing, and command
+  dispatch pipelines.
+- Runtime performance: not established by this review; performance optimization
+  requires profiling and benchmark evidence rather than line-count reduction.
+
+## Size profile
+
+Approximate measurements taken from tracked files:
+
+| Area | Size |
+| --- | ---: |
+| Active Rust, excluding one archived source copy | 141,803 lines |
+| Approximate production Rust before trailing `cfg(test)` modules | 90,000–92,000 lines |
+| Inline and external Rust tests | More than 45,000 lines |
+| Tooling, primarily Python | 37,857 lines |
+| All tracked code-like files, including tools and archived copies | About 196,000 lines |
+| Exact cross-file clone candidates of at least 12 lines | About 595 duplicated lines |
+| Tracked documentation and retained evidence | 2,596 files / 147.6 MiB |
+| Git pack | 61.6 MiB |
+
+Splinterm includes a terminal engine, persistent daemon, Wayland client,
+protocol, remote transport, automation client, MCP server, image protocols,
+packaging, benchmark harnesses, and Foot-oracle compatibility. The total size is
+large but proportionate to the supported system.
+
+An exact clone scan found 38 cross-file runs of at least 12 lines, representing
+about 595 duplicated lines on one side. This is a heuristic rather than a proof
+of semantic duplication, but it is sufficient to reject broad copy-and-paste as
+the primary source of size.
+
+## Findings
+
+### High priority: decompose daemon request execution without weakening its gate
+
+`crates/splinterd/src/main.rs:4721` begins
+`handle_authorized_request`, an approximately 1,905-line function covering
+access grants, topology and process mutations, history and search, controller
+lifecycle, and terminal actions.
+
+The single visible authorization boundary is valuable and should remain.
+However, operation implementations for unrelated protocol families now collide
+in one function. This increases merge conflicts and makes every operation
+change carry a large security-review surface.
+
+Recommended approach:
+
+1. Retain one exhaustive top-level `Request` match.
+2. Retain centralized authorization and resource tables.
+3. Move operation bodies incrementally into private family handlers for access,
+   topology lifecycle, history/search, control, and terminal actions.
+4. Pass explicit borrowed context instead of introducing a generic service
+   abstraction that hides authority or cleanup behavior.
+
+This is primarily a changeability improvement; it may not materially reduce
+line count.
+
+### High priority: turn Wayland update and drawing into explicit phases
+
+`crates/splinterm/src/wayland.rs:7163` begins the approximately 721-line
+`apply_updates` pipeline. `crates/splinterm/src/wayland.rs:8083` begins the
+approximately 879-line `draw` pipeline.
+
+Together they coordinate topology and terminal update reduction, history and
+search state, geometry, resize and focus reconciliation, frame preparation,
+shared-memory backing, terminal and overlay composition, damage, capture, and
+surface commit. Rendering, protocol-update, and overlay work therefore converge
+on the same high-churn file and transactions.
+
+The module already has focused submodules and grouped state structures. The
+recommended change is not an arbitrary split of `wayland.rs` or a flattening of
+`App` state. Instead:
+
+1. Extract phase-oriented private helpers for focused-pane update reduction,
+   prepared-frame reconciliation, SHM/backing synchronization, overlay
+   composition, and commit finalization.
+2. Keep `apply_updates` and `draw` as short, visibly ordered coordinators.
+3. Preserve the documented atomic acquisition, damage, and commit sequence.
+4. Retain Wayland object ownership in the Wayland layer.
+
+### Medium priority: remove the UI crate's daemon-library dependency
+
+`crates/splinterm/Cargo.toml` normally depends on `splinterd`, while the only
+source use is `splinterd::inspect_policy_file` in
+`crates/splinterm/src/app/local_service.rs:81` and `:86`. The API is exported by
+`crates/splinterd/src/lib.rs`.
+
+This couples the disposable graphical client to daemon implementation and its
+transitive runtime dependencies for one shared security function. It weakens an
+otherwise clean ownership boundary and expands rebuild and API-change scope.
+
+Recommended approach:
+
+1. Move the secure policy loader, typed representation, validation, and
+   normalized inspection API into a narrow shared policy crate.
+2. Use that crate from both `splinterd` and `splinterm`.
+3. Initially preserve `splinterd::inspect_policy_file` as a delegating
+   compatibility wrapper.
+4. Preserve all ownership, permissions, bounded-shape, and semantic checks.
+
+### Medium priority: split topology-manager command families
+
+`crates/splinterm/src/app/topology_manager.rs:1223` begins the approximately
+559-line `handle_session_manager_command` function. It handles picker
+operations, creation, navigation, restoration, renaming, retention,
+termination, and tab lifecycle within one serialized switch.
+
+Keep the single serialized manager loop, but delegate picker,
+creation/materialization, Lair lifecycle, Dojo lifecycle, and tab lifecycle to
+private handlers returning a common typed outcome.
+
+### Medium priority: modularize automation-client internals
+
+Before tests begin in `crates/splinterm-automation-client/src/lib.rs`, one module
+contains independently evolving DTO projection, event and subscription
+conversion, image transport/cache ownership, and connection framing and
+cancellation.
+
+Move these implementations into private `projection`, `events`, `image`, and
+`connection` modules and re-export the existing public API unchanged. This
+should reduce navigation and conflict cost without causing downstream churn.
+
+### Low priority: centralize audit operation naming
+
+The complete `AuditOperation` string mapping is duplicated in:
+
+- `crates/splinterm-automation-client/src/lib.rs:1383`
+- `crates/splinterm-mcp/src/dispatch.rs:1882`
+
+The authoritative enum already lives in
+`crates/splinterm-protocol/src/lib.rs:1372` with `snake_case` serialization.
+Add an exhaustive canonical `AuditOperation::as_str()` in the protocol crate and
+reuse it in both consumers. Keep exhaustive matching so new operations remain
+compile-time checked.
+
+### Low priority: conservatively extract MCP mutation response plumbing
+
+`crates/splinterm-mcp/src/dispatch.rs:1325` begins an approximately 544-line
+mutation dispatcher. Its explicit tool-to-request mapping is security relevant
+and should stay visibly exhaustive.
+
+Extract only per-resource-family response handling and repeated
+preflight/revision plumbing. Do not replace the closed tool-name match with a
+runtime registry or generic dispatch mechanism.
+
+## Architecture assessment
+
+The documented major boundaries still match implementation:
+
+- `splinterm-core` remains independent of async runtimes, PTYs, wire protocol,
+  and Wayland.
+- `splinterm-protocol` depends on core rather than UI or runtime
+  implementation.
+- `splinterd` has no Wayland or Smithay dependency.
+- `splinterm-graphical-relay` does not parse or depend on the private daemon
+  protocol.
+- Application services call the narrow `run_window` facade rather than owning
+  Smithay objects.
+- Internal APIs use private and scoped visibility deliberately.
+- Protocol and authority decisions remain explicit and fail closed.
+
+Recent change concentration supports the hotspot diagnosis. Of the last 100
+commits, 39 changed Rust; those commits touched a median of three and a mean of
+6.3 Rust files, with 15 touching at least five. `wayland.rs` appeared in 17 of
+the 100 commits and `splinterd/src/main.rs` in 11. Some spread is expected for
+protocol changes crossing daemon, client, and tests, but the two orchestration
+roots remain recurring convergence points.
+
+No blocker-level architectural failure was found.
+
+## Code that should not be reduced merely to lower LOC
+
+Do not compress or generalize the following without a separately justified
+behavioral design:
+
+- daemon authorization and resource mappings;
+- protocol `Request` and `Response` definitions;
+- MCP's closed tool mapping;
+- the built-in keymap table;
+- terminal and Foot-oracle regression coverage;
+- image-protocol compatibility coverage;
+- explicit resource limits and bounded validation; and
+- the daemon's single visible authorization gate.
+
+This verbosity supports security review, compatibility, and regression
+protection. Removing it would improve a metric while making the system less
+auditable.
+
+The large preset-validation result produced by the first heuristic scan was a
+false positive caused by naive brace tracking. The actual
+`validate_catalog_with_commands` function is already bounded and delegates tree
+validation and traversal; it does not justify a rewrite.
+
+## Repository bulk
+
+The working-tree size is dominated by retained benchmark, spike, oracle, and
+graphical evidence under `docs/`, not production source. This affects clone,
+search, and navigation ergonomics but is not demonstrated code-maintenance
+bloat. Tooling consumes portions of the retained evidence and repository policy
+requires preservation of historical artifacts.
+
+Do not delete or silently regenerate this material. If repository ergonomics
+become a material problem, evaluate Git LFS or versioned external object storage
+with checked manifests, immutable provenance, offline behavior, and tooling
+migration defined first.
+
+## Recommended sequence
+
+1. Extract the shared secure policy loader from `splinterd`.
+2. Decompose daemon request-family implementations while preserving one
+   exhaustive authorization gate.
+3. Refactor Wayland update and draw into explicit ordered phases.
+4. Split automation-client internals behind unchanged public exports.
+5. Split topology-manager command families.
+6. Centralize audit-operation string mapping.
+7. Conservatively extract repeated MCP mutation response plumbing.
+8. Adopt a review rule that new functions over roughly 200–300 lines require a
+   documented cohesion, security, or generated-table rationale.
+
+Safe deletion opportunities appear modest. The main return will come from
+smaller change surfaces and clearer ownership, not from removing tens of
+thousands of lines.
+
+## Validation and review evidence
+
+The following passed on the reviewed tree:
+
+```text
+cargo fmt --all --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace -- --test-threads=1
+git diff --check
+```
+
+Two fresh read-only reviews completed successfully. Both found no blocker-level
+architectural failure and independently identified the oversized daemon
+request handler and client-to-daemon policy dependency. One review additionally
+confirmed the Wayland update/draw pipelines as the largest UI changeability
+risk.


### PR DESCRIPTION
## Scope

Collect the current proposed `0.2.0` programs and architecture follow-up in one isolated planning branch:

- persistence expansion and guarded PTY upgrade handoff;
- live Omarchy system-font synchronization;
- fuzzy-searchable binding help and complete bindable Lair lifecycle controls;
- code-size and architecture review follow-up.

## Validation

- `git diff --cached --check` before commit
- documentation whitespace and link-target checks for Plans 0038 and 0039

## Draft boundary

This remains a draft until the combined planning set receives the required product, architecture, privacy, keymap/UI, and release review. It authorizes no implementation, graphical testing, installation, or publication.