### PR TITLE
Separate active-tab chrome from terminal selection

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -9,7 +9,7 @@
 - [x] Support explicit strict-JSON active-tab roles and deterministic
   higher-contrast endpoint fallbacks when they are absent.
 - [x] Pass focused non-graphical validation.
-- [ ] Pass the complete serialized boundary and fresh read-only review.
+- [x] Pass the complete serialized boundary and fresh read-only review.
 - [ ] Complete separately approved packaged graphical acceptance before release.
 
 Version integration, candidate construction, publication, and AUR distribution

--- a/TODO.md
+++ b/TODO.md
@@ -3,15 +3,13 @@
 ## Beta 1 active-tab foreground contrast patch
 
 - [ ] Complete [Plan 0041](docs/plans/0041-beta1-active-tab-foreground.md).
-- [x] Add optional `active_tab_foreground` roles to native Omarchy and strict
-  JSON theme resolution.
-- [x] Keep terminal `selection_foreground` independent from active Dojo-tab text.
-- [x] Fall back deterministically to the theme background or foreground with
-  higher contrast against the resolved active-tab background.
-- [x] Prove Dispatch resolves `#141d23` text on `#e6c93a` without changing its
-  terminal selection colors.
-- [x] Pass focused and serial non-graphical validation plus fresh read-only
-  review.
+- [x] Derive native active-tab bodies from standard Omarchy `lighter_bg`, then
+  effective Foot `bright0`, without app-specific theme roles.
+- [x] Keep terminal selection colors independent from active Dojo-tab chrome.
+- [x] Support explicit strict-JSON active-tab roles and deterministic
+  higher-contrast endpoint fallbacks when they are absent.
+- [x] Pass focused non-graphical validation.
+- [ ] Pass the complete serialized boundary and fresh read-only review.
 - [ ] Complete separately approved packaged graphical acceptance before release.
 
 Version integration, candidate construction, publication, and AUR distribution

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,22 @@
 # TODO
 
+## Beta 1 active-tab foreground contrast patch
+
+- [ ] Complete [Plan 0041](docs/plans/0041-beta1-active-tab-foreground.md).
+- [x] Add optional `active_tab_foreground` roles to native Omarchy and strict
+  JSON theme resolution.
+- [x] Keep terminal `selection_foreground` independent from active Dojo-tab text.
+- [x] Fall back deterministically to the theme background or foreground with
+  higher contrast against the resolved active-tab background.
+- [x] Prove Dispatch resolves `#141d23` text on `#e6c93a` without changing its
+  terminal selection colors.
+- [x] Pass focused and serial non-graphical validation plus fresh read-only
+  review.
+- [ ] Complete separately approved packaged graphical acceptance before release.
+
+Version integration, candidate construction, publication, and AUR distribution
+remain separate release-boundary work.
+
 ## Alpha3.2 Backspace crash hotfix
 
 - [x] Keep held Backspace and other ordinary terminal input nonblocking when a

--- a/config/splinterm/theme.json
+++ b/config/splinterm/theme.json
@@ -6,6 +6,7 @@
   "selection": "#354a60",
   "selection_foreground": "#ebebeb",
   "active_tab_background": "#354a60",
+  "active_tab_foreground": "#ebebeb",
   "url": "#78beff",
   "ui_accent": "#78d2ff",
   "pane_border": "#928374",

