### PR TITLE
Validate standard active-tab package roles

### DIFF
--- a/tools/package/validate-package.py
+++ b/tools/package/validate-package.py
@@ -868,7 +868,8 @@ def validate_relay_runtime(daemon: Path, client: Path, relay: Path) -> None:
 def validate_theme_generator(root: Path) -> None:
     colors = {
         "accent": "#010203", "bg": "#101112", "darker_bg": "#000000",
-        "selection": "#202122", "muted": "#303132", "fg": "#d0d1d2",
+        "selection": "#202122", "muted": "#303132", "color8": "#404142",
+        "fg": "#d0d1d2",
         "bright_fg": "#ffffff", "red": "#800000", "yellow": "#808000",
         "green": "#008000", "cyan": "#008080", "blue": "#000080",
         "magenta": "#800080", "bright_red": "#ff0000",
@@ -886,6 +887,9 @@ def validate_theme_generator(root: Path) -> None:
         generated = json.loads(output.read_text(encoding="utf-8"))
         assert generated["background"] == colors["bg"]
         assert generated["cursor"] == colors["accent"]
+        assert generated["selection"] == colors["selection"]
+        assert generated["active_tab_background"] == colors["color8"]
+        assert generated["active_tab_foreground"] == colors["fg"]
         assert generated["alpha"] == 0.85
         assert len(generated["ansi"]) == 16
 


### PR DESCRIPTION
## Summary

Correct the packaged theme-generator validation fixture after Plan 0041:

- provide the standard legacy `color8` fallback for `lighter_bg`;
- assert terminal selection remains independently sourced;
- assert generated active-tab background uses `color8`; and
- assert generated active-tab foreground uses the higher-contrast normal foreground.

The initial exact package build exposed this fixture gap before graphical acceptance. No runtime implementation change is included.

## Validation

- direct `tools/package/validate-package.py` rerun passed
- exact clean `tools/package/build-local-package.sh --no-check` passed
- extracted package runtime validation passed
- package SHA-256: `22f21317c17bbcfc510d99f6fdb9f3a593e7ab08736bcb8180527c8e2cac3c0b`
- `python -m py_compile tools/package/validate-package.py`
- `git diff --check`
- bounded follow-up review `fd3d8818` — CLEAN

The approved graphical smoke was aborted before mapping or input because the initial isolation harness moved the Wayland runtime; this PR does not claim graphical acceptance.
