### PR TITLE
Number default Dojo names

### DIFF
--- a/crates/splinterm-core/src/model.rs
+++ b/crates/splinterm-core/src/model.rs
@@ -188,8 +188,31 @@ impl Lair {
             lifetime,
             retention: LairRetention::Disposable,
             provenance: None,
-            dojos: vec![Dojo::with_shell("terminal", cwd)],
+            dojos: vec![Dojo::with_shell("Dojo 1", cwd)],
         }
+    }
+
+    /// Returns the next implicit Dojo name without reusing numeric gaps.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TopologyError::DefaultDojoNameExhausted`] when the highest
+    /// canonical numbered name is `Dojo 18446744073709551615`.
+    pub fn next_default_dojo_name(&self) -> Result<String, TopologyError> {
+        let highest = self
+            .dojos
+            .iter()
+            .filter_map(|dojo| {
+                let suffix = dojo.name.strip_prefix("Dojo ")?;
+                let number = suffix.parse::<u64>().ok()?;
+                (number > 0 && suffix == number.to_string()).then_some(number)
+            })
+            .max()
+            .unwrap_or(0);
+        let next = highest
+            .checked_add(1)
+            .ok_or(TopologyError::DefaultDojoNameExhausted)?;
+        Ok(format!("Dojo {next}"))
     }
 }
 
