### PR TITLE
Record Alpha3.2 publication

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Foot is Splinterm's behavioral foundation, not just visual inspiration. The term
 | Sixel, practical Kitty static images, and inline iTerm2 PNG | Documented supported subsets |
 | Arch/Omarchy package | Versioned GitHub release and AUR packages validated |
 | Public source and versioned builds | Available |
-| AUR packages | Prebuilt `splinterm-bin` and source-built `splinterm`, both `0.1.0alpha3.1-1` |
+| AUR packages | Prebuilt `splinterm-bin` and source-built `splinterm`, both `0.1.0alpha3.2-1` |
 | Stable support and broader compatibility | Not released |
 | Nix and broader distributions | Planned |
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,18 @@
 # TODO
 
-## Immediate hotfix
+## Alpha3.2 Backspace crash hotfix
+
+- [x] Keep held Backspace and other ordinary terminal input nonblocking when a
+  pane controller's bounded command queue is temporarily saturated.
+- [x] Bound pending terminal input globally, preserve pane identity and complete
+  input units, and retain input-before-focus/control ordering.
+- [x] Route file-drop input through the same bounded path and discard stale
+  pane-bound batches safely after pane or tab teardown.
+- [x] Add saturation, multi-pane, ordering, atomicity, retry, and teardown
+  regressions; pass full release CI and independent review.
+- [x] Publish `v0.1.0-alpha3.2` and both `0.1.0alpha3.2-1` AUR package bases.
+
+## Alpha3.1 transient-window hotfix
 
 - [x] Hide the tab strip by default when XDG invokes Splinterm with a
   command-bearing `-e` launch; these transient command windows should not present

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -157,7 +157,7 @@ The following table summarizes the current repository state. “Validated” mea
 | MCP adapter | Implemented and validated as an optional separately identified package. |
 | Arch/Omarchy package and release installer | Immutable versioned GitHub/AUR packages and installation paths implemented and validated. |
 | Public source and documentation | Available. |
-| AUR packages | Prebuilt `splinterm-bin` and source-built `splinterm` available as `0.1.0alpha3-1`; stable support remains unreleased. |
+| AUR packages | Prebuilt `splinterm-bin` and source-built `splinterm` available as `0.1.0alpha3.2-1`; stable support remains unreleased. |
 | Stable support policy | Not released. |
 | Nix and broader distribution | Planned. |
 | Public product/documentation website | Implemented and build/link validated; repository `docs/status.md` remains the maturity authority. |

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -3,11 +3,11 @@
 Release authority, candidate construction, approval boundaries, and the future
 n8n notification role are defined in [Release automation](release-automation.md).
 
-Splinterm's `packaging/PKGBUILD` produces the `0.1.0alpha3` split packages for
+Splinterm's `packaging/PKGBUILD` produces the `0.1.0alpha3.2` split packages for
 reviewed local and CI builds. Its local source archive and `SKIP` checksum are
 valid only in that workflow. The current public versioned release is
