### PR TITLE
Backport 0.1 maintenance release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, "maint/0.1"]
   pull_request:
 
 permissions:

--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -36,10 +36,14 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Require promotion dispatch from main
+      - name: Require promotion dispatch from a release authority branch
         env:
           DISPATCH_REF: ${{ github.ref }}
-        run: test "$DISPATCH_REF" = refs/heads/main
+        run: |
+          case "$DISPATCH_REF" in
+            refs/heads/main|refs/heads/maint/0.1) ;;
+            *) printf 'promotion dispatch branch is not authorized: %s\n' "$DISPATCH_REF" >&2; exit 1 ;;
+          esac
 
       - name: Validate promotion automation
         run: |
@@ -62,7 +66,8 @@ jobs:
             --run candidate-run.json \
             --artifacts candidate-artifacts.json \
             --repository "$RELEASE_REPOSITORY" \
-            --run-id "$CANDIDATE_RUN_ID")
+            --run-id "$CANDIDATE_RUN_ID" \
+            --expected-branch "$GITHUB_REF_NAME")
           python - "$source_record" <<'PY'
           import json
           import os
@@ -130,7 +135,7 @@ jobs:
           retention-days: 3
 
   publish:
-    name: Publish approved immutable release
+    name: Publish approved versioned release
     needs: verify
     runs-on: ubuntu-latest
     environment: release
@@ -196,8 +201,10 @@ jobs:
               for item in page.get("branch_policies", [])
               if isinstance(item, dict)
           ]
-          if [item.get("name") for item in policies] != ["main"]:
-              raise SystemExit("release environment must permit exactly the main branch")
+          if sorted(item.get("name") for item in policies) != ["main", "maint/0.1"]:
+              raise SystemExit(
+                  "release environment must permit exactly main and maint/0.1"
+              )
           PY
 
       - name: Refuse existing tag or release and fail closed on API errors
@@ -224,7 +231,7 @@ jobs:
           require_absent "repos/$RELEASE_REPOSITORY/git/ref/tags/$RELEASE_TAG" tag
           require_absent "repos/$RELEASE_REPOSITORY/releases/tags/$RELEASE_TAG" release
 
-      - name: Create tag and immutable prerelease
+      - name: Create versioned tag and prerelease
         env:
           GH_TOKEN: ${{ secrets.SPLINTERM_RELEASE_TOKEN }}
           RELEASE_TAG: ${{ needs.verify.outputs.tag }}

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -31,6 +31,15 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Require candidate dispatch from a release authority branch
+        env:
+          DISPATCH_REF: ${{ github.ref }}
+        run: |
+          case "$DISPATCH_REF" in
+            refs/heads/main|refs/heads/maint/0.1) ;;
+            *) printf 'candidate dispatch branch is not authorized: %s\n' "$DISPATCH_REF" >&2; exit 1 ;;
+          esac
+
       - name: Install candidate build dependencies
         run: |
           pacman -Syu --noconfirm

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,9 @@ commits remain permitted.
 Before the first edit for an authorized task:
 
 * Fetch the current remote state.
-* Create a short-lived branch from the reviewed `origin/main` base.
+* Create a short-lived branch from the reviewed `origin/main` base for 0.2 and
+  general work, or from `origin/maint/0.1` for an explicitly authorized 0.1
+  maintenance patch.
 * Create or use a dedicated worktree for that branch.
 * Confirm the branch and worktree path before editing.
 
@@ -46,10 +48,13 @@ non-graphical boundary, actual-diff inspection, `git diff --check`, and required
 independent review before merge. Record exact validation and residual risks in
 the pull request.
 
