### PR TITLE
Accept wide grids in Dojo picker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,7 @@ jobs:
       - run: shellcheck install.sh tools/package/build-local-package.sh tools/package/upgrade-local-package.sh
       - run: |
           python -m unittest \
+            tools/automation/test_dojo_picker.py \
             tools/package/test_release_manifest.py \
             tools/package/test_installer_safety.py \
             tools/release/test_prepare_candidate.py \

--- a/tools/automation/splinterm-dojo-picker.py
+++ b/tools/automation/splinterm-dojo-picker.py
@@ -21,6 +21,8 @@ EVENT_SCHEMA = "splinterm.cli.event.v2"
 MAX_DOCUMENT_BYTES = 8 * 1024 * 1024
 MAX_DIAGNOSTIC_BYTES = 64 * 1024
 READ_CHUNK_BYTES = 16 * 1024
+MAX_GRID_COLUMNS = 480
+MAX_GRID_ROWS = 128
 ERROR_CODES = {
     "authentication_failed", "handshake_required", "incompatible_version",
     "invalid_request", "unsupported_schema", "consent_unavailable", "consent_denied",
@@ -298,9 +300,9 @@ def validate_terminal_event(
         if not (
             data.get("content_encoding") == "unicode_scalars"
             and isinstance(data.get("columns"), int)
-            and 1 <= data["columns"] <= 240
+            and 1 <= data["columns"] <= MAX_GRID_COLUMNS
             and isinstance(data.get("rows"), int)
-            and 1 <= data["rows"] <= 80
+            and 1 <= data["rows"] <= MAX_GRID_ROWS
             and isinstance(data.get("title"), str)
             and isinstance(data.get("visible_rows"), list)
         ):

--- a/tools/automation/test_dojo_picker.py
+++ b/tools/automation/test_dojo_picker.py
@@ -107,7 +107,9 @@ if "window" in args and "--output" not in args:
     raise SystemExit(0)
 if "subscribe" in args:
     snapshot_data = ({
-        "content_encoding":"unicode_scalars", "columns":80, "rows":24,
+        "content_encoding":"unicode_scalars",
+        "columns":480 if mode == "wide_snapshot" else 80,
+        "rows":128 if mode == "wide_snapshot" else 24,
         "title":"shell", "visible_rows":[]
     } if mode != "malformed_snapshot" else {})
     print(json.dumps({
@@ -289,6 +291,13 @@ class DojoPickerTests(unittest.TestCase):
             if "subscribe" in call or "snapshot" in call:
                 expected = call.index("--expected-incarnation")
                 self.assertEqual(call[expected + 1], str(INCARNATION))
+
+    def test_wide_grid_subscription_snapshot_is_accepted(self) -> None:
+        wide = self.environment.copy()
+        wide["FAKE_MODE"] = "wide_snapshot"
+        completed = self.run_picker("watch-context", environment=wide)
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        self.assertEqual(json.loads(completed.stdout)["status"], "reconciled_after_resync")
 
     def test_subscription_failure_is_not_reported_as_success(self) -> None:
         failed = self.environment.copy()


### PR DESCRIPTION
## Summary

Fix the post-merge PR #23 P1 finding in the packaged `splinterm-dojo-picker`:

- accept terminal subscription snapshots through the protocol's `480×128` grid limits;
- retain explicit bounded validation;
- exercise an exact `480×128` snapshot through `watch-context`; and
- run the existing picker contract suite in CI so this boundary cannot silently drift again.

## Validation

- `python -m pytest tools/automation/test_dojo_picker.py -q` — 15 passed, 6 subtests
- combined CI unittest boundary — 49 passed
- `python tools/automation/validate-contract-fixtures.py` — 36 valid/41 invalid automation fixtures; 88 valid/31 invalid MCP fixtures
- `python -m py_compile tools/automation/splinterm-dojo-picker.py tools/automation/test_dojo_picker.py`
- `git diff --check`
- fresh read-only review `7070c298` — CLEAN

No package installation or graphical testing was performed.