-[`v0.1.0-alpha3`](https://github.com/OldJobobo/splinterm/releases/tag/v0.1.0-alpha3),
-and both AUR package bases publish `0.1.0alpha3-1`.
+[`v0.1.0-alpha3.2`](https://github.com/OldJobobo/splinterm/releases/tag/v0.1.0-alpha3.2),
+and both AUR package bases publish `0.1.0alpha3.2-1`.
 
 The source-built AUR authority is `packaging/aur/PKGBUILD`; candidate
 construction replaces its source-archive checksum with the exact immutable
@@ -120,8 +120,8 @@ creates the main package plus the explicitly optional `splinterm-mcp` split
 package without installing either. Inspect them with:
 
 ```bash
-pacman -Qlp packaging/splinterm-0.1.0alpha3-1-x86_64.pkg.tar.zst
-pacman -Qlp packaging/splinterm-mcp-0.1.0alpha3-1-x86_64.pkg.tar.zst
+pacman -Qlp packaging/splinterm-0.1.0alpha3.2-1-x86_64.pkg.tar.zst
+pacman -Qlp packaging/splinterm-mcp-0.1.0alpha3.2-1-x86_64.pkg.tar.zst
 namcap packaging/PKGBUILD packaging/*.pkg.tar.zst   # optional
 ```
 
@@ -233,7 +233,7 @@ The equivalent manual lifecycle is:
 
 ```bash
 systemctl --user stop splinterd.service
-sudo pacman -U packaging/splinterm-0.1.0alpha3-1-x86_64.pkg.tar.zst
+sudo pacman -U packaging/splinterm-0.1.0alpha3.2-1-x86_64.pkg.tar.zst
 systemctl --user daemon-reload
 systemctl --user start splinterd.service
 ```
@@ -241,7 +241,7 @@ systemctl --user start splinterd.service
 Install the adapter only when an MCP host will be configured:
 
 ```bash
-sudo pacman -U packaging/splinterm-mcp-0.1.0alpha3-1-x86_64.pkg.tar.zst
+sudo pacman -U packaging/splinterm-mcp-0.1.0alpha3.2-1-x86_64.pkg.tar.zst
 ```
 
 The guarded upgrade script upgrades `splinterm-mcp` only when that optional

--- a/docs/status.md
+++ b/docs/status.md
@@ -31,16 +31,48 @@ The current product target is:
 - native Wayland under the documented Hyprland environment;
 - Foot 1.27.0 commit `3c5b584b0eafa772eb4376fb6eaf6643399e190e`
   as the terminal-behavior oracle;
-- public Alpha3.1 `0.1.0alpha3.1-1` Arch packages built from clean committed
+- public Alpha3.2 `0.1.0alpha3.2-1` Arch packages built from clean committed
   source; and
 - guarded installed-package evidence for the Alpha3 command, scrollback,
-  saved-Lair, Wayland file-drop, and Omarchy screensaver workflows, plus isolated
-  exact-package acceptance for the Alpha3.1 transient-tab hotfixes.
+  saved-Lair, Wayland file-drop, and Omarchy screensaver workflows, isolated
+  exact-package acceptance for the Alpha3.1 transient-tab hotfixes, and
+  non-graphical release/package validation for the Alpha3.2 input-queue fix.
 
 Other Linux distributions, compositors, architectures, and package formats are
 not current compatibility promises. Headless `splinterd` does not require a
 graphical environment, but its packaged and remote workflows remain alpha
 interfaces on the documented platform.
+
+## Alpha3.2 release
+
+[`v0.1.0-alpha3.2`](https://github.com/OldJobobo/splinterm/releases/tag/v0.1.0-alpha3.2)
+was published as a GitHub prerelease on 2026-08-14 and distributed through both
+AUR package bases as `0.1.0alpha3.2-1`. It prevents held Backspace and other
+ordinary terminal input from terminating the Wayland client when a pane's
+bounded command queue is temporarily saturated. Pending input remains globally
+bounded, pane-bound, ordered before focus/control changes, atomic at input-event
+boundaries, and safe across pane teardown; file-drop input uses the same path.
+
+- Candidate workflow run `31849090413` built commit
+  `647b0eaa83314d588ce7b5bf97e65578e6d0f96f` once. Candidate manifest SHA-256:
+  `40dee74487229451e65fb5c871d8f163dfdaf867f839fe5f04e76dcad7a0ec5f`.
+- Protected promotion workflow run `31849556572` created the immutable tag,
+  published and downloaded the exact five-asset set, verified every hash, and
+  retained publication receipt artifact `9237255756`.
+- Source archive SHA-256:
+  `7684923026cefe8373a13468988286b4b83e214ab4bb04c06d75a44046e0d868`.
+  Main package SHA-256:
+  `868729721fc901d7b6c507974f0817c3f9e21901f393dad9e6e695f0a41bd6c4`.
+  MCP package SHA-256:
+  `2532a8171934a11ea1f6ac78b7021e4e9857fb68cc9ecb8932729c4f881dea1f`.
+- AUR source package commit: `908d85a14f9a80abd57fbe1b662bf91dc6841e66`.
+  AUR prebuilt package commit: `2b0c55c9a8d63526072e4e083c3a7105aed73c5b`.
+  Both public recipes passed `makepkg --verifysource` against the immutable
+  GitHub assets before publication.
+- Full serialized workspace tests, Clippy with warnings denied, release/package
+  automation tests, portable Foot provenance, focused queue regressions, and
+  independent read-only review passed. No graphical held-Backspace acceptance
+  was run for this hotfix.
 
 ## Alpha3.1 release
 
@@ -117,7 +149,7 @@ post-alpha3, pre-1.0 roadmap milestone.
 | MCP adapter | Implemented and validated | Optional, separately packaged, exact-identity adapter over the supported automation surface. See [MCP](mcp.md). |
 | Terminal images | Supported documented subset | Sixel, practical static Kitty, and inline iTerm2 PNG subsets are bounded; full Kitty graphics is not claimed. See [Images](images.md). |
 | Arch/Omarchy packaging | Public alpha packages validated | Immutable versioned GitHub and AUR split packages, service, desktop metadata, upgrade checks, trusted-client identity, and rollback guidance. See [Packaging](packaging.md). |
-| AUR packages | Available | Recommended prebuilt [`splinterm-bin` `0.1.0alpha3.1-1`](https://aur.archlinux.org/packages/splinterm-bin) publishes `splinterm-bin` and optional `splinterm-mcp-bin` from checksummed immutable versioned-release assets without local compilation. Source-built [`splinterm` `0.1.0alpha3.1-1`](https://aur.archlinux.org/packages/splinterm) and `splinterm-mcp` remain available. |
+| AUR packages | Available | Recommended prebuilt [`splinterm-bin` `0.1.0alpha3.2-1`](https://aur.archlinux.org/packages/splinterm-bin) publishes `splinterm-bin` and optional `splinterm-mcp-bin` from checksummed immutable versioned-release assets without local compilation. Source-built [`splinterm` `0.1.0alpha3.2-1`](https://aur.archlinux.org/packages/splinterm) and `splinterm-mcp` remain available. |
 | Public source and versioned releases | Available | The repository, documentation, protected GitHub prereleases, and AUR packages are public. The retired rolling edge channel is no longer produced or consumed. |
 | Stable support | Unreleased | No compatibility window, support duration, or formal support/security-reporting process is promised yet. |
 | Nix and broader distribution | Planned | Not current product behavior or support. |

--- a/site/src/content/docs/docs/status.md
+++ b/site/src/content/docs/docs/status.md
@@ -5,7 +5,7 @@ description: What is implemented, validated, limited, planned, and unreleased in
 
 Splinterm is a **public alpha**. Source, documentation, and immutable versioned GitHub and AUR packages are public. Substantial core behavior is implemented and validated, while the validated target remains narrow and stable compatibility guarantees have not been released.
 
-[`v0.1.0-alpha3`](https://github.com/OldJobobo/splinterm/releases/tag/v0.1.0-alpha3) is the current public prerelease. It adds the closed command/keymap surface, safe historical-Enter behavior, explicit saved-Lair restore workflows, bounded Wayland file drops, and the opt-in Omarchy screensaver integration.
+[`v0.1.0-alpha3.2`](https://github.com/OldJobobo/splinterm/releases/tag/v0.1.0-alpha3.2) is the current public prerelease. It retains the Alpha3 command/keymap, scrollback, saved-Lair, Wayland file-drop, and Omarchy integration scope while preventing held Backspace and other ordinary input from terminating the Wayland client when a bounded pane command queue is temporarily saturated.
 
 ## What that means
 
@@ -35,7 +35,7 @@ Splinterm is a **public alpha**. Source, documentation, and immutable versioned 
 | Sixel, practical Kitty static images, inline iTerm2 PNG | Documented supported subsets |
 | Arch/Omarchy package | Versioned GitHub release and AUR packages validated |
 | Public source and versioned builds | Available |
-| [AUR packages](https://aur.archlinux.org/packages/splinterm-bin) | Recommended prebuilt `splinterm-bin`; source-built `splinterm` also available, both `0.1.0alpha3-1` |
+| [AUR packages](https://aur.archlinux.org/packages/splinterm-bin) | Recommended prebuilt `splinterm-bin`; source-built `splinterm` also available, both `0.1.0alpha3.2-1` |
 | Stable support and broader compatibility | Not released |
 | Nix and broader distributions | Planned |
 


### PR DESCRIPTION
## Summary

- record the immutable Alpha3.2 GitHub release, candidate and promotion runs, manifest and package hashes, and receipt artifact
- record exact AUR source and prebuilt commits
- update README and current-status package versions
- close the Alpha3.2 Backspace crash hotfix checklist

## Verification

- GitHub tag `v0.1.0-alpha3.2` resolves to `647b0eaa83314d588ce7b5bf97e65578e6d0f96f`
- protected publication receipt artifact `9237255756` matches the public five-asset set
- AUR cgit exposes `0.1.0alpha3.2-1` for both package bases
- both AUR recipes passed `makepkg --verifysource` before push
- `git diff --check`

No code, package payload, tag, or release asset changes are made by this PR.