### PR TITLE
Prepare Alpha3.2 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1142,7 +1142,7 @@ dependencies = [
 
 [[package]]
 name = "splinterd"
-version = "0.1.0-alpha3.1"
+version = "0.1.0-alpha3.2"
 dependencies = [
  "anyhow",
  "nix",
@@ -1165,7 +1165,7 @@ dependencies = [
 
 [[package]]
 name = "splinterm"
-version = "0.1.0-alpha3.1"
+version = "0.1.0-alpha3.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -1195,7 +1195,7 @@ dependencies = [
 
 [[package]]
 name = "splinterm-automation-client"
-version = "0.1.0-alpha3.1"
+version = "0.1.0-alpha3.2"
 dependencies = [
  "anyhow",
  "rustix",
@@ -1211,7 +1211,7 @@ dependencies = [
 
 [[package]]
 name = "splinterm-core"
-version = "0.1.0-alpha3.1"
+version = "0.1.0-alpha3.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -1221,7 +1221,7 @@ dependencies = [
 
 [[package]]
 name = "splinterm-filemap"
-version = "0.1.0-alpha3.1"
+version = "0.1.0-alpha3.2"
 dependencies = [
  "memmap2",
  "rustix",
@@ -1229,7 +1229,7 @@ dependencies = [
 
 [[package]]
 name = "splinterm-freetype"
-version = "0.1.0-alpha3.1"
+version = "0.1.0-alpha3.2"
 dependencies = [
  "freetype-rs",
  "splinterm-pixman",
@@ -1238,7 +1238,7 @@ dependencies = [
 
 [[package]]
 name = "splinterm-graphical-relay"
-version = "0.1.0-alpha3.1"
+version = "0.1.0-alpha3.2"
 dependencies = [
  "anyhow",
  "tokio",
@@ -1247,7 +1247,7 @@ dependencies = [
 
 [[package]]
 name = "splinterm-mcp"
-version = "0.1.0-alpha3.1"
+version = "0.1.0-alpha3.2"
 dependencies = [
  "anyhow",
  "rmcp",
@@ -1262,7 +1262,7 @@ dependencies = [
 
 [[package]]
 name = "splinterm-pixman"
-version = "0.1.0-alpha3.1"
+version = "0.1.0-alpha3.2"
 dependencies = [
  "libc",
  "pixman-sys",
@@ -1271,7 +1271,7 @@ dependencies = [
 
 [[package]]
 name = "splinterm-protocol"
-version = "0.1.0-alpha3.1"
+version = "0.1.0-alpha3.2"
 dependencies = [
  "rustix",
  "serde",
@@ -1283,7 +1283,7 @@ dependencies = [
 
 [[package]]
 name = "splinterm-pty"
-version = "0.1.0-alpha3.1"
+version = "0.1.0-alpha3.2"
 dependencies = [
  "rustix",
  "thiserror",
@@ -1292,7 +1292,7 @@ dependencies = [
 
 [[package]]
 name = "splinterm-relay"
-version = "0.1.0-alpha3.1"
+version = "0.1.0-alpha3.2"
 dependencies = [
  "anyhow",
  "nix",
@@ -1304,7 +1304,7 @@ dependencies = [
 
 [[package]]
 name = "splinterm-terminal"
-version = "0.1.0-alpha3.1"
+version = "0.1.0-alpha3.2"
 dependencies = [
  "base64",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.1.0-alpha3.1"
+version = "0.1.0-alpha3.2"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT"

--- a/packaging/PKGBUILD
+++ b/packaging/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: OldJobobo
 pkgbase=splinterm
 pkgname=('splinterm' 'splinterm-mcp')
-pkgver=0.1.0alpha3.1
+pkgver=0.1.0alpha3.2
 pkgrel=1
 arch=('x86_64')
 url='https://github.com/oldjobobo/splinterm'

--- a/packaging/aur-bin/PKGBUILD
+++ b/packaging/aur-bin/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: OldJobobo
 pkgbase=splinterm-bin
 pkgname=('splinterm-bin' 'splinterm-mcp-bin')
-pkgver=0.1.0alpha3.1
+pkgver=0.1.0alpha3.2
 pkgrel=1
 _commit=11742b60cb5b502cdadb60a582b9c3c838120d2b
 arch=('x86_64')
@@ -9,8 +9,8 @@ url='https://github.com/oldjobobo/splinterm'
 license=('MIT')
 options=('!strip' '!debug')
 source=(
-  "splinterm-$pkgver-$CARCH.pkg.tar.zst::https://github.com/OldJobobo/splinterm/releases/download/v0.1.0-alpha3.1/splinterm-$_commit-$CARCH.pkg.tar.zst"
-  "splinterm-mcp-$pkgver-$CARCH.pkg.tar.zst::https://github.com/OldJobobo/splinterm/releases/download/v0.1.0-alpha3.1/splinterm-mcp-$_commit-$CARCH.pkg.tar.zst"
+  "splinterm-$pkgver-$CARCH.pkg.tar.zst::https://github.com/OldJobobo/splinterm/releases/download/v0.1.0-alpha3.2/splinterm-$_commit-$CARCH.pkg.tar.zst"
+  "splinterm-mcp-$pkgver-$CARCH.pkg.tar.zst::https://github.com/OldJobobo/splinterm/releases/download/v0.1.0-alpha3.2/splinterm-mcp-$_commit-$CARCH.pkg.tar.zst"
 )
 noextract=(
   "splinterm-$pkgver-$CARCH.pkg.tar.zst"

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -1,8 +1,8 @@
 # Maintainer: OldJobobo
 pkgbase=splinterm
 pkgname=('splinterm' 'splinterm-mcp')
-pkgver=0.1.0alpha3.1
-_upstream_ver=0.1.0-alpha3.1
+pkgver=0.1.0alpha3.2
+_upstream_ver=0.1.0-alpha3.2
 pkgrel=1
 arch=('x86_64')
 url='https://github.com/oldjobobo/splinterm'

--- a/tools/foot-oracle/provenance.json
+++ b/tools/foot-oracle/provenance.json
@@ -59,7 +59,7 @@
   "rust": {
     "rustc": "1.91.0",
     "cargo": "1.91.0",
-    "cargo_lock_sha256": "2f96cd2829b2d04d39d654524baabd703eaa925c7d0c229824240cd1bea40801",
+    "cargo_lock_sha256": "d167dd541f6be8f34be192eafe372577037668e5bfde13b8301d1cd9177ec600",
     "dependencies": {
       "fontdb": "0.23.0",
       "freetype-rs": "0.38.0",
@@ -112,7 +112,7 @@
     },
     "foreground": "ebebeb",
     "background": "0e1216",
-    "cargo_lock_sha256": "2f96cd2829b2d04d39d654524baabd703eaa925c7d0c229824240cd1bea40801"
+    "cargo_lock_sha256": "d167dd541f6be8f34be192eafe372577037668e5bfde13b8301d1cd9177ec600"
   },
   "semantic_fixture_schema": "fixtures/terminal/v1/schema.md",
   "final_buffer_schema": "tools/foot-oracle/final-buffer-schema.md",


### PR DESCRIPTION
## Summary

- set the workspace version to `0.1.0-alpha3.2`
- align local, source AUR, and binary AUR recipe versions and release URLs
- refresh the pinned Foot provenance lockfile digest after the version-only lock update

## Validation

- full `cargo test --workspace -- --test-threads=1`
- `cargo clippy --workspace --all-targets -- -D warnings`
- release/package Python unit tests
- `python tools/foot-oracle/check-provenance.py --portable`
- `python tools/release/prepare-candidate.py check --repository OldJobobo/splinterm --commit c4bb90b8ff33e5dc4c833935f8088f92c1ae9d90 --version 0.1.0-alpha3.2`
- formatting, ShellCheck, and `git diff --check`

## Release boundary

This PR prepares source identity only. It does not tag, publish, or distribute. Candidate and promotion workflows remain separately gated.