### PR TITLE
Backport wide-grid Dojo picker fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,7 @@ jobs:
       - run: shellcheck install.sh tools/package/build-local-package.sh tools/package/upgrade-local-package.sh
       - run: |
           python -m unittest \
+            tools/automation/test_dojo_picker.py \
             tools/package/test_release_manifest.py \
             tools/package/test_installer_safety.py \
             tools/release/test_prepare_candidate.py \

--- a/tools/automation/splinterm-dojo-picker.py
+++ b/tools/automation/splinterm-dojo-picker.py
@@ -21,6 +21,8 @@ EVENT_SCHEMA = "splinterm.cli.event.v2"
 MAX_DOCUMENT_BYTES = 8 * 1024 * 1024
 MAX_DIAGNOSTIC_BYTES = 64 * 1024
 READ_CHUNK_BYTES = 16 * 1024
+MAX_GRID_COLUMNS = 480
+MAX_GRID_ROWS = 128
 ERROR_CODES = {
     "authentication_failed", "handshake_required", "incompatible_version",
     "invalid_request", "unsupported_schema", "consent_unavailable", "consent_denied",
@@ -298,9 +300,9 @@ def validate_terminal_event(
         if not (
             data.get("content_encoding") == "unicode_scalars"
             and isinstance(data.get("columns"), int)
-            and 1 <= data["columns"] <= 240
+            and 1 <= data["columns"] <= MAX_GRID_COLUMNS
             and isinstance(data.get("rows"), int)
-            and 1 <= data["rows"] <= 80
+            and 1 <= data["rows"] <= MAX_GRID_ROWS
             and isinstance(data.get("title"), str)
             and isinstance(data.get("visible_rows"), list)
         ):

--- a/tools/automation/test_dojo_picker.py
+++ b/tools/automation/test_dojo_picker.py
@@ -107,7 +107,9 @@ if "window" in args and "--output" not in args:
     raise SystemExit(0)
 if "subscribe" in args:
     snapshot_data = ({
-        "content_encoding":"unicode_scalars", "columns":80, "rows":24,
+        "content_encoding":"unicode_scalars",
+        "columns":480 if mode == "wide_snapshot" else 80,
+        "rows":128 if mode == "wide_snapshot" else 24,
         "title":"shell", "visible_rows":[]
     } if mode != "malformed_snapshot" else {})
     print(json.dumps({
@@ -289,6 +291,13 @@ class DojoPickerTests(unittest.TestCase):
             if "subscribe" in call or "snapshot" in call:
                 expected = call.index("--expected-incarnation")
                 self.assertEqual(call[expected + 1], str(INCARNATION))
+
+    def test_wide_grid_subscription_snapshot_is_accepted(self) -> None:
+        wide = self.environment.copy()
+        wide["FAKE_MODE"] = "wide_snapshot"
+        completed = self.run_picker("watch-context", environment=wide)
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        self.assertEqual(json.loads(completed.stdout)["status"], "reconciled_after_resync")
 
     def test_subscription_failure_is_not_reported_as_success(self) -> None:
         failed = self.environment.copy()


### PR DESCRIPTION
## Summary

Backport the reviewed Dojo-picker wide-grid correction from main PR #24 to the Beta 1 authority branch `maint/0.1`.

This is an exact, conflict-free cherry-pick. Stable patch ID on both branches:

`2e0e7b9146113e5b6550fc56ee8d23f10ed9c6a7`

It keeps the packaged picker aligned with Plan 0042's `480×128` protocol limits and ensures the picker contract suite runs in maintenance CI.

## Validation

- `python -m unittest tools/automation/test_dojo_picker.py` — 15 passed
- `python tools/automation/validate-contract-fixtures.py` — 36 valid/41 invalid automation fixtures; 88 valid/31 invalid MCP fixtures
- `git diff --check`
- original fresh read-only review `7070c298` — CLEAN
- original main PR #24 full CI — passed

No package installation or graphical testing was performed.