--- a/crates/splinterm/src/config.rs
+++ b/crates/splinterm/src/config.rs
@@ -569,8 +569,8 @@ impl Default for ResolvedTheme {
             cursor: 0xebebeb,
             selection: 0x354a60,
             selection_foreground: 0xebebeb,
-            active_tab_background: 0x354a60,
-            active_tab_foreground: 0xebebeb,
+            active_tab_background: 0x928374,
+            active_tab_foreground: 0x0e1216,
             url: 0x78beff,
             ui_accent: 0x78d2ff,
             pane_border: 0x7c7e80,
@@ -658,7 +658,7 @@ impl ThemePalette {
             .as_deref()
             .map(parse_color)
             .transpose()?
-            .unwrap_or(selection);
+            .unwrap_or(ansi[8]);
         let active_tab_foreground = self
             .active_tab_foreground
             .as_deref()
@@ -805,19 +805,13 @@ fn resolve_omarchy_theme(colors_raw: &str, foot_raw: &str) -> Result<ResolvedThe
         .context("active Omarchy foot.ini has invalid cursor")?
         .unwrap_or(foreground);
     let active_tab_background = colors
-        .get("active_tab_background")
+        .get("lighter_bg")
         .map(|value| parse_color(value))
         .transpose()
-        .context("active Omarchy colors.toml has invalid active_tab_background")?
-        .unwrap_or(selection);
-    let active_tab_foreground = colors
-        .get("active_tab_foreground")
-        .map(|value| parse_color(value))
-        .transpose()
-        .context("active Omarchy colors.toml has invalid active_tab_foreground")?
-        .unwrap_or_else(|| {
-            active_tab_foreground_fallback(background, foreground, active_tab_background)
-        });
+        .context("active Omarchy colors.toml has invalid lighter_bg")?
+        .unwrap_or(ansi[8]);
+    let active_tab_foreground =
+        active_tab_foreground_fallback(background, foreground, active_tab_background);
     let ui_accent = ["accent", "cursor", "color4", "blue"]
         .iter()
         .find_map(|key| colors.get(*key))
@@ -1276,7 +1270,7 @@ mod tests {
 
     #[test]
     fn native_omarchy_theme_uses_effective_foot_palette_and_semantic_accent() {
-        let colors = "accent = \"0x010203\" # inline comment\nactive_tab_background = \"#070809\"\nactive_tab_foreground = \"#0a0b0c\"\n";
+        let colors = "accent = \"0x010203\" # inline comment\nlighter_bg = \"#070809\"\n";
         let foot = "[colors]\nforeground=000003\nbackground=000001\nselection-foreground=000002\nselection-background=000004\ncursor=000001 000006\nalpha=0.75\nblur=yes\nregular0=000000\nregular1=000001\nregular2=000002\nregular3=000003\nregular4=000004\nregular5=000005\nregular6=000006\nregular7=000007\nbright0=000008\nbright1=000009\nbright2=00000a\nbright3=00000b\nbright4=00000c\nbright5=00000d\nbright6=00000e\nbright7=00000f\n";
         let theme = resolve_omarchy_theme(colors, foot).unwrap();
         assert_eq!(theme.background, 1);
@@ -1285,7 +1279,7 @@ mod tests {
         assert_eq!(theme.selection, 4);
         assert_eq!(theme.selection_foreground, 2);
         assert_eq!(theme.active_tab_background, 0x07_08_09);
-        assert_eq!(theme.active_tab_foreground, 0x0a_0b_0c);
+        assert_eq!(theme.active_tab_foreground, theme.background);
         assert_eq!(theme.url, 4);
         assert_eq!(theme.ui_accent, 0x01_02_03);
         assert_eq!(theme.pane_border, 8);
@@ -1313,7 +1307,7 @@ mod tests {
         let resolved = resolve_omarchy_theme("cursor=\"#000006\"", &foot).unwrap();
         assert_eq!(resolved.background, 2);
         assert_eq!(resolved.selection_foreground, resolved.foreground);
-        assert_eq!(resolved.active_tab_background, resolved.selection);
+        assert_eq!(resolved.active_tab_background, resolved.ansi[8]);
         assert!(
             resolve_omarchy_theme("accent=\"#000006\"", "[colors-dark]\nbackground=000001")
                 .unwrap_err()
@@ -1327,6 +1321,28 @@ mod tests {
                 .to_string()
                 .contains("no [colors-dark] or [colors] palette")
         );
+    }
+
+    #[test]
+    fn missing_active_tab_background_uses_the_normal_background_ramp() {
+        let foot = complete_foot_palette("101112", "d0d1d2", "f0e0d0", "c0b0a0");
+
+        let semantic = resolve_omarchy_theme("lighter_bg=\"#f8f9fa\"\n", &foot).unwrap();
+        assert_eq!(semantic.selection, 0xf0_e0_d0);
+        assert_eq!(semantic.active_tab_background, 0xf8_f9_fa);
+        assert_eq!(semantic.active_tab_foreground, semantic.background);
+
+        let ignored_extensions = resolve_omarchy_theme(
+            "lighter_bg=\"#f8f9fa\"\nactive_tab_background=\"#010203\"\nactive_tab_foreground=\"#ffffff\"\n",
+            &foot,
+        )
+        .unwrap();
+        assert_eq!(ignored_extensions, semantic);
+
+        let legacy = resolve_omarchy_theme("", &foot).unwrap();
+        assert_eq!(legacy.selection, 0xf0_e0_d0);
+        assert_eq!(legacy.active_tab_background, legacy.ansi[8]);
+        assert_ne!(legacy.active_tab_background, legacy.selection);
     }
 
     #[test]
@@ -1403,8 +1419,9 @@ mod tests {
         let resolved = theme.resolve().unwrap();
         assert_eq!(resolved.background, 1);
         assert_eq!(resolved.selection_foreground, 3);
-        assert_eq!(resolved.active_tab_background, resolved.selection);
+        assert_eq!(resolved.active_tab_background, resolved.ansi[8]);
         assert_eq!(resolved.active_tab_foreground, resolved.background);
+        assert_ne!(resolved.active_tab_background, resolved.selection);
         assert_eq!(resolved.ui_accent, 6);
         assert_eq!(resolved.pane_border, 2);
         assert_eq!(resolved.pane_border_active, 6);
@@ -1475,43 +1492,28 @@ mod tests {
             .unwrap()
             .resolve()
             .unwrap();
-        assert_eq!(resolved.active_tab_background, resolved.selection);
-        assert_eq!(resolved.active_tab_foreground, resolved.background);
+        assert_eq!(resolved.active_tab_background, resolved.ansi[8]);
+        assert_eq!(resolved.active_tab_foreground, resolved.foreground);
 
-        let dark_tab = json.replace("\"selection\":\"#ffffff\"", "\"selection\":\"#000000\"");
-        let resolved = serde_json::from_str::<ThemePalette>(&dark_tab)
+        let different_selection =
+            json.replace("\"selection\":\"#ffffff\"", "\"selection\":\"#000000\"");
+        let resolved = serde_json::from_str::<ThemePalette>(&different_selection)
             .unwrap()
             .resolve()
             .unwrap();
+        assert_eq!(resolved.active_tab_background, resolved.ansi[8]);
         assert_eq!(resolved.active_tab_foreground, resolved.foreground);
     }
 
     #[test]
-    fn native_active_tab_foreground_is_independent_and_invalid_values_fail_closed() {
+    fn native_active_tab_foreground_is_derived_from_standard_omarchy_roles() {
         let foot = complete_foot_palette("141d23", "f2e8d5", "e6c93a", "b69f80");
-        let dispatch = resolve_omarchy_theme(
-            "active_tab_background=\"#e6c93a\"\nactive_tab_foreground=\"#141d23\"\naccent=\"#00aaff\"\n",
-            &foot,
-        )
-        .unwrap();
+        let dispatch =
+            resolve_omarchy_theme("lighter_bg=\"#e6c93a\"\naccent=\"#00aaff\"\n", &foot).unwrap();
         assert_eq!(dispatch.active_tab_background, 0xe6_c9_3a);
         assert_eq!(dispatch.active_tab_foreground, 0x14_1d_23);
         assert!((contrast_ratio(0x14_1d_23, 0xe6_c9_3a) - 10.39).abs() < 0.01);
         assert_eq!(dispatch.selection_foreground, 0xb6_9f_80);
-
-        let fallback = resolve_omarchy_theme(
-            "active_tab_background=\"#e6c93a\"\naccent=\"#00aaff\"\n",
-            &foot,
-        )
-        .unwrap();
-        assert_eq!(fallback.active_tab_foreground, fallback.background);
-
-        assert!(
-            resolve_omarchy_theme("active_tab_foreground=\"invalid\"\n", &foot)
-                .unwrap_err()
-                .to_string()
-                .contains("invalid active_tab_foreground")
-        );
 
         let json = r##"{"background":"#000000","foreground":"#ffffff","cursor":"#ffffff","selection":"#ffffff","active_tab_foreground":"#141d23","url":"#0000ff","ui_accent":"#00ffff","ansi":["#000000","#000001","#000002","#000003","#000004","#000005","#000006","#000007","#000008","#000009","#00000a","#00000b","#00000c","#00000d","#00000e","#00000f"]}"##;
         for invalid in ["invalid", "141d23", "0x141d23"] {

--- a/crates/splinterm/src/config.rs
+++ b/crates/splinterm/src/config.rs
@@ -528,6 +528,8 @@ pub struct ThemePalette {
     pub selection_foreground: Option<String>,
     #[serde(default)]
     pub active_tab_background: Option<String>,
+    #[serde(default)]
+    pub active_tab_foreground: Option<String>,
     pub url: String,
     pub ui_accent: String,
     #[serde(default = "opaque_alpha")]
@@ -549,6 +551,7 @@ pub struct ResolvedTheme {
     pub selection: u32,
     pub selection_foreground: u32,
     pub active_tab_background: u32,
+    pub active_tab_foreground: u32,
     pub url: u32,
     pub ui_accent: u32,
     pub pane_border: u32,
@@ -567,6 +570,7 @@ impl Default for ResolvedTheme {
             selection: 0x354a60,
             selection_foreground: 0xebebeb,
             active_tab_background: 0x354a60,
+            active_tab_foreground: 0xebebeb,
             url: 0x78beff,
             ui_accent: 0x78d2ff,
             pane_border: 0x7c7e80,
@@ -583,6 +587,41 @@ impl Default for ResolvedTheme {
 
 const fn opaque_alpha() -> f32 {
     1.0
+}
+
+fn srgb_channel_luminance(channel: u8) -> f64 {
+    let channel = f64::from(channel) / 255.0;
+    if channel <= 0.04045 {
+        channel / 12.92
+    } else {
+        ((channel + 0.055) / 1.055).powf(2.4)
+    }
+}
+
+fn relative_luminance(color: u32) -> f64 {
+    let red = srgb_channel_luminance(((color >> 16) & 0xff) as u8);
+    let green = srgb_channel_luminance(((color >> 8) & 0xff) as u8);
+    let blue = srgb_channel_luminance((color & 0xff) as u8);
+    0.2126 * red + 0.7152 * green + 0.0722 * blue
+}
+
+fn contrast_ratio(first: u32, second: u32) -> f64 {
+    let first = relative_luminance(first);
+    let second = relative_luminance(second);
+    let (lighter, darker) = if first >= second {
+        (first, second)
+    } else {
+        (second, first)
+    };
+    (lighter + 0.05) / (darker + 0.05)
+}
+
+fn active_tab_foreground_fallback(background: u32, foreground: u32, active_tab: u32) -> u32 {
+    if contrast_ratio(background, active_tab) > contrast_ratio(foreground, active_tab) {
+        background
+    } else {
+        foreground
+    }
 }
 
 impl ResolvedTheme {
@@ -614,6 +653,20 @@ impl ThemePalette {
         let background = parse_color(&self.background)?;
         let foreground = parse_color(&self.foreground)?;
         let selection = parse_color(&self.selection)?;
+        let active_tab_background = self
+            .active_tab_background
+            .as_deref()
+            .map(parse_color)
+            .transpose()?
+            .unwrap_or(selection);
+        let active_tab_foreground = self
+            .active_tab_foreground
+            .as_deref()
+            .map(parse_json_color)
+            .transpose()?
+            .unwrap_or_else(|| {
+                active_tab_foreground_fallback(background, foreground, active_tab_background)
+            });
         let ui_accent = parse_color(&self.ui_accent)?;
         Ok(ResolvedTheme {
             background,
@@ -626,12 +679,8 @@ impl ThemePalette {
                 .map(parse_color)
                 .transpose()?
                 .unwrap_or(foreground),
-            active_tab_background: self
-                .active_tab_background
-                .as_deref()
-                .map(parse_color)
-                .transpose()?
-                .unwrap_or(selection),
+            active_tab_background,
+            active_tab_foreground,
             url: parse_color(&self.url)?,
             ui_accent,
             pane_border: self
@@ -761,6 +810,14 @@ fn resolve_omarchy_theme(colors_raw: &str, foot_raw: &str) -> Result<ResolvedThe
         .transpose()
         .context("active Omarchy colors.toml has invalid active_tab_background")?
         .unwrap_or(selection);
+    let active_tab_foreground = colors
+        .get("active_tab_foreground")
+        .map(|value| parse_color(value))
+        .transpose()
+        .context("active Omarchy colors.toml has invalid active_tab_foreground")?
+        .unwrap_or_else(|| {
+            active_tab_foreground_fallback(background, foreground, active_tab_background)
+        });
     let ui_accent = ["accent", "cursor", "color4", "blue"]
         .iter()
         .find_map(|key| colors.get(*key))
@@ -791,6 +848,7 @@ fn resolve_omarchy_theme(colors_raw: &str, foot_raw: &str) -> Result<ResolvedThe
         selection,
         selection_foreground,
         active_tab_background,
+        active_tab_foreground,
         url: ansi[4],
         ui_accent,
         pane_border: ansi[8],
@@ -923,6 +981,14 @@ fn foot_alpha(alpha: f32) -> u16 {
     (alpha * f32::from(u16::MAX)) as u16
 }
 
+fn parse_json_color(value: &str) -> Result<u32> {
+    if value.len() != 7 || !value.starts_with('#') {
+        bail!("JSON theme color {value:?} must be #RRGGBB");
+    }
+    u32::from_str_radix(&value[1..], 16)
+        .with_context(|| format!("invalid JSON theme color {value:?}"))
+}
+
 fn parse_color(value: &str) -> Result<u32> {
     let value = value.trim();
     let hex = value
@@ -950,6 +1016,17 @@ fn blend_rgb(first: u32, second: u32) -> u32 {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn complete_foot_palette(
+        background: &str,
+        foreground: &str,
+        selection_background: &str,
+        selection_foreground: &str,
+    ) -> String {
+        format!(
+            "[colors-dark]\nforeground={foreground}\nbackground={background}\nselection-background={selection_background}\nselection-foreground={selection_foreground}\nregular0=000000\nregular1=000001\nregular2=000002\nregular3=000003\nregular4=000004\nregular5=000005\nregular6=000006\nregular7=000007\nbright0=000008\nbright1=000009\nbright2=00000a\nbright3=00000b\nbright4=00000c\nbright5=00000d\nbright6=00000e\nbright7=00000f\n"
+        )
+    }
 
     #[test]
     fn defaults_match_foot_font_and_resize_behavior() {
@@ -1199,8 +1276,7 @@ mod tests {
 
     #[test]
     fn native_omarchy_theme_uses_effective_foot_palette_and_semantic_accent() {
-        let colors =
-            "accent = \"0x010203\" # inline comment\nactive_tab_background = \"#070809\"\n";
+        let colors = "accent = \"0x010203\" # inline comment\nactive_tab_background = \"#070809\"\nactive_tab_foreground = \"#0a0b0c\"\n";
         let foot = "[colors]\nforeground=000003\nbackground=000001\nselection-foreground=000002\nselection-background=000004\ncursor=000001 000006\nalpha=0.75\nblur=yes\nregular0=000000\nregular1=000001\nregular2=000002\nregular3=000003\nregular4=000004\nregular5=000005\nregular6=000006\nregular7=000007\nbright0=000008\nbright1=000009\nbright2=00000a\nbright3=00000b\nbright4=00000c\nbright5=00000d\nbright6=00000e\nbright7=00000f\n";
         let theme = resolve_omarchy_theme(colors, foot).unwrap();
         assert_eq!(theme.background, 1);
@@ -1209,6 +1285,7 @@ mod tests {
         assert_eq!(theme.selection, 4);
         assert_eq!(theme.selection_foreground, 2);
         assert_eq!(theme.active_tab_background, 0x07_08_09);
+        assert_eq!(theme.active_tab_foreground, 0x0a_0b_0c);
         assert_eq!(theme.url, 4);
         assert_eq!(theme.ui_accent, 0x01_02_03);
         assert_eq!(theme.pane_border, 8);
@@ -1327,6 +1404,7 @@ mod tests {
         assert_eq!(resolved.background, 1);
         assert_eq!(resolved.selection_foreground, 3);
         assert_eq!(resolved.active_tab_background, resolved.selection);
+        assert_eq!(resolved.active_tab_foreground, resolved.background);
         assert_eq!(resolved.ui_accent, 6);
         assert_eq!(resolved.pane_border, 2);
         assert_eq!(resolved.pane_border_active, 6);
@@ -1336,7 +1414,7 @@ mod tests {
 
         let explicit = json.replace(
             "\"ansi\"",
-            "\"selection_foreground\":\"#000002\",\"active_tab_background\":\"#000009\",\"pane_border\":\"#000007\",\"pane_border_active\":\"#000008\",\"ansi\"",
+            "\"selection_foreground\":\"#000002\",\"active_tab_background\":\"#000009\",\"active_tab_foreground\":\"#00000a\",\"pane_border\":\"#000007\",\"pane_border_active\":\"#000008\",\"ansi\"",
         );
         let resolved = serde_json::from_str::<ThemePalette>(&explicit)
             .unwrap()
@@ -1344,6 +1422,7 @@ mod tests {
             .unwrap();
         assert_eq!(resolved.selection_foreground, 2);
         assert_eq!(resolved.active_tab_background, 9);
+        assert_eq!(resolved.active_tab_foreground, 10);
         assert_eq!(resolved.pane_border, 7);
         assert_eq!(resolved.pane_border_active, 8);
 
@@ -1374,5 +1453,76 @@ mod tests {
             )
             .is_err()
         );
+    }
+
+    #[test]
+    fn active_tab_foreground_fallback_uses_the_higher_contrast_endpoint() {
+        assert_eq!(
+            active_tab_foreground_fallback(0x00_00_00, 0xff_ff_ff, 0xff_ff_ff),
+            0x00_00_00
+        );
+        assert_eq!(
+            active_tab_foreground_fallback(0x00_00_00, 0xff_ff_ff, 0x00_00_00),
+            0xff_ff_ff
+        );
+        assert_eq!(
+            active_tab_foreground_fallback(0x12_34_56, 0x12_34_56, 0x78_9a_bc),
+            0x12_34_56
+        );
+
+        let json = r##"{"background":"#000000","foreground":"#ffffff","cursor":"#ffffff","selection":"#ffffff","url":"#0000ff","ui_accent":"#00ffff","ansi":["#000000","#000001","#000002","#000003","#000004","#000005","#000006","#000007","#000008","#000009","#00000a","#00000b","#00000c","#00000d","#00000e","#00000f"]}"##;
+        let resolved = serde_json::from_str::<ThemePalette>(json)
+            .unwrap()
+            .resolve()
+            .unwrap();
+        assert_eq!(resolved.active_tab_background, resolved.selection);
+        assert_eq!(resolved.active_tab_foreground, resolved.background);
+
+        let dark_tab = json.replace("\"selection\":\"#ffffff\"", "\"selection\":\"#000000\"");
+        let resolved = serde_json::from_str::<ThemePalette>(&dark_tab)
+            .unwrap()
+            .resolve()
+            .unwrap();
+        assert_eq!(resolved.active_tab_foreground, resolved.foreground);
+    }
+
+    #[test]
+    fn native_active_tab_foreground_is_independent_and_invalid_values_fail_closed() {
+        let foot = complete_foot_palette("141d23", "f2e8d5", "e6c93a", "b69f80");
+        let dispatch = resolve_omarchy_theme(
+            "active_tab_background=\"#e6c93a\"\nactive_tab_foreground=\"#141d23\"\naccent=\"#00aaff\"\n",
+            &foot,
+        )
+        .unwrap();
+        assert_eq!(dispatch.active_tab_background, 0xe6_c9_3a);
+        assert_eq!(dispatch.active_tab_foreground, 0x14_1d_23);
+        assert!((contrast_ratio(0x14_1d_23, 0xe6_c9_3a) - 10.39).abs() < 0.01);
+        assert_eq!(dispatch.selection_foreground, 0xb6_9f_80);
+
+        let fallback = resolve_omarchy_theme(
+            "active_tab_background=\"#e6c93a\"\naccent=\"#00aaff\"\n",
+            &foot,
+        )
+        .unwrap();
+        assert_eq!(fallback.active_tab_foreground, fallback.background);
+
+        assert!(
+            resolve_omarchy_theme("active_tab_foreground=\"invalid\"\n", &foot)
+                .unwrap_err()
+                .to_string()
+                .contains("invalid active_tab_foreground")
+        );
+
+        let json = r##"{"background":"#000000","foreground":"#ffffff","cursor":"#ffffff","selection":"#ffffff","active_tab_foreground":"#141d23","url":"#0000ff","ui_accent":"#00ffff","ansi":["#000000","#000001","#000002","#000003","#000004","#000005","#000006","#000007","#000008","#000009","#00000a","#00000b","#00000c","#00000d","#00000e","#00000f"]}"##;
+        for invalid in ["invalid", "141d23", "0x141d23"] {
+            let invalid_json = json.replace("#141d23", invalid);
+            assert!(
+                serde_json::from_str::<ThemePalette>(&invalid_json)
+                    .unwrap()
+                    .resolve()
+                    .is_err(),
+                "accepted malformed JSON active_tab_foreground {invalid:?}"
+            );
+        }
     }
 }

--- a/crates/splinterm/src/wayland/tabs.rs
+++ b/crates/splinterm/src/wayland/tabs.rs
@@ -110,7 +110,7 @@ pub(super) const fn tab_context_target(target: TabHitTarget) -> Option<DojoId> {
 
 const fn tab_foreground(theme: ResolvedTheme, active: bool) -> u32 {
     if active {
-        theme.selection_foreground
+        theme.active_tab_foreground
     } else {
         theme.foreground
     }
@@ -596,11 +596,13 @@ mod tests {
             foreground: 0xaa_bb_cc,
             selection_foreground: 0x11_22_33,
             active_tab_background: 0x44_55_66,
+            active_tab_foreground: 0xdd_ee_ff,
             ui_accent: 0x77_88_99,
             ..ResolvedTheme::default()
         };
         assert_eq!(tab_foreground(theme, false), 0xaa_bb_cc);
-        assert_eq!(tab_foreground(theme, true), 0x11_22_33);
+        assert_eq!(tab_foreground(theme, true), 0xdd_ee_ff);
+        assert_eq!(theme.selection_foreground, 0x11_22_33);
         assert_eq!(opaque_rgba(theme.ui_accent), [0x77, 0x88, 0x99, 0xff]);
 
         let active_dojo = DojoId::new();

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -402,24 +402,20 @@ With `main.theme` unset, Splinterm reads the active Quattro theme directly from
 `${XDG_STATE_HOME:-~/.local/state}/omarchy/current/theme/`. The effective
 `foot.ini` supplies the terminal foreground/background, ANSI 16, cursor,
 selection background and foreground, alpha, and blur; `colors.toml` supplies the
-Omarchy UI accent used by trusted surfaces and active pane chrome plus the exact
-`active_tab_background` role used for the selected-Dojo-tab body and the optional
-`active_tab_foreground` role used for its label and close affordance. The
-tab-strip and selected-tab backgrounds both inherit the terminal alpha while
-preserving their exact theme colors. The selected-tab underline remains the
+standard Omarchy `accent` and `lighter_bg` roles used by application chrome. The
+selected-Dojo-tab body uses `lighter_bg` when present and otherwise Foot
+`bright0`; it never borrows the terminal selection background. Its label and
+close affordance use whichever effective Foot background or foreground has
+higher WCAG contrast against that resolved tab body, preferring foreground on
+an exact tie. Native Omarchy themes do not need Splinterm-specific palette
+roles.
+
+The tab-strip and selected-tab backgrounds both inherit the terminal alpha
+while preserving their resolved colors. The selected-tab underline remains the
 opaque UI accent. Terminal selections continue to use Foot's independent
 `selection-foreground`, falling back to the terminal foreground when that Foot
-role is absent.
-
-If an older theme omits `active_tab_background`, the selected-tab body falls
-back to the exact terminal selection background. If it omits
-`active_tab_foreground`, Splinterm compares the WCAG contrast of the effective
-Foot background and foreground against that final selected-tab background and
-uses the higher-contrast endpoint, preferring foreground on an exact tie. It
-does not synthesize or contrast-correct a color. An explicit malformed role
-rejects the palette atomically instead of invoking the fallback. `[colors-dark]`
-takes precedence over legacy `[colors]`, while absent alpha defaults opaque and
-absent blur defaults off.
+role is absent. `[colors-dark]` takes precedence over legacy `[colors]`, while
+absent alpha defaults opaque and absent blur defaults off.
 
 Splinterm fingerprints the active directory plus both source files every 500 ms.
 This detects Omarchy's atomic current-theme directory replacement and applies a
@@ -434,9 +430,9 @@ No theme hook, generated file, or manual integration step is required. Setting
 portable or isolated use. The strict JSON schema retains optional
 `selection_foreground`, `active_tab_background`, `active_tab_foreground`,
 `pane_border`, and `pane_border_active` overrides. `selection_foreground` falls
-back to the normal foreground and `active_tab_background` falls back to
-`selection` for older JSON themes. A missing `active_tab_foreground` uses the
+back to the normal foreground and `active_tab_background` falls back to ANSI
+color 8 for older JSON themes. A missing `active_tab_foreground` uses the
 same contrast algorithm against the JSON palette's resolved `background` and
 `foreground`; malformed explicit values fail theme loading. The optional
-`tools/generate-omarchy-theme.py` exporter preserves an explicit role or derives
-one from the background, foreground, and selected-tab background roles it emits.
+`tools/generate-omarchy-theme.py` exporter derives these JSON roles from the
+standard Omarchy background ramp and foreground/background endpoints.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -403,16 +403,23 @@ With `main.theme` unset, Splinterm reads the active Quattro theme directly from
 `foot.ini` supplies the terminal foreground/background, ANSI 16, cursor,
 selection background and foreground, alpha, and blur; `colors.toml` supplies the
 Omarchy UI accent used by trusted surfaces and active pane chrome plus the exact
-`active_tab_background` role used for the selected-Dojo-tab body. The tab-strip
-and selected-tab backgrounds both inherit the terminal alpha while preserving
-their exact theme colors. The selected-tab underline remains the opaque UI
-accent. Active tab labels and close
-affordances use `selection-foreground`, falling back to the terminal foreground
-when that Foot role is absent. If an older theme omits `active_tab_background`,
-the selected-tab body falls back to the exact terminal selection background.
-`[colors-dark]` takes
-precedence over legacy `[colors]`, while absent alpha defaults opaque and absent
-blur defaults off.
+`active_tab_background` role used for the selected-Dojo-tab body and the optional
+`active_tab_foreground` role used for its label and close affordance. The
+tab-strip and selected-tab backgrounds both inherit the terminal alpha while
+preserving their exact theme colors. The selected-tab underline remains the
+opaque UI accent. Terminal selections continue to use Foot's independent
+`selection-foreground`, falling back to the terminal foreground when that Foot
+role is absent.
+
+If an older theme omits `active_tab_background`, the selected-tab body falls
+back to the exact terminal selection background. If it omits
+`active_tab_foreground`, Splinterm compares the WCAG contrast of the effective
+Foot background and foreground against that final selected-tab background and
+uses the higher-contrast endpoint, preferring foreground on an exact tie. It
+does not synthesize or contrast-correct a color. An explicit malformed role
+rejects the palette atomically instead of invoking the fallback. `[colors-dark]`
+takes precedence over legacy `[colors]`, while absent alpha defaults opaque and
+absent blur defaults off.
 
 Splinterm fingerprints the active directory plus both source files every 500 ms.
 This detects Omarchy's atomic current-theme directory replacement and applies a
@@ -425,8 +432,11 @@ safe fallback.
 No theme hook, generated file, or manual integration step is required. Setting
 `main.theme=/path/to/theme.json` explicitly opts out of Omarchy discovery for
 portable or isolated use. The strict JSON schema retains optional
-`selection_foreground`, `active_tab_background`, `pane_border`, and
-`pane_border_active` overrides; `selection_foreground` falls back to the normal
-foreground and `active_tab_background` falls back to `selection` for older JSON
-themes. `tools/generate-omarchy-theme.py`
-remains only an optional exporter for that override format.
+`selection_foreground`, `active_tab_background`, `active_tab_foreground`,
+`pane_border`, and `pane_border_active` overrides. `selection_foreground` falls
+back to the normal foreground and `active_tab_background` falls back to
+`selection` for older JSON themes. A missing `active_tab_foreground` uses the
+same contrast algorithm against the JSON palette's resolved `background` and
+`foreground`; malformed explicit values fail theme loading. The optional
+`tools/generate-omarchy-theme.py` exporter preserves an explicit role or derives
+one from the background, foreground, and selected-tab background roles it emits.

--- a/docs/plans/0041-beta1-active-tab-foreground.md
+++ b/docs/plans/0041-beta1-active-tab-foreground.md
@@ -1,47 +1,38 @@
 # Plan 0041: Beta 1 active-tab foreground contrast
 
-- **Status:** Implementation, non-graphical validation, and review complete; packaged graphical acceptance pending for `0.1.0-beta.1`
+- **Status:** Implementation revised and focused validation complete; fresh review
+  and packaged graphical acceptance pending for `0.1.0-beta.1`
 - **Date:** 2026-08-14
-- **Product authority:** Active Dojo-tab text has its own optional theme role and
-  never borrows terminal selection text color implicitly
+- **Product authority:** Active Dojo-tab chrome derives from standard Omarchy
+  and Foot roles without requiring app-specific additions to `colors.toml`; its
+  body and text never borrow terminal selection colors implicitly
 - **Depends on:** native Omarchy theme discovery, strict JSON theme resolution,
   and the accepted exact-color selected-tab rendering path
 
 ## Decision
 
-Add an optional `active_tab_foreground` role to Splinterm's native Omarchy and
-JSON theme inputs. Active Dojo-tab labels and close affordances use the resolved
-role. Terminal selection keeps using `selection_foreground`; changing tab text
-must not change selected terminal glyphs.
+Active Dojo-tab labels and close affordances use a resolved foreground that is
+independent from terminal `selection_foreground`; changing tab text must not
+change selected terminal glyphs.
 
-When `active_tab_foreground` is absent, choose whichever of the resolved theme
-`background` or `foreground` has the higher WCAG contrast ratio against the
-resolved `active_tab_background`. Prefer `foreground` on an exact tie. This is a
-deterministic compatibility fallback, not a promise to synthesize a new color
-or force every legacy palette above a minimum ratio.
+Native Omarchy discovery derives the tab body only from standard theme roles:
+`lighter_bg`, then effective Foot `bright0`. It derives tab text by choosing
+whichever effective Foot `background` or `foreground` has the higher WCAG
+contrast ratio against that resolved body, preferring `foreground` on an exact
+tie. Native themes require no Splinterm-specific `colors.toml` keys.
 
-An explicit `active_tab_foreground` remains an exact theme-owned RGB value. It is
-validated but not contrast-corrected, blended, or replaced. An invalid explicit
-value rejects the candidate theme atomically instead of silently using the
-fallback.
-
-For Dispatch, the intended native Omarchy roles are:
-
-```toml
-active_tab_background = "#e6c93a"
-active_tab_foreground = "#141d23"
-```
-
-The active tab therefore uses dark `#141d23` text on yellow `#e6c93a` at
-approximately 10.39:1 contrast, while Foot's tan `selection-foreground` remains
-unchanged for terminal selection.
+Strict JSON themes remain a Splinterm-owned portable format. They may explicitly
+set `active_tab_background` and `active_tab_foreground`; absent values use ANSI
+color 8 and the same deterministic contrast chooser. Explicit JSON values remain
+exact and malformed values reject the candidate palette atomically.
 
 ## Confirmed baseline defect
 
-Before this patch, the native path resolved `active_tab_background` from
-`colors.toml` but resolved `selection_foreground` from Foot. `tab_foreground()`
-then used `selection_foreground` for active tabs. Dispatch consequently renders
-`#b69f80` text on `#e6c93a`, approximately 1.55:1 contrast.
+Before this patch, the native path accepted a Splinterm-specific
+`active_tab_background` from `colors.toml` and otherwise borrowed Foot selection
+background. `tab_foreground()` then used Foot `selection_foreground` for active
+tabs. This coupled application chrome to terminal selection roles and encouraged
+app-specific additions to Omarchy themes.
 
 An explicit `~/.config/splinterm/theme.json` does not affect the running client
 unless `main.theme` selects it. With `main.theme` unset, native Omarchy discovery
@@ -54,15 +45,16 @@ selection and application-chrome semantics and is outside this patch.
 1. Extend `ResolvedTheme` with a complete `active_tab_foreground` value and give
    the bundled default theme an explicit readable value.
 2. Extend strict JSON `ThemePalette` with optional `active_tab_foreground`.
-   Resolve an explicit valid `#RRGGBB` exactly; otherwise compute the fallback
+   Resolve explicit valid JSON overrides exactly; otherwise compute the fallback
    only after `background` and `active_tab_background` are resolved.
-3. In native Omarchy discovery, read optional `active_tab_foreground` only from
-   `colors.toml`. Keep `selection-foreground` sourced from effective Foot
-   `[colors-dark]` or legacy `[colors]` exactly as before.
-4. Resolve `active_tab_background` first, retaining its existing fallback to the
-   terminal selection background. Then resolve the missing foreground from the
-   theme background/foreground endpoint with higher contrast against that final
-   active-tab background.
+3. In native Omarchy discovery, keep `selection-foreground` sourced from
+   effective Foot `[colors-dark]` or legacy `[colors]` exactly as before. Do not
+   read Splinterm-specific active-tab roles from `colors.toml`.
+4. Resolve native `active_tab_background` from standard `lighter_bg`, then
+   effective Foot `bright0`. Resolve strict JSON from an explicit override, then
+   ANSI color 8. Never borrow terminal selection. Derive the native foreground,
+   or a missing JSON foreground, from the higher-contrast background/foreground
+   endpoint against that final active-tab body.
 5. Use the WCAG sRGB relative-luminance and contrast-ratio calculation. Compare
    ratios without rounding; documentation-only displayed ratios may be rounded.
 6. Prefer normal theme `foreground` on an exact contrast tie. Do not use
@@ -76,13 +68,12 @@ selection and application-chrome semantics and is outside this patch.
    the compositor background behind translucent tabs.
 9. Live theme reload remains atomic: a malformed new role retains the last valid
    complete `ResolvedTheme` through the existing watcher boundary.
-10. The optional Omarchy exporter emits `active_tab_foreground`. It preserves an
-    explicit source role and applies the same contrast algorithm to the
-    `background` and `foreground` roles in the JSON palette it emits. Native
-    discovery instead compares its effective Foot background and foreground.
-    Exact cross-path color equality is required only when those resolved
-    endpoints and the active-tab background are equal; this patch does not
-    redefine the exporter's existing color-source ownership.
+10. The optional Omarchy exporter derives both active-tab JSON roles from
+    standard Omarchy roles and ignores app-specific source keys. It applies the
+    same contrast algorithm to the `background` and `foreground` roles in the
+    JSON palette it emits. Native discovery instead compares its effective Foot
+    background and foreground. Exact cross-path color equality is required only
+    when those resolved endpoints and the active-tab background are equal.
 
 ## Implementation milestones
 
@@ -103,15 +94,15 @@ Work:
 
 Focused tests must prove:
 
-- explicit native and JSON roles survive exactly;
-- missing roles choose dark background against a bright selected-tab body and
-  light foreground against a dark selected-tab body;
+- explicit strict JSON roles survive exactly;
+- native themes use `lighter_bg`, then Foot `bright0`, without app-specific keys;
+- missing JSON roles choose dark background against a bright selected-tab body
+  and light foreground against a dark selected-tab body;
 - an exact tie chooses foreground;
-- fallback uses the final selection-derived tab background when
-  `active_tab_background` is absent;
-- malformed explicit roles fail rather than falling back;
-- Dispatch resolves active tab foreground to `0x141d23` while preserving its
-  independent Foot selection foreground; and
+- foreground fallback uses the final background-ramp-derived tab body;
+- malformed explicit JSON roles fail rather than falling back;
+- native active-tab text is derived independently from Foot selection
+  foreground; and
 - default/live-reload paths still carry one complete atomic theme.
 
 ### Milestone 2 — renderer separation and exporter parity
@@ -133,9 +124,11 @@ Focused tests must prove:
 
 - active tabs use `active_tab_foreground` even when
   `selection_foreground` is deliberately different;
+- missing active-tab backgrounds use the normal background ramp even when the
+  terminal selection background is deliberately different;
 - inactive tabs still use normal foreground;
 - active-tab background alpha and accent underline bytes remain unchanged;
-- exporter output preserves an explicit role;
+- exporter output ignores app-specific Omarchy source keys;
 - exporter output derives both dark-on-light and light-on-dark fallbacks from
   the background and foreground roles emitted into that JSON;
 - native discovery derives from deliberately different effective Foot endpoints
@@ -187,14 +180,14 @@ than weakening or silently skipping the boundary.
 After separate approval under the repository graphical-testing rules and after
 an approved adjacent packaged client installation:
 
-1. select the Dispatch Omarchy theme in one isolated Splinterm test Window;
-2. prove the active tab label and close affordance use dark `#141d23` while the
-   active tab body remains exact `#e6c93a` and the underline remains the UI
-   accent;
-3. create a terminal selection and prove its foreground remains Dispatch's Foot
-   selection foreground rather than the tab foreground;
-4. switch to a theme without `active_tab_foreground` and prove the active tab
-   remains readable through the deterministic fallback;
+1. select an Omarchy theme in one isolated Splinterm test Window;
+2. prove the active tab body uses that theme's standard `lighter_bg` and the
+   label and close affordance use the derived higher-contrast endpoint while the
+   underline remains the UI accent;
+3. create a terminal selection and prove its foreground remains Foot's selection
+   foreground rather than the tab foreground;
+4. switch to a theme without `lighter_bg` and prove Foot `bright0` supplies the
+   body fallback;
 5. switch back and prove live native discovery updates the complete palette
    without restart; and
 6. restore the original theme, focus, workspace, monitor, Window geometry,
@@ -208,12 +201,13 @@ cleanup.
 
 The patch is complete only when:
 
-- native Omarchy and strict JSON themes accept optional
-  `active_tab_foreground`;
-- absent roles use the documented deterministic higher-contrast endpoint;
+- native Omarchy uses no Splinterm-specific `colors.toml` roles;
+- strict JSON themes accept optional active-tab overrides;
+- absent JSON roles and native inputs use the documented deterministic
+  fallbacks;
 - active tab chrome no longer consumes `selection_foreground`;
-- Dispatch's exact tab pair resolves to `#141d23` on `#e6c93a` without changing
-  terminal selection colors;
+- missing active-tab backgrounds no longer consume terminal selection color;
+- native active-tab chrome remains independent from terminal selection colors;
 - focused and serial validation plus fresh read-only review are recorded;
 - separately approved packaged graphical acceptance is recorded; and
 - the Beta 1 candidate, promotion, publication, and AUR states are recorded

--- a/docs/plans/0041-beta1-active-tab-foreground.md
+++ b/docs/plans/0041-beta1-active-tab-foreground.md
@@ -1,7 +1,7 @@
 # Plan 0041: Beta 1 active-tab foreground contrast
 
-- **Status:** Implementation revised and focused validation complete; fresh review
-  and packaged graphical acceptance pending for `0.1.0-beta.1`
+- **Status:** Implementation, complete non-graphical validation, and fresh review
+  accepted; packaged graphical acceptance pending for `0.1.0-beta.1`
 - **Date:** 2026-08-14
 - **Product authority:** Active Dojo-tab chrome derives from standard Omarchy
   and Foot roles without requiring app-specific additions to `colors.toml`; its
@@ -174,6 +174,12 @@ Before release integration, run the repository's complete serialized workspace,
 release-tooling, package, portable Foot-provenance, and documentation boundaries.
 Record any known unrelated flaky failure plus its exact isolated rerun rather
 than weakening or silently skipping the boundary.
+
+The reviewed implementation boundary at `9316a5f` passed the focused config,
+tab-renderer, and exporter tests; the complete serialized workspace; all-target
+warnings-denied Clippy; all 63 benchmark tests; release/package/automation
+unittests; portable Foot provenance; automation contract fixtures; formatting;
+and `git diff --check`. Fresh read-only review `4c6bdf91` returned **CLEAN**.
 
 ## Packaged graphical acceptance
 

--- a/docs/plans/0041-beta1-active-tab-foreground.md
+++ b/docs/plans/0041-beta1-active-tab-foreground.md
@@ -1,0 +1,224 @@
+# Plan 0041: Beta 1 active-tab foreground contrast
+
+- **Status:** Implementation, non-graphical validation, and review complete; packaged graphical acceptance pending for `0.1.0-beta.1`
+- **Date:** 2026-08-14
+- **Product authority:** Active Dojo-tab text has its own optional theme role and
+  never borrows terminal selection text color implicitly
+- **Depends on:** native Omarchy theme discovery, strict JSON theme resolution,
+  and the accepted exact-color selected-tab rendering path
+
+## Decision
+
+Add an optional `active_tab_foreground` role to Splinterm's native Omarchy and
+JSON theme inputs. Active Dojo-tab labels and close affordances use the resolved
+role. Terminal selection keeps using `selection_foreground`; changing tab text
+must not change selected terminal glyphs.
+
+When `active_tab_foreground` is absent, choose whichever of the resolved theme
+`background` or `foreground` has the higher WCAG contrast ratio against the
+resolved `active_tab_background`. Prefer `foreground` on an exact tie. This is a
+deterministic compatibility fallback, not a promise to synthesize a new color
+or force every legacy palette above a minimum ratio.
+
+An explicit `active_tab_foreground` remains an exact theme-owned RGB value. It is
+validated but not contrast-corrected, blended, or replaced. An invalid explicit
+value rejects the candidate theme atomically instead of silently using the
+fallback.
+
+For Dispatch, the intended native Omarchy roles are:
+
+```toml
+active_tab_background = "#e6c93a"
+active_tab_foreground = "#141d23"
+```
+
+The active tab therefore uses dark `#141d23` text on yellow `#e6c93a` at
+approximately 10.39:1 contrast, while Foot's tan `selection-foreground` remains
+unchanged for terminal selection.
+
+## Confirmed baseline defect
+
+Before this patch, the native path resolved `active_tab_background` from
+`colors.toml` but resolved `selection_foreground` from Foot. `tab_foreground()`
+then used `selection_foreground` for active tabs. Dispatch consequently renders
+`#b69f80` text on `#e6c93a`, approximately 1.55:1 contrast.
+
+An explicit `~/.config/splinterm/theme.json` does not affect the running client
+unless `main.theme` selects it. With `main.theme` unset, native Omarchy discovery
+is authoritative, so changing only that generated JSON is not a runtime fix.
+Changing Dispatch's Foot selection foreground would couple unrelated terminal
+selection and application-chrome semantics and is outside this patch.
+
+## Behavior contract
+
+1. Extend `ResolvedTheme` with a complete `active_tab_foreground` value and give
+   the bundled default theme an explicit readable value.
+2. Extend strict JSON `ThemePalette` with optional `active_tab_foreground`.
+   Resolve an explicit valid `#RRGGBB` exactly; otherwise compute the fallback
+   only after `background` and `active_tab_background` are resolved.
+3. In native Omarchy discovery, read optional `active_tab_foreground` only from
+   `colors.toml`. Keep `selection-foreground` sourced from effective Foot
+   `[colors-dark]` or legacy `[colors]` exactly as before.
+4. Resolve `active_tab_background` first, retaining its existing fallback to the
+   terminal selection background. Then resolve the missing foreground from the
+   theme background/foreground endpoint with higher contrast against that final
+   active-tab background.
+5. Use the WCAG sRGB relative-luminance and contrast-ratio calculation. Compare
+   ratios without rounding; documentation-only displayed ratios may be rounded.
+6. Prefer normal theme `foreground` on an exact contrast tie. Do not use
+   `selection_foreground`, `ui_accent`, ANSI colors, hard-coded black/white, or a
+   generated intermediate color as the fallback.
+7. `tab_foreground()` uses `active_tab_foreground` only for active tab labels and
+   their close affordances. Inactive tabs retain normal `foreground`; terminal
+   selection rendering retains `selection_foreground`.
+8. Preserve exact active-tab background RGB, configured alpha, and opaque accent
+   underline behavior. This patch does not alter compositing or attempt to infer
+   the compositor background behind translucent tabs.
+9. Live theme reload remains atomic: a malformed new role retains the last valid
+   complete `ResolvedTheme` through the existing watcher boundary.
+10. The optional Omarchy exporter emits `active_tab_foreground`. It preserves an
+    explicit source role and applies the same contrast algorithm to the
+    `background` and `foreground` roles in the JSON palette it emits. Native
+    discovery instead compares its effective Foot background and foreground.
+    Exact cross-path color equality is required only when those resolved
+    endpoints and the active-tab background are equal; this patch does not
+    redefine the exporter's existing color-source ownership.
+
+## Implementation milestones
+
+### Milestone 1 — theme role and deterministic fallback
+
+Expected files:
+
+- `crates/splinterm/src/config.rs`
+- `config/splinterm/theme.json`
+
+Work:
+
+- add the optional JSON field and complete resolved field;
+- add a small pure sRGB luminance/contrast chooser at theme resolution;
+- resolve the role in both JSON and native Omarchy paths;
+- keep explicit values exact and malformed values fail-closed; and
+- update the bundled JSON theme so its schema example is complete.
+
+Focused tests must prove:
+
+- explicit native and JSON roles survive exactly;
+- missing roles choose dark background against a bright selected-tab body and
+  light foreground against a dark selected-tab body;
+- an exact tie chooses foreground;
+- fallback uses the final selection-derived tab background when
+  `active_tab_background` is absent;
+- malformed explicit roles fail rather than falling back;
+- Dispatch resolves active tab foreground to `0x141d23` while preserving its
+  independent Foot selection foreground; and
+- default/live-reload paths still carry one complete atomic theme.
+
+### Milestone 2 — renderer separation and exporter parity
+
+Expected files:
+
+- `crates/splinterm/src/wayland/tabs.rs`
+- `tools/generate-omarchy-theme.py`
+- `tools/benchmark/test_benchmark.py`
+
+Work:
+
+- route active tab text and close-glyph painting through the new resolved role;
+- leave inactive tabs and terminal selection untouched;
+- teach the optional Omarchy exporter to preserve or derive the new role; and
+- keep Rust and Python fallback semantics aligned with shared fixed fixtures.
+
+Focused tests must prove:
+
+- active tabs use `active_tab_foreground` even when
+  `selection_foreground` is deliberately different;
+- inactive tabs still use normal foreground;
+- active-tab background alpha and accent underline bytes remain unchanged;
+- exporter output preserves an explicit role;
+- exporter output derives both dark-on-light and light-on-dark fallbacks from
+  the background and foreground roles emitted into that JSON;
+- native discovery derives from deliberately different effective Foot endpoints
+  when sibling `colors.toml` values differ; and
+- native and generated JSON results match when their resolved endpoint fixtures
+  and active-tab background match.
+
+### Milestone 3 — documentation, review, and release boundary
+
+Expected files:
+
+- `docs/configuration.md`
+- `TODO.md`
+- release-state files only in a later dedicated Beta 1 release commit
+
+Work:
+
+- update the existing optional-role and fallback paragraph in
+  `docs/configuration.md` to document native and JSON endpoint ownership,
+  fail-closed explicit-role validation, fallback order, and the separation from
+  Foot selection colors;
+- record focused and serial non-graphical validation;
+- inspect the actual diff and obtain one fresh read-only correctness review;
+- prepare the `0.1.0-beta.1` version/package/provenance changes only after the
+  implementation branch is accepted; and
+- keep candidate construction, publication, and AUR distribution behind their
+  existing separate approval boundaries.
+
+## Validation
+
+Run after each coherent implementation milestone as applicable:
+
+```bash
+cargo test -p splinterm config::tests
+cargo test -p splinterm wayland::tabs::tests
+python -m pytest tools/benchmark/test_benchmark.py -k omarchy_theme_generator
+cargo fmt --all --check
+cargo clippy -p splinterm --all-targets -- -D warnings
+git diff --check
+```
+
+Before release integration, run the repository's complete serialized workspace,
+release-tooling, package, portable Foot-provenance, and documentation boundaries.
+Record any known unrelated flaky failure plus its exact isolated rerun rather
+than weakening or silently skipping the boundary.
+
+## Packaged graphical acceptance
+
+After separate approval under the repository graphical-testing rules and after
+an approved adjacent packaged client installation:
+
+1. select the Dispatch Omarchy theme in one isolated Splinterm test Window;
+2. prove the active tab label and close affordance use dark `#141d23` while the
+   active tab body remains exact `#e6c93a` and the underline remains the UI
+   accent;
+3. create a terminal selection and prove its foreground remains Dispatch's Foot
+   selection foreground rather than the tab foreground;
+4. switch to a theme without `active_tab_foreground` and prove the active tab
+   remains readable through the deterministic fallback;
+5. switch back and prove live native discovery updates the complete palette
+   without restart; and
+6. restore the original theme, focus, workspace, monitor, Window geometry,
+   package state, and test topology.
+
+Abort on wrong-window input, unrelated theme/config mutation, loss of exact
+selected-tab background behavior, selection-color regression, or incomplete
+cleanup.
+
+## Beta 1 acceptance
+
+The patch is complete only when:
+
+- native Omarchy and strict JSON themes accept optional
+  `active_tab_foreground`;
+- absent roles use the documented deterministic higher-contrast endpoint;
+- active tab chrome no longer consumes `selection_foreground`;
+- Dispatch's exact tab pair resolves to `#141d23` on `#e6c93a` without changing
+  terminal selection colors;
+- focused and serial validation plus fresh read-only review are recorded;
+- separately approved packaged graphical acceptance is recorded; and
+- the Beta 1 candidate, promotion, publication, and AUR states are recorded
+  only after their separate authorizations.
+
+This plan does not authorize implementation, installation, graphical testing,
+pushing, candidate dispatch, promotion approval, AUR publication, or release
+publication.

--- a/site/src/content/docs/docs/configure/configuration.md
+++ b/site/src/content/docs/docs/configure/configuration.md
@@ -79,7 +79,9 @@ The default `main.font-sizing-policy=output-scale` follows Wayland compositor ou
 
 ## Omarchy theme integration
 
-With `main.theme` unset, Splinterm reads the active Omarchy theme from `${XDG_STATE_HOME:-~/.local/state}/omarchy/current/theme/`. The effective `foot.ini` supplies terminal colors, selection, alpha, and blur; `colors.toml` supplies the Omarchy UI accent.
+With `main.theme` unset, Splinterm reads the active Omarchy theme from `${XDG_STATE_HOME:-~/.local/state}/omarchy/current/theme/`. The effective `foot.ini` supplies terminal colors, selection, alpha, and blur; `colors.toml` supplies the Omarchy UI accent plus optional active-tab background and foreground roles.
+
+Active tab text is independent from terminal selection text. When `active_tab_foreground` is absent, Splinterm chooses whichever effective terminal background or foreground has higher WCAG contrast against the resolved active-tab background, preferring foreground on a tie. Explicit malformed roles reject the palette instead of silently invoking the fallback. Explicit JSON themes use the same rule against their own background and foreground roles.
 
 Valid theme changes reload without restarting the daemon, shell, or window. A malformed or incomplete replacement retains the last valid palette.
 

--- a/site/src/content/docs/docs/configure/configuration.md
+++ b/site/src/content/docs/docs/configure/configuration.md
@@ -79,9 +79,9 @@ The default `main.font-sizing-policy=output-scale` follows Wayland compositor ou
 
 ## Omarchy theme integration
 
-With `main.theme` unset, Splinterm reads the active Omarchy theme from `${XDG_STATE_HOME:-~/.local/state}/omarchy/current/theme/`. The effective `foot.ini` supplies terminal colors, selection, alpha, and blur; `colors.toml` supplies the Omarchy UI accent plus optional active-tab background and foreground roles.
+With `main.theme` unset, Splinterm reads the active Omarchy theme from `${XDG_STATE_HOME:-~/.local/state}/omarchy/current/theme/`. The effective `foot.ini` supplies terminal colors, selection, alpha, and blur; `colors.toml` supplies standard Omarchy accent and background-ramp roles. The active-tab body uses `lighter_bg`, then Foot `bright0`, rather than terminal selection color.
 
-Active tab text is independent from terminal selection text. When `active_tab_foreground` is absent, Splinterm chooses whichever effective terminal background or foreground has higher WCAG contrast against the resolved active-tab background, preferring foreground on a tie. Explicit malformed roles reject the palette instead of silently invoking the fallback. Explicit JSON themes use the same rule against their own background and foreground roles.
+Active tab text is independent from terminal selection text. Splinterm chooses whichever effective terminal background or foreground has higher WCAG contrast against the resolved active-tab body, preferring foreground on a tie. Native Omarchy themes need no Splinterm-specific roles. Explicit JSON themes may override the active-tab roles and use the same fallback rule against their own background and foreground roles.
 
 Valid theme changes reload without restarting the daemon, shell, or window. A malformed or incomplete replacement retains the last valid palette.
 

--- a/tools/benchmark/test_benchmark.py
+++ b/tools/benchmark/test_benchmark.py
@@ -1343,8 +1343,25 @@ def test_omarchy_theme_generator_uses_foot_presentation_and_legacy_roles(
     assert generated["background"] == legacy["background"]
     assert generated["selection_foreground"] == legacy["foreground"]
     assert generated["active_tab_background"] == legacy["selection_background"]
-    explicit = module.generate({**legacy, "active_tab_background": "#303132"})
+    assert generated["active_tab_foreground"] == legacy["foreground"]
+    explicit = module.generate(
+        {
+            **legacy,
+            "active_tab_background": "#303132",
+            "active_tab_foreground": "#a0b0c0",
+        }
+    )
     assert explicit["active_tab_background"] == "#303132"
+    assert explicit["active_tab_foreground"] == "#a0b0c0"
+    light_tab = module.generate(
+        {**legacy, "active_tab_background": "#f0f1f2"}
+    )
+    assert light_tab["active_tab_foreground"] == legacy["background"]
+    assert module.active_tab_foreground_fallback(
+        "#123456", "#123456", "#789abc"
+    ) == "#123456"
+    with pytest.raises(ValueError, match="active_tab_foreground"):
+        module.generate({**legacy, "active_tab_foreground": "invalid"})
     assert generated["ansi"][0] == legacy["color0"]
     assert generated["ansi"][15] == legacy["color15"]
 

--- a/tools/benchmark/test_benchmark.py
+++ b/tools/benchmark/test_benchmark.py
@@ -1342,26 +1342,27 @@ def test_omarchy_theme_generator_uses_foot_presentation_and_legacy_roles(
     assert generated["blur"] is True
     assert generated["background"] == legacy["background"]
     assert generated["selection_foreground"] == legacy["foreground"]
-    assert generated["active_tab_background"] == legacy["selection_background"]
+    assert generated["active_tab_background"] == legacy["color8"]
     assert generated["active_tab_foreground"] == legacy["foreground"]
-    explicit = module.generate(
+    assert generated["active_tab_background"] != legacy["selection_background"]
+    semantic_ramp = module.generate({**legacy, "lighter_bg": "#f8f9fa"})
+    assert semantic_ramp["active_tab_background"] == "#f8f9fa"
+    assert semantic_ramp["active_tab_foreground"] == legacy["background"]
+    assert semantic_ramp["selection"] == legacy["selection_background"]
+    ignored_extensions = module.generate(
         {
             **legacy,
             "active_tab_background": "#303132",
             "active_tab_foreground": "#a0b0c0",
         }
     )
-    assert explicit["active_tab_background"] == "#303132"
-    assert explicit["active_tab_foreground"] == "#a0b0c0"
-    light_tab = module.generate(
-        {**legacy, "active_tab_background": "#f0f1f2"}
-    )
+    assert ignored_extensions["active_tab_background"] == legacy["color8"]
+    assert ignored_extensions["active_tab_foreground"] == legacy["foreground"]
+    light_tab = module.generate({**legacy, "lighter_bg": "#f0f1f2"})
     assert light_tab["active_tab_foreground"] == legacy["background"]
     assert module.active_tab_foreground_fallback(
         "#123456", "#123456", "#789abc"
     ) == "#123456"
-    with pytest.raises(ValueError, match="active_tab_foreground"):
-        module.generate({**legacy, "active_tab_foreground": "invalid"})
     assert generated["ansi"][0] == legacy["color0"]
     assert generated["ansi"][15] == legacy["color15"]
 

--- a/tools/generate-omarchy-theme.py
+++ b/tools/generate-omarchy-theme.py
@@ -14,6 +14,7 @@ ROLE_ALIASES = {
     "accent": ("accent", "cursor"),
     "bg": ("bg", "background"),
     "darker_bg": ("darker_bg", "color0"),
+    "lighter_bg": ("lighter_bg", "color8"),
     "selection": ("selection", "selection_background"),
     "muted": ("muted", "color8"),
     "fg": ("fg", "foreground"),
@@ -127,20 +128,15 @@ def generate(
     roles["selection_foreground"] = colors.get(
         "selection_foreground", roles["fg"]
     )
-    roles["active_tab_background"] = colors.get(
-        "active_tab_background", roles["selection"]
-    )
+    roles["active_tab_background"] = roles["lighter_bg"]
     missing = [name for name, value in roles.items() if value is None]
     if missing:
         raise ValueError("missing Omarchy roles: " + ", ".join(missing))
     for name, value in roles.items():
         validate_role(name, value)
-    active_tab_foreground = colors.get("active_tab_foreground")
-    if active_tab_foreground is None:
-        active_tab_foreground = active_tab_foreground_fallback(
-            roles["bg"], roles["fg"], roles["active_tab_background"]
-        )
-    validate_role("active_tab_foreground", active_tab_foreground)
+    active_tab_foreground = active_tab_foreground_fallback(
+        roles["bg"], roles["fg"], roles["active_tab_background"]
+    )
     roles["active_tab_foreground"] = active_tab_foreground
     if not 0.0 <= alpha <= 1.0:
         raise ValueError("alpha must be between 0.0 and 1.0")

--- a/tools/generate-omarchy-theme.py
+++ b/tools/generate-omarchy-theme.py
@@ -79,6 +79,44 @@ def theme_settings(theme_dir: Path) -> tuple[float, bool]:
     return alpha, blur
 
 
+def relative_luminance(color: str) -> float:
+    channels = [int(color[index : index + 2], 16) / 255.0 for index in (1, 3, 5)]
+    linear = [
+        channel / 12.92
+        if channel <= 0.04045
+        else ((channel + 0.055) / 1.055) ** 2.4
+        for channel in channels
+    ]
+    return 0.2126 * linear[0] + 0.7152 * linear[1] + 0.0722 * linear[2]
+
+
+def contrast_ratio(first: str, second: str) -> float:
+    first_luminance = relative_luminance(first)
+    second_luminance = relative_luminance(second)
+    lighter = max(first_luminance, second_luminance)
+    darker = min(first_luminance, second_luminance)
+    return (lighter + 0.05) / (darker + 0.05)
+
+
+def active_tab_foreground_fallback(
+    background: str, foreground: str, active_tab_background: str
+) -> str:
+    if contrast_ratio(background, active_tab_background) > contrast_ratio(
+        foreground, active_tab_background
+    ):
+        return background
+    return foreground
+
+
+def validate_role(name: str, value: object) -> None:
+    if not isinstance(value, str) or len(value) != 7 or not value.startswith("#"):
+        raise ValueError(f"{name} must be #RRGGBB")
+    try:
+        int(value[1:], 16)
+    except ValueError as error:
+        raise ValueError(f"{name} must be #RRGGBB") from error
+
+
 def generate(
     colors: dict[str, object], alpha: float = 1.0, blur: bool = False
 ) -> dict[str, object]:
@@ -96,9 +134,14 @@ def generate(
     if missing:
         raise ValueError("missing Omarchy roles: " + ", ".join(missing))
     for name, value in roles.items():
-        if not isinstance(value, str) or len(value) != 7 or not value.startswith("#"):
-            raise ValueError(f"{name} must be #RRGGBB")
-        int(value[1:], 16)
+        validate_role(name, value)
+    active_tab_foreground = colors.get("active_tab_foreground")
+    if active_tab_foreground is None:
+        active_tab_foreground = active_tab_foreground_fallback(
+            roles["bg"], roles["fg"], roles["active_tab_background"]
+        )
+    validate_role("active_tab_foreground", active_tab_foreground)
+    roles["active_tab_foreground"] = active_tab_foreground
     if not 0.0 <= alpha <= 1.0:
         raise ValueError("alpha must be between 0.0 and 1.0")
     if not isinstance(blur, bool):
@@ -112,6 +155,7 @@ def generate(
         "selection": roles["selection"],
         "selection_foreground": roles["selection_foreground"],
         "active_tab_background": roles["active_tab_background"],
+        "active_tab_foreground": roles["active_tab_foreground"],
         "url": roles["blue"],
         "ui_accent": roles["accent"],
         "pane_border": roles["muted"],


### PR DESCRIPTION
## Summary

Complete Plan 0041's active-tab color separation for Beta 1:

- native Omarchy tab bodies use standard `lighter_bg`, then effective Foot `bright0`;
- native tab text deterministically selects the higher-contrast effective Foot background/foreground endpoint;
- strict JSON themes retain explicit optional active-tab overrides with bounded fallbacks;
- active tab labels/close affordances no longer consume terminal `selection_foreground`;
- terminal selection colors, active-tab alpha, and accent underline ownership remain independent;
- the optional exporter derives only from standard Omarchy roles and ignores app-specific source keys.

Native Omarchy themes require no Splinterm-specific `colors.toml` roles. Graphical packaged acceptance remains a separate gated step and is not claimed by this PR.

## Validation

- `cargo test -p splinterm config::tests` — 20 passed
- `cargo test -p splinterm wayland::tabs::tests` — 4 passed
- `python -m pytest tools/benchmark/test_benchmark.py -k omarchy_theme_generator -q` — 1 passed
- `cargo test --workspace -- --test-threads=1`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `python -m pytest tools/benchmark/test_benchmark.py -q` — 63 passed
- release/package/automation unittest boundary
- `python tools/foot-oracle/check-provenance.py --portable`
- automation contract fixture validation
- `cargo fmt --all -- --check`
- `git diff --check`
- fresh read-only review `4c6bdf91` of implementation commit `9316a5f` — CLEAN

No package installation, theme application, or graphical testing was performed.