-Prefer squash merge so `main` receives one coherent milestone commit. Delete the
-merged task branch and remove its worktree after verifying the merge. Releases,
-candidates, tags, and publication remain `main`-only and retain their separate
-approval requirements.
+Prefer squash merge so the owning integration branch receives one coherent
+milestone commit. Merge 0.2 and general work into `main`; merge 0.1 maintenance
+patches into `maint/0.1` and forward-port applicable fixes to `main` through a
+separate reviewed branch. Delete the merged task branch and remove its worktree
+after verifying the merge. Release candidates, promotions, tags, and publication
+may originate only from `main` or `maint/0.1`; the candidate and promotion must
+use the same authority branch and retain their separate approval requirements.
 
 ## 1. Cost and Delegation Stop-Loss
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,10 +24,14 @@ cd "$worktree"
 ```
 
 Use `plan/…`, `feat/…`, `fix/…`, `docs/…`, or `release/…` names with one coherent
-milestone per branch. One writer owns each branch/worktree; dependent or
-overlapping milestones remain serial. Read-only review may inspect the same
-worktree, while intentionally concurrent writers require separate worktrees and
-explicit approval under [`AGENTS.md`](AGENTS.md).
+milestone per branch. Base 0.2 and general work on `origin/main`; base an
+explicitly authorized 0.1 maintenance patch on `origin/maint/0.1`. Merge the
+maintenance patch back to `maint/0.1`, then forward-port any applicable fix to
+`main` through a separate reviewed branch rather than merging the long-lived
+branches together. One writer owns each branch/worktree; dependent or overlapping
+milestones remain serial. Read-only review may inspect the same worktree, while
+intentionally concurrent writers require separate worktrees and explicit
+approval under [`AGENTS.md`](AGENTS.md).
 
 Open a pull request only after focused validation, actual-diff inspection,
 `git diff --check`, and the independent review required by the owning plan.
@@ -48,7 +52,9 @@ git branch -D feat/0039-binding-help-search
 ```
 
 Do not publish releases from task branches. Release candidates and promotion
-remain bound to reviewed commits on `main`.
+remain bound to reviewed commits on `main` for the active 0.2 line or
+`maint/0.1` for the 0.1 maintenance line. Candidate construction and promotion
+must be dispatched from the same authority branch.
 
 ## Standard validation
 

--- a/docs/release-automation.md
+++ b/docs/release-automation.md
@@ -7,6 +7,7 @@ This document defines the authority boundaries and state transitions for Splinte
 | Concern | Authority |
 | --- | --- |
 | Product version | `[workspace.package].version` in `Cargo.toml` |
+| Release authority branches | `main` for the active 0.2 line; `maint/0.1` for 0.1 maintenance |
 | Local Arch package layout | `packaging/PKGBUILD` |
 | Source-built AUR recipe | `packaging/aur/PKGBUILD` and generated `.SRCINFO` |
 | Prebuilt AUR recipe | `packaging/aur-bin/PKGBUILD` and generated `.SRCINFO` |
@@ -19,10 +20,10 @@ n8n is not trusted with release authority. Its unavailability may delay a notifi
 
 ## State machine
 
-1. **Source** — an exact Git commit contains a consistent workspace version, package recipes, documentation, and tests.
+1. **Source** — an exact reviewed commit on `main` or `maint/0.1` contains a consistent workspace version, package recipes, documentation, and tests.
 2. **Candidate** — a manually dispatched, read-only workflow builds that commit once and emits a closed manifest, source archive, packages, checksums, release-notes draft, and AUR recipe drafts. Candidate artifacts are private GitHub workflow artifacts and are explicitly marked non-published.
 3. **Approved** — a maintainer starts `.github/workflows/promote-release.yml` with the exact candidate workflow run ID and manifest SHA-256, reviews the verified summary, and approves the protected GitHub `release` environment. Creating or selecting a candidate never implies approval.
-4. **Published** — the protected job creates the immutable tag and GitHub prerelease from the approved candidate artifacts without rebuilding them, downloads every published asset, verifies the tag target and exact asset set, and retains a publication receipt.
+4. **Published** — the protected job creates the versioned tag and GitHub prerelease from the approved candidate artifacts without rebuilding them, downloads every published asset, verifies the tag target and exact asset set, and retains a publication receipt.
 5. **Distributed** — separately gated automation updates AUR recipes to the exact published assets and verifies their visible state.
 6. **Recorded** — release URLs, hashes, workflow run, AUR versions, and resulting status-document changes are retained as release evidence.
 
