### PR TITLE
Record Alpha3.3 publication

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Foot is Splinterm's behavioral foundation, not just visual inspiration. The term
 | Sixel, practical Kitty static images, and inline iTerm2 PNG | Documented supported subsets |
 | Arch/Omarchy package | Versioned GitHub release and AUR packages validated |
 | Public source and versioned builds | Available |
-| AUR packages | Prebuilt `splinterm-bin` and source-built `splinterm`, both `0.1.0alpha3.2-1` |
+| AUR packages | Prebuilt `splinterm-bin` and source-built `splinterm`, both `0.1.0alpha3.3-1` |
 | Stable support and broader compatibility | Not released |
 | Nix and broader distributions | Planned |
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,18 @@
 # TODO
 
+## Alpha3.3 numbered default Dojo names
+
+- [x] Complete [Plan 0040](docs/plans/0040-numbered-default-dojo-names.md).
+- [x] Start new Lairs at `Dojo 1` and advance implicit per-Lair names from the
+  highest exact canonical `Dojo N` without reusing gaps.
+- [x] Preserve explicit and persisted names, retain collision-resistant generated
+  Lair names, and fail closed at numbering exhaustion.
+- [x] Cover graphical, human CLI, remote-interactive, and machine creation with
+  exact topology-revision retention and stable machine error classification.
+- [x] Pass full release CI, isolated graphical smoke, independent implementation
+  and candidate review, immutable GitHub promotion, and AUR source verification.
+- [x] Publish `v0.1.0-alpha3.3` and both `0.1.0alpha3.3-1` AUR package bases.
+
 ## Alpha3.2 Backspace crash hotfix
 
 - [x] Keep held Backspace and other ordinary terminal input nonblocking when a

--- a/TODO.md
+++ b/TODO.md
@@ -10,7 +10,7 @@
 - [x] Cover graphical, human CLI, remote-interactive, and machine creation with
   exact topology-revision retention and stable machine error classification.
 - [x] Pass full release CI, isolated graphical smoke, independent implementation
-  and candidate review, immutable GitHub promotion, and AUR source verification.
+  and candidate review, protected GitHub promotion, and AUR source verification.
 - [x] Publish `v0.1.0-alpha3.3` and both `0.1.0alpha3.3-1` AUR package bases.
 
 ## Alpha3.2 Backspace crash hotfix

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -157,7 +157,7 @@ The following table summarizes the current repository state. “Validated” mea
 | MCP adapter | Implemented and validated as an optional separately identified package. |
 | Arch/Omarchy package and release installer | Immutable versioned GitHub/AUR packages and installation paths implemented and validated. |
 | Public source and documentation | Available. |
-| AUR packages | Prebuilt `splinterm-bin` and source-built `splinterm` available as `0.1.0alpha3.2-1`; stable support remains unreleased. |
+| AUR packages | Prebuilt `splinterm-bin` and source-built `splinterm` available as `0.1.0alpha3.3-1`; stable support remains unreleased. |
 | Stable support policy | Not released. |
 | Nix and broader distribution | Planned. |
 | Public product/documentation website | Implemented and build/link validated; repository `docs/status.md` remains the maturity authority. |

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -3,11 +3,11 @@
 Release authority, candidate construction, approval boundaries, and the future
 n8n notification role are defined in [Release automation](release-automation.md).
 
-Splinterm's `packaging/PKGBUILD` produces the `0.1.0alpha3.2` split packages for
+Splinterm's `packaging/PKGBUILD` produces the `0.1.0alpha3.3` split packages for
 reviewed local and CI builds. Its local source archive and `SKIP` checksum are
 valid only in that workflow. The current public versioned release is
