### PR TITLE
Prepare Alpha3.3 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1142,7 +1142,7 @@ dependencies = [
 
 [[package]]
 name = "splinterd"
-version = "0.1.0-alpha3.2"
+version = "0.1.0-alpha3.3"
 dependencies = [
  "anyhow",
  "nix",
@@ -1165,7 +1165,7 @@ dependencies = [
 
 [[package]]
 name = "splinterm"
-version = "0.1.0-alpha3.2"
+version = "0.1.0-alpha3.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -1195,7 +1195,7 @@ dependencies = [
 
 [[package]]
 name = "splinterm-automation-client"
-version = "0.1.0-alpha3.2"
+version = "0.1.0-alpha3.3"
 dependencies = [
  "anyhow",
  "rustix",
@@ -1211,7 +1211,7 @@ dependencies = [
 
 [[package]]
 name = "splinterm-core"
-version = "0.1.0-alpha3.2"
+version = "0.1.0-alpha3.3"
 dependencies = [
  "serde",
  "serde_json",
@@ -1221,7 +1221,7 @@ dependencies = [
 
 [[package]]
 name = "splinterm-filemap"
-version = "0.1.0-alpha3.2"
+version = "0.1.0-alpha3.3"
 dependencies = [
  "memmap2",
  "rustix",
@@ -1229,7 +1229,7 @@ dependencies = [
 
 [[package]]
 name = "splinterm-freetype"
-version = "0.1.0-alpha3.2"
+version = "0.1.0-alpha3.3"
 dependencies = [
  "freetype-rs",
  "splinterm-pixman",
@@ -1238,7 +1238,7 @@ dependencies = [
 
 [[package]]
 name = "splinterm-graphical-relay"
-version = "0.1.0-alpha3.2"
+version = "0.1.0-alpha3.3"
 dependencies = [
  "anyhow",
  "tokio",
@@ -1247,7 +1247,7 @@ dependencies = [
 
 [[package]]
 name = "splinterm-mcp"
-version = "0.1.0-alpha3.2"
+version = "0.1.0-alpha3.3"
 dependencies = [
  "anyhow",
  "rmcp",
@@ -1262,7 +1262,7 @@ dependencies = [
 
 [[package]]
 name = "splinterm-pixman"
-version = "0.1.0-alpha3.2"
+version = "0.1.0-alpha3.3"
 dependencies = [
  "libc",
  "pixman-sys",
@@ -1271,7 +1271,7 @@ dependencies = [
 
 [[package]]
 name = "splinterm-protocol"
-version = "0.1.0-alpha3.2"
+version = "0.1.0-alpha3.3"
 dependencies = [
  "rustix",
  "serde",
@@ -1283,7 +1283,7 @@ dependencies = [
 
 [[package]]
 name = "splinterm-pty"
-version = "0.1.0-alpha3.2"
+version = "0.1.0-alpha3.3"
 dependencies = [
  "rustix",
  "thiserror",
@@ -1292,7 +1292,7 @@ dependencies = [
 
 [[package]]
 name = "splinterm-relay"
-version = "0.1.0-alpha3.2"
+version = "0.1.0-alpha3.3"
 dependencies = [
  "anyhow",
  "nix",
@@ -1304,7 +1304,7 @@ dependencies = [
 
 [[package]]
 name = "splinterm-terminal"
-version = "0.1.0-alpha3.2"
+version = "0.1.0-alpha3.3"
 dependencies = [
  "base64",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.1.0-alpha3.2"
+version = "0.1.0-alpha3.3"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT"

--- a/packaging/PKGBUILD
+++ b/packaging/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: OldJobobo
 pkgbase=splinterm
 pkgname=('splinterm' 'splinterm-mcp')
-pkgver=0.1.0alpha3.2
+pkgver=0.1.0alpha3.3
 pkgrel=1
 arch=('x86_64')
 url='https://github.com/oldjobobo/splinterm'

--- a/packaging/aur-bin/PKGBUILD
+++ b/packaging/aur-bin/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: OldJobobo
 pkgbase=splinterm-bin
 pkgname=('splinterm-bin' 'splinterm-mcp-bin')
-pkgver=0.1.0alpha3.2
+pkgver=0.1.0alpha3.3
 pkgrel=1
 _commit=11742b60cb5b502cdadb60a582b9c3c838120d2b
 arch=('x86_64')
@@ -9,8 +9,8 @@ url='https://github.com/oldjobobo/splinterm'
 license=('MIT')
 options=('!strip' '!debug')
 source=(
-  "splinterm-$pkgver-$CARCH.pkg.tar.zst::https://github.com/OldJobobo/splinterm/releases/download/v0.1.0-alpha3.2/splinterm-$_commit-$CARCH.pkg.tar.zst"
-  "splinterm-mcp-$pkgver-$CARCH.pkg.tar.zst::https://github.com/OldJobobo/splinterm/releases/download/v0.1.0-alpha3.2/splinterm-mcp-$_commit-$CARCH.pkg.tar.zst"
+  "splinterm-$pkgver-$CARCH.pkg.tar.zst::https://github.com/OldJobobo/splinterm/releases/download/v0.1.0-alpha3.3/splinterm-$_commit-$CARCH.pkg.tar.zst"
+  "splinterm-mcp-$pkgver-$CARCH.pkg.tar.zst::https://github.com/OldJobobo/splinterm/releases/download/v0.1.0-alpha3.3/splinterm-mcp-$_commit-$CARCH.pkg.tar.zst"
 )
 noextract=(
   "splinterm-$pkgver-$CARCH.pkg.tar.zst"

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -1,8 +1,8 @@
 # Maintainer: OldJobobo
 pkgbase=splinterm
 pkgname=('splinterm' 'splinterm-mcp')
-pkgver=0.1.0alpha3.2
-_upstream_ver=0.1.0-alpha3.2
+pkgver=0.1.0alpha3.3
+_upstream_ver=0.1.0-alpha3.3
 pkgrel=1
 arch=('x86_64')
 url='https://github.com/oldjobobo/splinterm'

--- a/tools/foot-oracle/provenance.json
+++ b/tools/foot-oracle/provenance.json
@@ -59,7 +59,7 @@
   "rust": {
     "rustc": "1.91.0",
     "cargo": "1.91.0",
-    "cargo_lock_sha256": "d167dd541f6be8f34be192eafe372577037668e5bfde13b8301d1cd9177ec600",
+    "cargo_lock_sha256": "4763f93756ff7665bec5241375de5838c245b8602bb6b2f902f3d9fb3d4878f6",
     "dependencies": {
       "fontdb": "0.23.0",
       "freetype-rs": "0.38.0",
@@ -112,7 +112,7 @@
     },
     "foreground": "ebebeb",
     "background": "0e1216",
-    "cargo_lock_sha256": "d167dd541f6be8f34be192eafe372577037668e5bfde13b8301d1cd9177ec600"
+    "cargo_lock_sha256": "4763f93756ff7665bec5241375de5838c245b8602bb6b2f902f3d9fb3d4878f6"
   },
   "semantic_fixture_schema": "fixtures/terminal/v1/schema.md",
   "final_buffer_schema": "tools/foot-oracle/final-buffer-schema.md",


### PR DESCRIPTION
## Summary

Prepare the reviewed Plan 0040 implementation for the `0.1.0-alpha3.3` release boundary.

- align the workspace and all 13 lockfile package entries at `0.1.0-alpha3.3`
- align local, source-built AUR, and prebuilt AUR recipe versions and release URLs
- refresh both version-derived Cargo.lock provenance digests
- leave candidate commit fields, package checksums, and the pinned Foot authority unchanged

## Validation

- `cargo test --workspace -- --test-threads=1`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all --check`
- `git diff --check`
- release/package automation unittest suite: 34 passed, one host-dependent test skipped
- `python tools/foot-oracle/check-provenance.py --portable`
- `desktop-file-validate dist/applications/com.oldjobobo.splinterm.desktop`
- `appstreamcli validate --no-net dist/metainfo/com.oldjobobo.splinterm.metainfo.xml`
- `(cd packaging && makepkg --printsrcinfo -p PKGBUILD >/dev/null)`
- `(cd site && npm ci && npm run validate)`

Fresh read-only release review found no blocker or worthwhile fix and marked the six-file candidate-preparation diff ready.

## Publication boundary

This PR does not tag, publish, install, or update AUR. After merge, the non-publishing candidate workflow must build the exact reviewed `main` commit. Promotion remains separately bound to its run ID, manifest SHA-256, and protected release-environment approval.