@@ -32,7 +33,9 @@ A failure never advances the state. Retrying candidate construction creates a ne
 
 `.github/workflows/release-candidate.yml` is deliberately non-publishing:
 
-- manual `workflow_dispatch` only;
+- manual `workflow_dispatch` only from `main` or `maint/0.1`;
+- protected push CI runs the complete workspace boundary on both authority
+  branches before a merged commit can become a candidate;
 - repository permission limited to `contents: read`;
 - no GitHub Environment, release token, AUR credential, tag creation, push, or release API call;
 - full Git history is fetched so the exact commit and previous version tag can be recorded;
@@ -47,14 +50,14 @@ The candidate manifest binds the repository, commit, version, tag, architecture,
 
 ## Human approval boundary
 
-The publishing job uses `environment: release`. Configure at least one required reviewer and exactly one custom deployment-branch policy named `main` in the GitHub repository settings before running it. The protected job independently queries the Environment and fails closed unless both controls are present; merely referencing an automatically created unprotected Environment cannot publish. The read-only verification job has only `actions: read` and `contents: read`; it accepts a candidate run ID and candidate-manifest SHA-256, proves that the source was one successful manual candidate run from `main`, paginates the run artifact inventory, requires exactly one unexpired artifact, binds its workflow commit to the candidate manifest commit, and closes over the exact file set and hashes before the protected job becomes approvable. The write-authorized job executes release tooling only from the reviewed promotion-workflow dispatch commit, never from candidate-controlled source, and checkout credentials are not persisted.
+The publishing job uses `environment: release`. Configure at least one required reviewer and exactly two custom deployment-branch policies named `main` and `maint/0.1` in the GitHub repository settings before running it. The protected job independently queries the Environment and fails closed unless both controls are present; merely referencing an automatically created unprotected Environment cannot publish. The read-only verification job has only `actions: read` and `contents: read`; it accepts a candidate run ID and candidate-manifest SHA-256, proves that the source was one successful manual candidate run from the same authority branch as the promotion dispatch, paginates the run artifact inventory, requires exactly one unexpired artifact, binds its workflow commit to the candidate manifest commit, and closes over the exact file set and hashes before the protected job becomes approvable. The write-authorized job executes release tooling only from the reviewed promotion-workflow dispatch commit, never from candidate-controlled source, and checkout credentials are not persisted.
 
-Approval authorizes only the exact candidate identified by commit, version, manifest digest, and workflow run. After approval, publication refuses an existing tag or release and never clobbers, force-updates, or deletes remote state. If a later step fails after tag or release creation, the workflow stops and reports the partial immutable state for maintainer diagnosis. It does not retry by replacing that state.
+Approval authorizes only the exact candidate identified by authority branch, commit, version, manifest digest, and workflow run. After approval, publication refuses an existing tag or release and never clobbers, force-updates, or deletes remote state. If a later step fails after tag or release creation, the workflow stops and reports the partial published state for maintainer diagnosis. It does not retry by replacing that state.
 
 The protected `release` environment supplies `SPLINTERM_RELEASE_TOKEN`, a
 fine-grained token scoped only to this repository with Contents and Workflows
 read/write permission. The read-only verifier cannot access it. The protected
-publisher needs Workflows permission because the immutable tag may point to a
+publisher needs Workflows permission because the versioned tag may point to a
 candidate that changes files under `.github/workflows/`; GitHub rejects that
 ref creation when only the job's ordinary `GITHUB_TOKEN` is used.
 

--- a/tools/release/promote-release.py
+++ b/tools/release/promote-release.py
@@ -25,6 +25,7 @@ EXPECTED_KINDS = {
     "aur-bin-draft": 3,
     "release-notes-draft": 1,
 }
+RELEASE_BRANCHES = {"main", "maint/0.1"}
 
 
 def sha256(path: Path) -> str:
@@ -63,16 +64,19 @@ def validate_source_run(
     artifacts: Any,
     repository: str,
     run_id: int,
+    expected_branch: str,
 ) -> tuple[int, str]:
     if REPOSITORY.fullmatch(repository) is None:
         raise ValueError("repository must be an owner/name pair")