-[`v0.1.0-alpha3.2`](https://github.com/OldJobobo/splinterm/releases/tag/v0.1.0-alpha3.2),
-and both AUR package bases publish `0.1.0alpha3.2-1`.
+[`v0.1.0-alpha3.3`](https://github.com/OldJobobo/splinterm/releases/tag/v0.1.0-alpha3.3),
+and both AUR package bases publish `0.1.0alpha3.3-1`.
 
 The source-built AUR authority is `packaging/aur/PKGBUILD`; candidate
 construction replaces its source-archive checksum with the exact immutable
@@ -120,8 +120,8 @@ creates the main package plus the explicitly optional `splinterm-mcp` split
 package without installing either. Inspect them with:
 
 ```bash
-pacman -Qlp packaging/splinterm-0.1.0alpha3.2-1-x86_64.pkg.tar.zst
-pacman -Qlp packaging/splinterm-mcp-0.1.0alpha3.2-1-x86_64.pkg.tar.zst
+pacman -Qlp packaging/splinterm-0.1.0alpha3.3-1-x86_64.pkg.tar.zst
+pacman -Qlp packaging/splinterm-mcp-0.1.0alpha3.3-1-x86_64.pkg.tar.zst
 namcap packaging/PKGBUILD packaging/*.pkg.tar.zst   # optional
 ```
 
@@ -233,7 +233,7 @@ The equivalent manual lifecycle is:
 
 ```bash
 systemctl --user stop splinterd.service
-sudo pacman -U packaging/splinterm-0.1.0alpha3.2-1-x86_64.pkg.tar.zst
+sudo pacman -U packaging/splinterm-0.1.0alpha3.3-1-x86_64.pkg.tar.zst
 systemctl --user daemon-reload
 systemctl --user start splinterd.service
 ```
@@ -241,7 +241,7 @@ systemctl --user start splinterd.service
 Install the adapter only when an MCP host will be configured:
 
 ```bash
-sudo pacman -U packaging/splinterm-mcp-0.1.0alpha3.2-1-x86_64.pkg.tar.zst
+sudo pacman -U packaging/splinterm-mcp-0.1.0alpha3.3-1-x86_64.pkg.tar.zst
 ```
 
 The guarded upgrade script upgrades `splinterm-mcp` only when that optional

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -100,8 +100,8 @@ complete package test suite. This is the mode used by `./install.sh --source`;
 Its equivalent manual build from a clean checkout is:
 
 ```bash
-git archive --format=tar.gz --prefix=splinterm-0.1.0alpha3/ \
-  -o packaging/splinterm-0.1.0alpha3.tar.gz HEAD
+git archive --format=tar.gz --prefix=splinterm-0.1.0alpha3.3/ \
+  -o packaging/splinterm-0.1.0alpha3.3.tar.gz HEAD
 ```
 
 The archive honors `.gitattributes` `export-ignore` entries; website source and

--- a/docs/plans/0040-numbered-default-dojo-names.md
+++ b/docs/plans/0040-numbered-default-dojo-names.md
@@ -1,6 +1,6 @@
 # Plan 0040: Numbered default Dojo names
 
-- **Status:** Implementation complete and reviewed for `0.1.0-alpha3.3`; release integration pending
+- **Status:** Complete and published in `0.1.0-alpha3.3`; implementation, review, isolated graphical smoke, immutable promotion, and AUR distribution recorded
 - **Date:** 2026-08-14
 - **Product authority:** Implicitly named Dojos use short, predictable per-Lair labels; explicit and persisted names remain user-owned
 - **Depends on:** accepted Lair/Dojo topology, topology revisions, graphical Dojo tabs, and `new-dojo` CLI creation
@@ -113,3 +113,27 @@ work.
 - Fresh read-only review found no correctness blocker and requested stronger
   request-construction coverage. That coverage was added; bounded follow-up
   review confirmed the finding resolved and the patch ready.
+- GitHub review identified that local machine-mode exhaustion initially mapped
+  to `internal`; the release-boundary fix now emits stable `invalid_argument`,
+  returns exit status 5, and has focused regression coverage.
+
+## Release evidence (2026-08-14)
+
+- PR #10 squash-merged the reviewed implementation as commit
+  `d7368ff07f87a40979561dfa01b55be052e01ca3`; protected CI passed after one
+  unrelated MCP timing retry whose exact failed test passed in isolation.
+- An isolated development client/daemon pair on freeside workspace 2 started a
+  new Lair with `Dojo 1` without taking focus from the existing user Window.
+  This was not installed-package acceptance.
+- Candidate workflow run `31859941186` built release commit
+  `0c4276703eaa01b347fdbeb6327669b2b109e8b6` once. Candidate manifest SHA-256:
+  `da995d5f0fe7dcd3993ebdc289160d1ef9fd1fcf325a3c46c353a2967f29cce6`.
+- Fresh release-state and candidate-artifact reviews found no blocker and marked
+  the exact candidate ready for promotion.
+- Protected promotion workflow run `31860432730` created immutable tag
+  `v0.1.0-alpha3.3`, published and redownloaded the exact five assets, verified
+  every hash, and retained receipt artifact `9240460284`.
+- Public source package commit:
+  `8f373bf27f14831722c59fcd6e3f7f3ac2cd1907`. Public prebuilt package commit:
+  `b618d457bcc43a9a1993b596479c9d22c9cd1f25`. Both recipes passed
+  `makepkg --verifysource` against the immutable release assets before push.

--- a/docs/plans/0040-numbered-default-dojo-names.md
+++ b/docs/plans/0040-numbered-default-dojo-names.md
@@ -1,6 +1,6 @@
 # Plan 0040: Numbered default Dojo names
 
-- **Status:** Complete and published in `0.1.0-alpha3.3`; implementation, review, isolated graphical smoke, immutable promotion, and AUR distribution recorded
+- **Status:** Complete and published in `0.1.0-alpha3.3`; implementation, review, isolated graphical smoke, protected promotion, and AUR distribution recorded
 - **Date:** 2026-08-14
 - **Product authority:** Implicitly named Dojos use short, predictable per-Lair labels; explicit and persisted names remain user-owned
 - **Depends on:** accepted Lair/Dojo topology, topology revisions, graphical Dojo tabs, and `new-dojo` CLI creation
@@ -130,7 +130,7 @@ work.
   `da995d5f0fe7dcd3993ebdc289160d1ef9fd1fcf325a3c46c353a2967f29cce6`.
 - Fresh release-state and candidate-artifact reviews found no blocker and marked
   the exact candidate ready for promotion.
-- Protected promotion workflow run `31860432730` created immutable tag
+- Protected promotion workflow run `31860432730` created versioned tag
   `v0.1.0-alpha3.3`, published and redownloaded the exact five assets, verified
   every hash, and retained receipt artifact `9240460284`.
 - Public source package commit:

--- a/docs/status.md
+++ b/docs/status.md
@@ -58,7 +58,7 @@ exhaustion is reported as a stable machine `invalid_argument`.
 - Candidate workflow run `31859941186` built commit
   `0c4276703eaa01b347fdbeb6327669b2b109e8b6` once. Candidate manifest SHA-256:
   `da995d5f0fe7dcd3993ebdc289160d1ef9fd1fcf325a3c46c353a2967f29cce6`.
-- Protected promotion workflow run `31860432730` created the immutable tag,
+- Protected promotion workflow run `31860432730` created the versioned tag,
   published and downloaded the exact five-asset set, verified every hash, and
   retained publication receipt artifact `9240460284`.
 - Source archive SHA-256:

--- a/docs/status.md
+++ b/docs/status.md
@@ -31,17 +31,51 @@ The current product target is:
 - native Wayland under the documented Hyprland environment;
 - Foot 1.27.0 commit `3c5b584b0eafa772eb4376fb6eaf6643399e190e`
   as the terminal-behavior oracle;
-- public Alpha3.2 `0.1.0alpha3.2-1` Arch packages built from clean committed
+- public Alpha3.3 `0.1.0alpha3.3-1` Arch packages built from clean committed
   source; and
 - guarded installed-package evidence for the Alpha3 command, scrollback,
   saved-Lair, Wayland file-drop, and Omarchy screensaver workflows, isolated
-  exact-package acceptance for the Alpha3.1 transient-tab hotfixes, and
-  non-graphical release/package validation for the Alpha3.2 input-queue fix.
+  exact-package acceptance for the Alpha3.1 transient-tab hotfixes,
+  non-graphical release/package validation for Alpha3.2, and isolated
+  development-build graphical smoke plus release/package validation for the
+  Alpha3.3 numbered-name patch.
 
 Other Linux distributions, compositors, architectures, and package formats are
 not current compatibility promises. Headless `splinterd` does not require a
 graphical environment, but its packaged and remote workflows remain alpha
 interfaces on the documented platform.
+
+## Alpha3.3 release
+
+[`v0.1.0-alpha3.3`](https://github.com/OldJobobo/splinterm/releases/tag/v0.1.0-alpha3.3)
+was published as a GitHub prerelease on 2026-08-14 and distributed through both
+AUR package bases as `0.1.0alpha3.3-1`. New persistent and transient Lairs start
+with `Dojo 1`; later implicit Dojo names advance from the highest exact canonical
+`Dojo N` in that Lair without reusing gaps. Explicit and persisted names remain
+unchanged, generated Lair names remain collision-resistant, and bounded
+exhaustion is reported as a stable machine `invalid_argument`.
+
+- Candidate workflow run `31859941186` built commit
+  `0c4276703eaa01b347fdbeb6327669b2b109e8b6` once. Candidate manifest SHA-256:
+  `da995d5f0fe7dcd3993ebdc289160d1ef9fd1fcf325a3c46c353a2967f29cce6`.
+- Protected promotion workflow run `31860432730` created the immutable tag,
+  published and downloaded the exact five-asset set, verified every hash, and
+  retained publication receipt artifact `9240460284`.
+- Source archive SHA-256:
+  `cf6726439a2b8977610453edd3368700304727027753f88e39ed88302dea1093`.
+  Main package SHA-256:
+  `5104941b47776b1a06aea044c50a4179afcc9fa6c843a663d47ac728d99bc456`.
+  MCP package SHA-256:
+  `a5b8e5ac5c583df75275881e2527940d3a999c20cb33e2521a366840d2abc4c2`.
+- AUR source package commit: `8f373bf27f14831722c59fcd6e3f7f3ac2cd1907`.
+  AUR prebuilt package commit: `b618d457bcc43a9a1993b596479c9d22c9cd1f25`.
+  Both public recipes passed `makepkg --verifysource` against the immutable
+  GitHub assets before publication.
+- Full serialized workspace tests, Clippy with warnings denied, release/package
+  automation tests, portable Foot provenance, exact package-content checks, and
+  two fresh read-only release reviews passed. An isolated development build on
+  freeside confirmed `Dojo 1` without stealing focus; no installed Alpha3.3
+  graphical acceptance was run.
 
 ## Alpha3.2 release
 
@@ -149,7 +183,7 @@ post-alpha3, pre-1.0 roadmap milestone.
 | MCP adapter | Implemented and validated | Optional, separately packaged, exact-identity adapter over the supported automation surface. See [MCP](mcp.md). |
 | Terminal images | Supported documented subset | Sixel, practical static Kitty, and inline iTerm2 PNG subsets are bounded; full Kitty graphics is not claimed. See [Images](images.md). |
 | Arch/Omarchy packaging | Public alpha packages validated | Immutable versioned GitHub and AUR split packages, service, desktop metadata, upgrade checks, trusted-client identity, and rollback guidance. See [Packaging](packaging.md). |
-| AUR packages | Available | Recommended prebuilt [`splinterm-bin` `0.1.0alpha3.2-1`](https://aur.archlinux.org/packages/splinterm-bin) publishes `splinterm-bin` and optional `splinterm-mcp-bin` from checksummed immutable versioned-release assets without local compilation. Source-built [`splinterm` `0.1.0alpha3.2-1`](https://aur.archlinux.org/packages/splinterm) and `splinterm-mcp` remain available. |
+| AUR packages | Available | Recommended prebuilt [`splinterm-bin` `0.1.0alpha3.3-1`](https://aur.archlinux.org/packages/splinterm-bin) publishes `splinterm-bin` and optional `splinterm-mcp-bin` from checksummed immutable versioned-release assets without local compilation. Source-built [`splinterm` `0.1.0alpha3.3-1`](https://aur.archlinux.org/packages/splinterm) and `splinterm-mcp` remain available. |
 | Public source and versioned releases | Available | The repository, documentation, protected GitHub prereleases, and AUR packages are public. The retired rolling edge channel is no longer produced or consumed. |
 | Stable support | Unreleased | No compatibility window, support duration, or formal support/security-reporting process is promised yet. |
 | Nix and broader distribution | Planned | Not current product behavior or support. |

--- a/site/src/content/docs/docs/status.md
+++ b/site/src/content/docs/docs/status.md
@@ -5,7 +5,7 @@ description: What is implemented, validated, limited, planned, and unreleased in
 
 Splinterm is a **public alpha**. Source, documentation, and immutable versioned GitHub and AUR packages are public. Substantial core behavior is implemented and validated, while the validated target remains narrow and stable compatibility guarantees have not been released.
 
-[`v0.1.0-alpha3.3`](https://github.com/OldJobobo/splinterm/releases/tag/v0.1.0-alpha3.3) is the current public prerelease. It retains the Alpha3 command/keymap, scrollback, saved-Lair, Wayland file-drop, Omarchy integration, and bounded-input fixes while giving new and implicitly created Dojos predictable per-Lair names such as `Dojo 1` and `Dojo 2`.
+[`v0.1.0-alpha3.3`](https://github.com/OldJobobo/splinterm/releases/tag/v0.1.0-alpha3.3) is the current public prerelease. It retains the Alpha3 command/keymap, scrollback, saved-Lair, Wayland file-drop, Omarchy integration, and bounded-input fixes while starting new Lairs at `Dojo 1` and giving later implicitly created Dojos predictable per-Lair names such as `Dojo 2`. Explicit names remain unchanged.
 
 ## What that means
 

--- a/site/src/content/docs/docs/status.md
+++ b/site/src/content/docs/docs/status.md
@@ -5,7 +5,7 @@ description: What is implemented, validated, limited, planned, and unreleased in
 
 Splinterm is a **public alpha**. Source, documentation, and immutable versioned GitHub and AUR packages are public. Substantial core behavior is implemented and validated, while the validated target remains narrow and stable compatibility guarantees have not been released.
 
-[`v0.1.0-alpha3.2`](https://github.com/OldJobobo/splinterm/releases/tag/v0.1.0-alpha3.2) is the current public prerelease. It retains the Alpha3 command/keymap, scrollback, saved-Lair, Wayland file-drop, and Omarchy integration scope while preventing held Backspace and other ordinary input from terminating the Wayland client when a bounded pane command queue is temporarily saturated.
+[`v0.1.0-alpha3.3`](https://github.com/OldJobobo/splinterm/releases/tag/v0.1.0-alpha3.3) is the current public prerelease. It retains the Alpha3 command/keymap, scrollback, saved-Lair, Wayland file-drop, Omarchy integration, and bounded-input fixes while giving new and implicitly created Dojos predictable per-Lair names such as `Dojo 1` and `Dojo 2`.
 
 ## What that means
 
@@ -35,7 +35,7 @@ Splinterm is a **public alpha**. Source, documentation, and immutable versioned 
 | Sixel, practical Kitty static images, inline iTerm2 PNG | Documented supported subsets |
 | Arch/Omarchy package | Versioned GitHub release and AUR packages validated |
 | Public source and versioned builds | Available |
-| [AUR packages](https://aur.archlinux.org/packages/splinterm-bin) | Recommended prebuilt `splinterm-bin`; source-built `splinterm` also available, both `0.1.0alpha3.2-1` |
+| [AUR packages](https://aur.archlinux.org/packages/splinterm-bin) | Recommended prebuilt `splinterm-bin`; source-built `splinterm` also available, both `0.1.0alpha3.3-1` |
 | Stable support and broader compatibility | Not released |
 | Nix and broader distributions | Planned |
 


### PR DESCRIPTION
## Summary

Record completed `0.1.0-alpha3.3` GitHub and AUR publication and synchronize all current-facing package/status documentation.

- close Plan 0040 with implementation, review, smoke, promotion, and AUR evidence
- record exact candidate/promotion workflow IDs, manifest and package hashes, receipt artifact, and AUR commits
- update current release and package references to `v0.1.0-alpha3.3` / `0.1.0alpha3.3-1`
- distinguish isolated development-build graphical smoke from installed-package acceptance

## Public evidence

- GitHub release: https://github.com/OldJobobo/splinterm/releases/tag/v0.1.0-alpha3.3
- release commit/tag target: `0c4276703eaa01b347fdbeb6327669b2b109e8b6`
- candidate run: `31859941186`
- promotion run: `31860432730`
- source AUR commit: `8f373bf27f14831722c59fcd6e3f7f3ac2cd1907`
- prebuilt AUR commit: `b618d457bcc43a9a1993b596479c9d22c9cd1f25`

## Validation

- public release target, prerelease state, exact five-asset set, and downloaded hashes verified
- promotion receipt artifact `9240460284` downloaded and inspected
- AUR RPC reports both package bases at `0.1.0alpha3.3-1`
- both public recipes passed `makepkg --verifysource` before push
- `npm run validate` passed: 0 Astro diagnostics and 560 local links checked
- `git diff --check`

No product code, package recipe, installation, or release artifact changes are included.