@@ -808,6 +831,8 @@ pub enum TopologyError {
     TransientLairRetention(LairId),
     #[error("Dojo {0:?} does not exist")]
     DojoNotFound(DojoId),
+    #[error("default Dojo numbering is exhausted")]
+    DefaultDojoNameExhausted,
     #[error("preset materialization requires at least one Dojo")]
     EmptyDojoSet,
     #[error("Dojo {0:?} already exists")]
@@ -837,6 +862,61 @@ pub enum TopologyError {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn default_dojo_names_start_at_one_and_advance_past_the_highest_exact_number() {
+        let mut lair = Lair::new("main", PathBuf::from("/tmp"));
+        assert_eq!(lair.dojos[0].name, "Dojo 1");
+        assert_eq!(lair.next_default_dojo_name().unwrap(), "Dojo 2");
+
+        lair.dojos
+            .push(Dojo::with_shell("Dojo 3", PathBuf::from("/tmp")));
+        lair.dojos
+            .push(Dojo::with_shell("logs", PathBuf::from("/tmp")));
+        assert_eq!(lair.next_default_dojo_name().unwrap(), "Dojo 4");
+    }
+
+    #[test]
+    fn legacy_and_empty_lairs_begin_numbering_at_one() {
+        let mut lair = Lair::new("main", PathBuf::from("/tmp"));
+        lair.dojos[0].name = "terminal".to_owned();
+        assert_eq!(lair.next_default_dojo_name().unwrap(), "Dojo 1");
+
+        lair.dojos.clear();
+        assert_eq!(lair.next_default_dojo_name().unwrap(), "Dojo 1");
+    }
+
+    #[test]
+    fn default_dojo_names_ignore_noncanonical_numbers_and_reject_exhaustion() {
+        let mut lair = Lair::new("main", PathBuf::from("/tmp"));
+        for name in [
+            "dojo 9",
+            "Dojo 0",
+            "Dojo 02",
+            "Dojo +8",
+            "Dojo 7 ",
+            "Dojo 18446744073709551616",
+        ] {
+            lair.dojos
+                .push(Dojo::with_shell(name, PathBuf::from("/tmp")));
+        }
+        assert_eq!(lair.next_default_dojo_name().unwrap(), "Dojo 2");
+
+        lair.dojos.push(Dojo::with_shell(
+            format!("Dojo {}", u64::MAX),
+            PathBuf::from("/tmp"),
+        ));
+        assert_eq!(
+            lair.next_default_dojo_name(),
+            Err(TopologyError::DefaultDojoNameExhausted)
+        );
+    }
+
+    #[test]
+    fn transient_lairs_also_start_with_dojo_one() {
+        let lair = Lair::transient("private", PathBuf::from("/tmp"));
+        assert_eq!(lair.dojos[0].name, "Dojo 1");
+    }
 
     #[test]
     fn runtime_state_can_transition_and_failed_creation_can_roll_back() {

--- a/crates/splinterm/src/app/cli.rs
+++ b/crates/splinterm/src/app/cli.rs
@@ -53,7 +53,9 @@ use super::{
     },
     presets::{materialize_preset, run_preset_command},
     remote_cli::run_remote_command,
-    session_catalog::{automation_launch, create_request, launch_parameters, remember_dojo},
+    session_catalog::{
+        automation_launch, create_request, launch_parameters, new_dojo_request_for, remember_dojo,
+    },
     sessions::{launch, reopen_recent, run_dojos, select_dojo, xdg_launch},
 };
 
@@ -477,26 +479,24 @@ async fn run_headless(
             cwd,
             command,
         } => {
-            let expected_topology_revision = connection.topology_revision().await?;
-            let cwd = endpoint_launch_cwd(factory, cwd)?;
-            let request = match factory.capabilities().launch_semantics {
-                LaunchSemantics::LocalTrusted => Request::NewDojo {
-                    expected_topology_revision,
-                    lair_id,
-                    name,
-                    launch: launch_parameters(
-                        cwd.context("local Dojo working directory is unavailable")?,
-                        command,
-                        config,
-                    ),
-                },
-                LaunchSemantics::RemoteInteractive => Request::NewDojoAutomation {
-                    expected_topology_revision,
-                    lair_id,
-                    name,
-                    launch: automation_launch(cwd, command),
-                },
+            let Response::Lairs {
+                lairs,
+                topology_revision: expected_topology_revision,
+            } = connection.request(Request::ListLairs).await?
+            else {
+                bail!("splinterd did not return its Lair catalog");
             };
+            let cwd = endpoint_launch_cwd(factory, cwd)?;
+            let request = new_dojo_request_for(
+                factory.capabilities().launch_semantics,
+                expected_topology_revision,
+                &lairs,
+                lair_id,
+                name,
+                cwd,
+                command,
+                config,
+            )?;
             print_response(connection.request(request).await?)
         }
         Command::CloseDojo { dojo_id, .. } => {
@@ -939,6 +939,30 @@ mod tests {
         assert!(Cli::try_parse_from(["splinterm", "remote"]).is_err());
         assert!(Cli::try_parse_from(["splinterm", "remote", "inspect"]).is_err());
         assert!(Cli::try_parse_from(["splinterm", "remote", "check"]).is_err());
+    }
+
+    #[test]
+    fn new_dojo_name_is_optional_and_explicit_names_are_preserved() {
+        let lair_id = LairId::new();
+        let implicit =
+            Cli::try_parse_from(["splinterm", "new-dojo", &lair_id.to_string()]).unwrap();
+        assert!(matches!(
+            implicit.command,
+            Some(Command::NewDojo { name: None, .. })
+        ));
+
+        let explicit = Cli::try_parse_from([
+            "splinterm",
+            "new-dojo",
+            &lair_id.to_string(),
+            "--name",
+            "logs",
+        ])
+        .unwrap();
+        assert!(matches!(
+            explicit.command,
+            Some(Command::NewDojo { name: Some(name), .. }) if name == "logs"
+        ));
     }
 
     #[test]

--- a/crates/splinterm/src/app/commands.rs
+++ b/crates/splinterm/src/app/commands.rs
@@ -240,8 +240,8 @@ pub(in crate::app) enum Command {
     /// Create a persistent Dojo with one live Splint.
     NewDojo {
         lair_id: LairId,
-        #[arg(long, default_value = "terminal")]
-        name: String,
+        #[arg(long)]
+        name: Option<String>,
         #[arg(long)]
         cwd: Option<PathBuf>,
         #[arg(last = true, allow_hyphen_values = true)]

--- a/crates/splinterm/src/app/machine/mutation.rs
+++ b/crates/splinterm/src/app/machine/mutation.rs
@@ -33,7 +33,7 @@ pub(super) enum MachineMutation {
     },
     NewDojo {
         lair_id: LairId,
-        name: String,
+        name: Option<String>,
         cwd: Option<PathBuf>,
         command: Vec<String>,
     },
@@ -250,6 +250,28 @@ fn require_lair(topology: &splinterm_protocol::TopologySnapshot, lair_id: LairId
     }
 }
 
+fn machine_new_dojo_request(
+    topology: &splinterm_protocol::TopologySnapshot,
+    lair_id: LairId,
+    name: Option<&str>,
+    launch: LaunchParameters,
+) -> Result<Request> {
+    let lair = topology
+        .topology
+        .find_lair(lair_id)
+        .context("requested Lair was not found")?;
+    let name = match name {
+        Some(name) => name.to_owned(),
+        None => lair.next_default_dojo_name()?,
+    };
+    Ok(Request::NewDojo {
+        expected_topology_revision: topology.revision,
+        lair_id,
+        name,
+        launch,
+    })
+}
+
 #[allow(
     clippy::too_many_lines,
     reason = "closed machine mutation request construction stays adjacent for auditability"
@@ -306,15 +328,12 @@ fn machine_mutation_request(
             name,
             cwd,
             command,
-        } => {
-            require_lair(topology, *lair_id)?;
-            Request::NewDojo {
-                expected_topology_revision,
-                lair_id: *lair_id,
-                name: name.clone(),
-                launch: machine_launch(cwd.clone(), command.clone())?,
-            }
-        }
+        } => machine_new_dojo_request(
+            topology,
+            *lair_id,
+            name.as_deref(),
+            machine_launch(cwd.clone(), command.clone())?,
+        )?,
         MachineMutation::CloseDojo { dojo_id, .. } => {
             topology_dojo_location(topology, *dojo_id)?;
             Request::CloseDojo {
@@ -916,4 +935,66 @@ pub(super) async fn run_machine_audit(
     }
     .await;
     finish_machine_envelope(OPERATION, result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use splinterm_core::{Dojo, Topology};
+
+    fn launch() -> LaunchParameters {
+        LaunchParameters {
+            cwd: PathBuf::from("/tmp"),
+            command: vec!["true".to_owned()],
+            shell: None,
+            login_shell: false,
+            scrollback_lines: 1_000,
+        }
+    }
+
+    #[test]
+    fn machine_new_dojo_requests_resolve_defaults_and_preserve_explicit_names_and_revision() {
+        let mut model = Topology::new();
+        let lair_id = model.create_lair("main", PathBuf::from("/tmp")).unwrap().id;
+        model
+            .new_dojo_at(
+                model.revision(),
+                lair_id,
+                Dojo::with_shell("Dojo 3", PathBuf::from("/tmp")),
+            )
+            .unwrap();
+        let revision = model.revision();
+        let snapshot = splinterm_protocol::TopologySnapshot {
+            revision,
+            topology: model,
+            runtimes: Vec::new(),
+        };
+
+        let implicit = machine_new_dojo_request(&snapshot, lair_id, None, launch()).unwrap();
+        assert!(matches!(
+            implicit,
+            Request::NewDojo {
+                expected_topology_revision,
+                lair_id: requested_lair,
+                name,
+                ..
+            } if expected_topology_revision == revision
+                && requested_lair == lair_id
+                && name == "Dojo 4"
+        ));
+
+        let explicit =
+            machine_new_dojo_request(&snapshot, lair_id, Some("logs"), launch()).unwrap();
+        assert!(matches!(
+            explicit,
+            Request::NewDojo {
+                expected_topology_revision,
+                lair_id: requested_lair,
+                name,
+                ..
+            } if expected_topology_revision == revision
+                && requested_lair == lair_id
+                && name == "logs"
+        ));
+    }
 }

--- a/crates/splinterm/src/app/machine/output.rs
+++ b/crates/splinterm/src/app/machine/output.rs
@@ -2,6 +2,15 @@ use super::{
     CliEnvelopeV2, CliErrorCodeV2, ErrorCode, Result, protocol_error, write_json_document,
 };
 
+fn is_default_dojo_name_exhausted(error: &anyhow::Error) -> bool {
+    error.chain().any(|cause| {
+        matches!(
+            cause.downcast_ref::<splinterm_core::TopologyError>(),
+            Some(splinterm_core::TopologyError::DefaultDojoNameExhausted)
+        )
+    })
+}
+
 pub(in crate::app) fn machine_exit_code(error: &anyhow::Error) -> i32 {
     if let Some(protocol) = protocol_error(error) {
         return match protocol.code {
@@ -13,6 +22,9 @@ pub(in crate::app) fn machine_exit_code(error: &anyhow::Error) -> i32 {
             ErrorCode::Internal | ErrorCode::DevelopmentFeatureDisabled => 70,
             _ => 5,
         };
+    }
+    if is_default_dojo_name_exhausted(error) {
+        return 5;
     }
     let message = error.to_string();
     if message.contains("requires --yes") {
@@ -70,6 +82,22 @@ pub(super) fn write_machine_connection_failure(
     )
 }
 
+fn local_machine_failure(error: &anyhow::Error) -> (CliErrorCodeV2, bool) {
+    if is_default_dojo_name_exhausted(error) {
+        (CliErrorCodeV2::InvalidArgument, false)
+    } else if error.to_string().contains("timed out") {
+        (CliErrorCodeV2::Timeout, true)
+    } else if error.to_string().contains("not found") {
+        (CliErrorCodeV2::NotFound, false)
+    } else if error.to_string().contains("expected incarnation")
+        || error.to_string().contains("does not have a live process")
+    {
+        (CliErrorCodeV2::StaleIncarnation, false)
+    } else {
+        (CliErrorCodeV2::Internal, false)
+    }
+}
+
 pub(super) fn finish_machine_envelope(
     operation: &'static str,
     result: Result<CliEnvelopeV2>,
@@ -85,17 +113,7 @@ pub(super) fn finish_machine_envelope(
                 )?)?;
                 return Err(error);
             }
-            let (code, retryable) = if error.to_string().contains("timed out") {
-                (CliErrorCodeV2::Timeout, true)
-            } else if error.to_string().contains("not found") {
-                (CliErrorCodeV2::NotFound, false)
-            } else if error.to_string().contains("expected incarnation")
-                || error.to_string().contains("does not have a live process")
-            {
-                (CliErrorCodeV2::StaleIncarnation, false)
-            } else {
-                (CliErrorCodeV2::Internal, false)
-            };
+            let (code, retryable) = local_machine_failure(&error);
             write_machine_read_failure(operation, code, bounded_public_message(&error), retryable)?;
             Err(error)
         }
@@ -112,4 +130,20 @@ pub(super) fn bounded_public_message(error: &anyhow::Error) -> String {
         .take(1023)
         .chain(std::iter::once('…'))
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn exhausted_default_dojo_number_is_a_recoverable_invalid_argument() {
+        let error = anyhow::Error::new(splinterm_core::TopologyError::DefaultDojoNameExhausted);
+
+        assert_eq!(machine_exit_code(&error), 5);
+        assert_eq!(
+            local_machine_failure(&error),
+            (CliErrorCodeV2::InvalidArgument, false)
+        );
+    }
 }

--- a/crates/splinterm/src/app/session_catalog.rs
+++ b/crates/splinterm/src/app/session_catalog.rs
@@ -33,6 +33,44 @@ pub(in crate::app) fn automation_launch(
     AutomationLaunch { cwd, argv }
 }
 
+#[allow(
+    clippy::too_many_arguments,
+    reason = "the shared local/remote request boundary keeps every launch field explicit"
+)]
+pub(in crate::app) fn new_dojo_request_for(
+    semantics: LaunchSemantics,
+    expected_topology_revision: TopologyRevision,
+    lairs: &[splinterm_core::Lair],
+    lair_id: LairId,
+    name: Option<String>,
+    cwd: Option<PathBuf>,
+    command: Vec<String>,
+    config: &AppConfig,
+) -> Result<Request> {
+    let name = match name {
+        Some(name) => name,
+        None => next_default_dojo_name(lairs, lair_id)?,
+    };
+    Ok(match semantics {
+        LaunchSemantics::LocalTrusted => Request::NewDojo {
+            expected_topology_revision,
+            lair_id,
+            name,
+            launch: launch_parameters(
+                cwd.context("local Dojo working directory is unavailable")?,
+                command,
+                config,
+            ),
+        },
+        LaunchSemantics::RemoteInteractive => Request::NewDojoAutomation {
+            expected_topology_revision,
+            lair_id,
+            name,
+            launch: automation_launch(cwd, command),
+        },
+    })
+}
+
 pub(in crate::app) fn create_request(
     factory: &ConnectionFactory,
     expected_topology_revision: TopologyRevision,
@@ -75,6 +113,18 @@ pub(in crate::app) fn create_request_for(
             launch: automation_launch(cwd, command),
         },
     })
+}
+
+pub(in crate::app) fn next_default_dojo_name(
+    lairs: &[splinterm_core::Lair],
+    lair_id: LairId,
+) -> Result<String> {
+    lairs
+        .iter()
+        .find(|lair| lair.id == lair_id)
+        .context("selected Lair is not present in the current topology")?
+        .next_default_dojo_name()
+        .map_err(Into::into)
 }
 
 pub(in crate::app) fn select_dojo_from(
@@ -122,5 +172,111 @@ pub(in crate::app) fn session_picker_item(entry: &SessionEntry) -> SessionPicker
         working_directory: entry.working_directory(),
         pane_count: entry.pane_count,
         running_pane_count: entry.running_panes,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use splinterm_core::Dojo;
+
+    #[test]
+    fn new_dojo_requests_preserve_revision_and_resolve_names_for_both_semantics() {
+        let mut lair = splinterm_core::Lair::new("main", PathBuf::from("/tmp"));
+        let lair_id = lair.id;
+        lair.dojos
+            .push(Dojo::with_shell("Dojo 3", PathBuf::from("/tmp")));
+        let revision = TopologyRevision::new(41);
+        let config = AppConfig::default();
+
+        let local = new_dojo_request_for(
+            LaunchSemantics::LocalTrusted,
+            revision,
+            std::slice::from_ref(&lair),
+            lair_id,
+            None,
+            Some(PathBuf::from("/work")),
+            vec!["local".to_owned()],
+            &config,
+        )
+        .unwrap();
+        assert!(matches!(
+            local,
+            Request::NewDojo {
+                expected_topology_revision,
+                lair_id: requested_lair,
+                name,
+                launch,
+            } if expected_topology_revision == revision
+                && requested_lair == lair_id
+                && name == "Dojo 4"
+                && launch.cwd == std::path::Path::new("/work")
+                && launch.command == ["local"]
+        ));
+
+        let local_explicit = new_dojo_request_for(
+            LaunchSemantics::LocalTrusted,
+            revision,
+            std::slice::from_ref(&lair),
+            lair_id,
+            Some("logs".to_owned()),
+            Some(PathBuf::from("/work")),
+            Vec::new(),
+            &config,
+        )
+        .unwrap();
+        assert!(matches!(
+            local_explicit,
+            Request::NewDojo {
+                expected_topology_revision,
+                name,
+                ..
+            } if expected_topology_revision == revision && name == "logs"
+        ));
+
+        let remote_implicit = new_dojo_request_for(
+            LaunchSemantics::RemoteInteractive,
+            revision,
+            std::slice::from_ref(&lair),
+            lair_id,
+            None,
+            None,
+            Vec::new(),
+            &config,
+        )
+        .unwrap();
+        assert!(matches!(
+            remote_implicit,
+            Request::NewDojoAutomation {
+                expected_topology_revision,
+                name,
+                ..
+            } if expected_topology_revision == revision && name == "Dojo 4"
+        ));
+
+        let remote = new_dojo_request_for(
+            LaunchSemantics::RemoteInteractive,
+            revision,
+            &[lair],
+            lair_id,
+            Some("logs".to_owned()),
+            None,
+            vec!["remote".to_owned()],
+            &config,
+        )
+        .unwrap();
+        assert!(matches!(
+            remote,
+            Request::NewDojoAutomation {
+                expected_topology_revision,
+                lair_id: requested_lair,
+                name,
+                launch,
+            } if expected_topology_revision == revision
+                && requested_lair == lair_id
+                && name == "logs"
+                && launch.cwd.is_none()
+                && launch.argv == ["remote"]
+        ));
     }
 }

--- a/crates/splinterm/src/app/sessions.rs
+++ b/crates/splinterm/src/app/sessions.rs
@@ -210,25 +210,13 @@ pub(in crate::app) async fn run_dojos(config: AppConfig, factory: ConnectionFact
             if let Some(diagnostics) = splinterm::diagnostics::global() {
                 diagnostics.begin_window(None, None);
             }
-            let stamp = SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_secs();
+            let name = fresh_lair_name(SystemTime::now(), std::process::id());
             let cwd = if factory.is_local() {
                 Some(env::current_dir().context("failed to read current directory")?)
             } else {
                 None
             };
-            launch(
-                Some(format!("terminal-{stamp}-{}", std::process::id())),
-                cwd,
-                None,
-                true,
-                Vec::new(),
-                config,
-                factory,
-            )
-            .await
+            launch(Some(name), cwd, None, true, Vec::new(), config, factory).await
         }
         Some(SessionPickerDecision::Open(index)) => {
             if let Some(diagnostics) = splinterm::diagnostics::global() {
@@ -271,7 +259,7 @@ pub(in crate::app) async fn reopen_recent(
     run_live_multipane_window(config, dojo, factory).await
 }
 
-fn fresh_dojo_name(now: SystemTime, process_id: u32) -> String {
+fn fresh_lair_name(now: SystemTime, process_id: u32) -> String {
     let stamp = now.duration_since(UNIX_EPOCH).unwrap_or_default().as_secs();
     format!("terminal-{stamp}-{process_id}")
 }
@@ -316,7 +304,7 @@ pub(in crate::app) async fn xdg_launch(
         .await
         .context("splinterd is unavailable; start splinterd.service or run splinterd")?;
     let expected = owner.topology_revision().await?;
-    let name = fresh_dojo_name(SystemTime::now(), std::process::id());
+    let name = fresh_lair_name(SystemTime::now(), std::process::id());
     let Response::LairCreated { lair, .. } = owner
         .request(Request::CreateTransientLair {
             expected_topology_revision: expected,
@@ -389,7 +377,7 @@ async fn launch_with_app_id(
         return run_live_window(config, splint_id, factory).await;
     }
 
-    let name = name.unwrap_or_else(|| fresh_dojo_name(SystemTime::now(), std::process::id()));
+    let name = name.unwrap_or_else(|| fresh_lair_name(SystemTime::now(), std::process::id()));
     let expected = connection.topology_revision().await?;
     let Response::LairCreated { lair: dojo, .. } = connection
         .request(create_request(
@@ -489,9 +477,9 @@ mod tests {
     }
 
     #[test]
-    fn fresh_dojo_names_include_time_and_process_identity() {
+    fn fresh_lair_names_include_time_and_process_identity() {
         assert_eq!(
-            fresh_dojo_name(
+            fresh_lair_name(
                 SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(1_234),
                 56
             ),

--- a/crates/splinterm/src/app/topology_manager.rs
+++ b/crates/splinterm/src/app/topology_manager.rs
@@ -26,8 +26,8 @@ use tokio::sync::mpsc;
 use super::{
     pane_bridge::{PaneTask, layout_splint_ids, prepare_live_pane},
     session_catalog::{
-        automation_launch, create_request, launch_parameters, recent_dojo_ids, remember_dojo,
-        select_dojo_from, session_picker_item,
+        automation_launch, create_request, launch_parameters, new_dojo_request_for,
+        recent_dojo_ids, remember_dojo, select_dojo_from, session_picker_item,
     },
 };
 
@@ -791,25 +791,23 @@ async fn create_dojo_in_lair(
     lair_id: LairId,
     cwd: std::path::PathBuf,
 ) -> Result<(WindowDojoIdentity, splinterm_core::Dojo)> {
-    let expected_topology_revision = connection.topology_revision().await?;
-    let stamp = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs();
-    let request = match factory.capabilities().launch_semantics {
-        LaunchSemantics::LocalTrusted => Request::NewDojo {
-            expected_topology_revision,
-            lair_id,
-            name: format!("terminal-{stamp}"),
-            launch: launch_parameters(cwd.clone(), Vec::new(), config),
-        },
-        LaunchSemantics::RemoteInteractive => Request::NewDojoAutomation {
-            expected_topology_revision,
-            lair_id,
-            name: format!("terminal-{stamp}"),
-            launch: automation_launch(Some(cwd), Vec::new()),
-        },
+    let Response::Lairs {
+        lairs,
+        topology_revision: expected_topology_revision,
+    } = connection.request(Request::ListLairs).await?
+    else {
+        bail!("splinterd did not return its Lair catalog");
     };
+    let request = new_dojo_request_for(
+        factory.capabilities().launch_semantics,
+        expected_topology_revision,
+        &lairs,
+        lair_id,
+        None,
+        Some(cwd),
+        Vec::new(),
+        config,
+    )?;
     let Response::DojoStarted { dojo_id, .. } = connection.request(request).await? else {
         bail!("splinterd did not create the requested Dojo");
     };

--- a/crates/splinterm/src/session_picker.rs
+++ b/crates/splinterm/src/session_picker.rs
@@ -401,7 +401,7 @@ mod tests {
         let entries = collect_sessions(&[first, second], &[recent]);
         assert_eq!(entries.len(), 3);
         assert_eq!(entries[0].dojo_id, recent);
-        assert_eq!(entries[0].display_title(), "notes / terminal");
+        assert_eq!(entries[0].display_title(), "notes / Dojo 1");
         assert_eq!(entries[0].working_directory(), "/notes");
     }
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -88,7 +88,10 @@ paths. With no focused Splinterm Window, its two projection fields are null.
 | `dojo-focus-hint DOJO_ID SPLINT_ID` | Persist a presentation hint; it does not focus a client or Window. |
 
 `ARGV` after `--` is executed directly, never through a shell. With no explicit
-argv, creation uses the configured shell.
+argv, creation uses the configured shell. A new Lair starts with `Dojo 1`. When
+`new-dojo` omits `--name`, Splinterm uses one greater than that Lair's highest
+existing exact `Dojo N` name; numeric gaps are not reused. Explicit names are
+preserved.
 
 ```bash
 splinterm new project --cwd "$HOME/src/project"

--- a/docs/plans/0037-numbered-default-dojo-names.md
+++ b/docs/plans/0037-numbered-default-dojo-names.md
@@ -1,0 +1,115 @@
+# Plan 0037: Numbered default Dojo names
+
+- **Status:** Implementation complete and reviewed for the current `0.1.0-alpha` patch line; release integration pending
+- **Date:** 2026-08-14
+- **Product authority:** Implicitly named Dojos use short, predictable per-Lair labels; explicit and persisted names remain user-owned
+- **Depends on:** accepted Lair/Dojo topology, topology revisions, graphical Dojo tabs, and `new-dojo` CLI creation
+
+## Decision
+
+Replace generated default Dojo labels such as `terminal` and
+`terminal-<timestamp>` with `Dojo 1`, `Dojo 2`, and so on.
+
+Numbering is local to one Lair. An implicitly named Dojo uses one greater than
+the highest existing name that exactly matches `Dojo N`, where `N` is a
+positive decimal integer. Gaps are not reused: if a Lair contains `Dojo 1` and
+`Dojo 3`, the next implicit name is `Dojo 4`.
+
+Explicit names remain exact after existing normalization and validation.
+Existing persisted Dojos are not migrated or renamed. Collision-resistant Lair
+names such as `terminal-<timestamp>-<pid>` also remain unchanged because they
+identify Lairs rather than Dojo tabs.
+
+## Behavior contract
+
+- A newly created persistent or transient Lair starts with `Dojo 1`.
+- Creating an unnamed Dojo in that Lair chooses `max(existing numbered Dojos) + 1`.
+- Exact names such as `Dojo 7` participate in numbering, including names set by
+  an explicit create or rename operation.
+- Custom names, different capitalization, malformed suffixes, zero, signs,
+  whitespace variants, and numeric overflow do not participate.
+- If the highest recognized number cannot be incremented safely, implicit
+  creation fails with a bounded error rather than wrapping or generating a
+  duplicate fallback.
+- An explicit CLI `--name` bypasses default-name generation.
+- MCP, automation, preset, and protocol requests that already require an
+  explicit name retain that contract.
+- Name derivation and the create request use the same listed topology revision;
+  concurrent topology mutation is rejected through the existing stale-revision
+  boundary.
+
+## Implementation milestones
+
+### Milestone 1 — shared numbering contract and initial Dojo
+
+- Add one shared pure helper for deriving the next numbered Dojo name from a
+  Lair's current Dojos.
+- Change the initial Dojo created by `Lair::new` and `Lair::transient` from
+  `terminal` to `Dojo 1`.
+- Test empty, contiguous, gapped, custom, malformed, explicitly high, and
+  overflow cases.
+- Preserve legacy persistence fixtures and prove old `terminal` names still load
+  without migration.
+
+### Milestone 2 — graphical and CLI implicit creation
+
+- Replace timestamp-derived graphical tab names with the shared helper.
+- Derive the name from the target Lair in a `ListLairs` response and use that
+  response's topology revision for creation.
+- Make `new-dojo --name` optional. Resolve omission through the same helper in
+  both human and machine execution paths while preserving explicit names.
+- Keep generated Lair names collision-resistant and rename misleading internal
+  helper terminology where it otherwise suggests those values are Dojo names.
+- Test omitted and explicit CLI behavior plus local and remote-interactive
+  request construction.
+
+### Milestone 3 — documentation and acceptance
+
+- Document the numbered omitted-name behavior in the source and website CLI
+  references.
+- Run focused affected-crate tests, the non-graphical workspace boundary,
+  formatting, strict affected-crate Clippy, and `git diff --check`.
+- Inspect the actual diff and obtain one fresh read-only review before claiming
+  completion.
+
+## Validation
+
+```bash
+cargo test -p splinterm-core
+cargo test -p splinterm
+cargo test --workspace
+cargo fmt --all --check
+cargo clippy -p splinterm-core -p splinterm --all-targets -- -D warnings
+git diff --check
+```
+
+No graphical test is required for acceptance: topology responses and focused
+unit/integration tests can prove the generated names. Packaging, installation,
+version bumps, publication, and release tagging remain separate release-boundary
+work.
+
+## Implementation evidence (2026-08-14)
+
+- New persistent and transient Lairs now start with `Dojo 1`; legacy persisted
+  names remain unchanged when loaded.
+- One core helper recognizes only canonical positive `Dojo N` names, advances
+  past the maximum without reusing gaps, ignores malformed and over-`u64`
+  suffixes, and fails closed at `u64::MAX`.
+- Graphical creation, human `new-dojo`, remote-interactive creation, and machine
+  JSON creation derive implicit names from the exact listed topology revision.
+  Explicit names bypass derivation. Generated Lair names remain unchanged.
+- Focused request tests cover implicit and explicit names for local,
+  remote-interactive, and machine requests, including exact revision retention.
+- `cargo test -p splinterm-core` passed. Post-review `cargo test -p splinterm
+  --lib --bin splinterm` passed with 370 library tests passed, one manual timing
+  harness ignored, and 99 binary tests passed.
+- Strict affected-crate Clippy, formatting, `git diff --check`, and the complete
+  website build/link validation passed.
+- The workspace run passed affected work but encountered unrelated timing
+  failures in two MCP stdio tests; both passed exact isolated retries. Full
+  `splinterm` integration runs also exposed the existing fake-SSH `ETXTBSY`
+  fixture race; the exact failed case passed in isolation. No remote or MCP code
+  was changed for this patch.
+- Fresh read-only review found no correctness blocker and requested stronger
+  request-construction coverage. That coverage was added; bounded follow-up
+  review confirmed the finding resolved and the patch ready.

--- a/docs/plans/0040-numbered-default-dojo-names.md
+++ b/docs/plans/0040-numbered-default-dojo-names.md
@@ -1,6 +1,6 @@
-# Plan 0037: Numbered default Dojo names
+# Plan 0040: Numbered default Dojo names
 
-- **Status:** Implementation complete and reviewed for the current `0.1.0-alpha` patch line; release integration pending
+- **Status:** Implementation complete and reviewed for `0.1.0-alpha3.3`; release integration pending
 - **Date:** 2026-08-14
 - **Product authority:** Implicitly named Dojos use short, predictable per-Lair labels; explicit and persisted names remain user-owned
 - **Depends on:** accepted Lair/Dojo topology, topology revisions, graphical Dojo tabs, and `new-dojo` CLI creation

--- a/site/src/content/docs/docs/cli.md
+++ b/site/src/content/docs/docs/cli.md
@@ -42,6 +42,8 @@ splinterm rename-splint SPLINT_ID TITLE
 
 Arguments after `--` are executed directly as an argument vector. Splinterm does not rebuild them into shell text.
 
+A new Lair starts with `Dojo 1`. If `new-dojo` omits `--name`, Splinterm chooses one greater than that Lair's highest exact `Dojo N` name without reusing gaps. Explicit names are preserved.
+
 ## Lifecycle
 
 | Command | Effect |


### PR DESCRIPTION
## Problem

Unnamed Dojos currently receive timestamp-oriented terminal names, which are difficult to scan and do not communicate their order within a Lair.

## Change

- start new persistent and transient Lairs with `Dojo 1`
- derive later implicit names per Lair as the highest canonical `Dojo N` plus one
- do not reuse gaps
- preserve explicit names and existing persisted names unchanged
- ignore malformed and over-`u64` suffixes; fail closed after canonical `Dojo 18446744073709551615`
- use the same listed topology revision for name derivation and creation
- apply the behavior to graphical, human CLI, remote-interactive, and machine JSON creation paths
- keep generated `terminal-<timestamp>-<pid>` Lair names unchanged
- update CLI documentation and record Plan 0040

## Validation

- `cargo test -p splinterm-core`
- `cargo test -p splinterm --lib --bin splinterm`
  - 370 library tests passed, one manual timing harness ignored
  - 99 binary tests passed
- `cargo clippy -p splinterm-core -p splinterm --all-targets -- -D warnings`
- `cargo fmt --all --check`
- `git diff --check`
- `cd site && npm run validate`
- isolated graphical smoke test on freeside/workspace 2 confirmed a new Lair displays `Dojo 1` without stealing focus

A fresh read-only review found no correctness blocker and requested stronger request-construction coverage. Focused local, remote-interactive, and machine request tests were added; bounded follow-up review confirmed the finding resolved and the patch ready.

## Residual test-harness notes

Broader workspace execution exposed unrelated timing failures in two MCP stdio tests and the existing fake-SSH `ETXTBSY` fixture race. The exact failed tests passed isolated retries. This branch does not change MCP or remote-session code.

## Release boundary

Version bumps, packaging, installation, publication, and tagging remain separate release work.

## Target release

This patch targets `0.1.0-alpha3.3`, after which the `0.1` maintenance boundary will be established and `main` will become the 0.2 integration trunk.