+    if expected_branch not in RELEASE_BRANCHES:
+        raise ValueError("candidate branch is not a release authority")
     expected_run = {
         "id": run_id,
         "event": "workflow_dispatch",
         "status": "completed",
         "conclusion": "success",
         "path": ".github/workflows/release-candidate.yml",
-        "head_branch": "main",
+        "head_branch": expected_branch,
     }
     for key, expected in expected_run.items():
         if run.get(key) != expected:
@@ -298,6 +302,9 @@ def parser() -> argparse.ArgumentParser:
     source.add_argument("--artifacts", type=Path, required=True)
     source.add_argument("--repository", required=True)
     source.add_argument("--run-id", type=int, required=True)
+    source.add_argument(
+        "--expected-branch", choices=sorted(RELEASE_BRANCHES), required=True
+    )
     verify = commands.add_parser("verify-candidate")
     verify.add_argument("--directory", type=Path, required=True)
     verify.add_argument("--repository", required=True)
@@ -328,6 +335,7 @@ def main() -> int:
                 load_json_value(arguments.artifacts, "candidate artifacts"),
                 arguments.repository,
                 arguments.run_id,
+                arguments.expected_branch,
             )
             print(json.dumps({"artifact_id": artifact_id, "commit": commit}))
         elif arguments.command == "verify-candidate":

--- a/tools/release/test_promote_release.py
+++ b/tools/release/test_promote_release.py
@@ -59,7 +59,7 @@ class CandidateFixture:
 
 
 class PromoteReleaseTests(unittest.TestCase):
-    def test_source_run_requires_successful_main_candidate_and_one_artifact(self) -> None:
+    def test_source_run_requires_matching_release_branch_and_one_artifact(self) -> None:
         run = {
             "id": RUN_ID,
             "event": "workflow_dispatch",
@@ -80,10 +80,14 @@ class PromoteReleaseTests(unittest.TestCase):
                 }
             ]
         }
-        self.assertEqual(
-            MODULE.validate_source_run(run, artifacts, REPOSITORY, RUN_ID),
-            (99, COMMIT),
-        )
+        for branch in sorted(MODULE.RELEASE_BRANCHES):
+            run["head_branch"] = branch
+            self.assertEqual(
+                MODULE.validate_source_run(
+                    run, artifacts, REPOSITORY, RUN_ID, branch
+                ),
+                (99, COMMIT),
+            )
         artifacts["artifacts"].append(
             {
                 "id": 100,
@@ -93,11 +97,19 @@ class PromoteReleaseTests(unittest.TestCase):
             }
         )
         with self.assertRaisesRegex(ValueError, "exactly one unexpired"):
-            MODULE.validate_source_run(run, artifacts, REPOSITORY, RUN_ID)
+            MODULE.validate_source_run(
+                run, artifacts, REPOSITORY, RUN_ID, "maint/0.1"
+            )
         artifacts["artifacts"].pop()
-        run["head_branch"] = "feature"
+        run["head_branch"] = "main"
         with self.assertRaisesRegex(ValueError, "head_branch"):
-            MODULE.validate_source_run(run, artifacts, REPOSITORY, RUN_ID)
+            MODULE.validate_source_run(
+                run, artifacts, REPOSITORY, RUN_ID, "maint/0.1"
+            )
+        with self.assertRaisesRegex(ValueError, "release authority"):
+            MODULE.validate_source_run(
+                run, artifacts, REPOSITORY, RUN_ID, "feature"
+            )
 
     def test_candidate_closes_over_exact_files_and_hashes(self) -> None:
         with tempfile.TemporaryDirectory(prefix="splinterm-promotion-") as value:

--- a/tools/release/test_promote_release_workflow.py
+++ b/tools/release/test_promote_release_workflow.py
@@ -14,7 +14,8 @@ class PromoteReleaseWorkflowTests(unittest.TestCase):
         self.assertNotIn("\n  push:", workflow)
         self.assertIn("candidate_run_id:", workflow)
         self.assertIn("candidate_manifest_sha256:", workflow)
-        self.assertIn("test \"$DISPATCH_REF\" = refs/heads/main", workflow)
+        self.assertIn("refs/heads/main|refs/heads/maint/0.1", workflow)
+        self.assertIn('--expected-branch "$GITHUB_REF_NAME"', workflow)
         self.assertIn("group: versioned-release-promotion", workflow)
         self.assertIn("cancel-in-progress: false", workflow)
 
@@ -58,12 +59,15 @@ class PromoteReleaseWorkflowTests(unittest.TestCase):
         workflow = WORKFLOW.read_text(encoding="utf-8")
         environment = workflow.index("name: Require configured protected release environment")
         existing = workflow.index("name: Refuse existing tag or release and fail closed on API errors")
-        create = workflow.index("name: Create tag and immutable prerelease")
+        create = workflow.index("name: Create versioned tag and prerelease")
         self.assertLess(environment, existing)
         self.assertLess(existing, create)
         self.assertIn('rule.get("type") == "required_reviewers"', workflow[environment:existing])
         self.assertIn('"custom_branch_policies": True', workflow[environment:existing])
-        self.assertIn('item.get("name") for item in policies] != ["main"]', workflow[environment:existing])
+        self.assertIn(
+            'sorted(item.get("name") for item in policies) != ["main", "maint/0.1"]',
+            workflow[environment:existing],
+        )
         self.assertIn("Refuse existing tag or release and fail closed on API errors", workflow)
         self.assertIn("HTTP/2.0 404", workflow)
         self.assertIn("HTTP/1.1 404", workflow)
@@ -74,7 +78,7 @@ class PromoteReleaseWorkflowTests(unittest.TestCase):
 
     def test_published_assets_are_downloaded_and_receipted(self) -> None:
         workflow = WORKFLOW.read_text(encoding="utf-8")
-        create = workflow.index("name: Create tag and immutable prerelease")
+        create = workflow.index("name: Create versioned tag and prerelease")
         upload = workflow.index("name: Upload exact approved assets without replacement")
         verify = workflow.index("name: Download and verify published release")
         receipt = workflow.index("name: Retain durable publication receipt")

--- a/tools/release/test_release_candidate_workflow.py
+++ b/tools/release/test_release_candidate_workflow.py
@@ -14,6 +14,7 @@ class ReleaseCandidateWorkflowTests(unittest.TestCase):
         self.assertNotIn("\n  push:", workflow)
         self.assertNotIn("\n  pull_request:", workflow)
         self.assertIn("permissions:\n  contents: read", workflow)
+        self.assertIn("refs/heads/main|refs/heads/maint/0.1", workflow)
         self.assertNotIn("contents: write", workflow)
         self.assertNotIn("environment:", workflow)
         self.assertNotIn("secrets.", workflow)
@@ -68,8 +69,9 @@ class ReleaseCandidateWorkflowTests(unittest.TestCase):
         self.assertIn("retention-days: 14", workflow)
         self.assertIn("fetch-depth: 0", workflow)
 
-    def test_candidate_tests_are_part_of_ci(self) -> None:
+    def test_candidate_tests_are_part_of_both_authority_branch_checks(self) -> None:
         ci = (ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")
+        self.assertIn('branches: [main, "maint/0.1"]', ci)
         self.assertIn("tools/release/test_prepare_candidate.py", ci)
         self.assertIn("tools/release/test_release_candidate_workflow.py", ci)
 


### PR DESCRIPTION
## Summary

Backport the exact reviewed `main` release-authority workflow from commit `8d781dfa5b52d30ac37a0afffcd433555f6a95a4` to protected `maint/0.1`.

This makes the candidate/promotion branch guards, same-branch binding, protected environment policy closure, CI push coverage, tests, and contributor/agent documentation present on both release authority branches before the environment policy is expanded.

## Validation

- patch ID exactly matches `8d781df`
- 25 release automation tests passed
- 9 package/installer integration tests passed
- changed Python compiled successfully
- CI, candidate, and promotion workflows parse as YAML
- `git diff --check`
- original read-only workflow review: READY; GitHub P1 CI finding fixed before merge

No product code, version, tag, package, release, or repository setting is changed by this PR.