### PR TITLE
Prepare Beta 1 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1142,7 +1142,7 @@ dependencies = [
 
 [[package]]
 name = "splinterd"
-version = "0.1.0-alpha3.3"
+version = "0.1.0-beta1"
 dependencies = [
  "anyhow",
  "nix",
@@ -1165,7 +1165,7 @@ dependencies = [
 
 [[package]]
 name = "splinterm"
-version = "0.1.0-alpha3.3"
+version = "0.1.0-beta1"
 dependencies = [
  "anyhow",
  "clap",
@@ -1195,7 +1195,7 @@ dependencies = [
 
 [[package]]
 name = "splinterm-automation-client"
-version = "0.1.0-alpha3.3"
+version = "0.1.0-beta1"
 dependencies = [
  "anyhow",
  "rustix",
@@ -1211,7 +1211,7 @@ dependencies = [
 
 [[package]]
 name = "splinterm-core"
-version = "0.1.0-alpha3.3"
+version = "0.1.0-beta1"
 dependencies = [
  "serde",
  "serde_json",
@@ -1221,7 +1221,7 @@ dependencies = [
 
 [[package]]
 name = "splinterm-filemap"
-version = "0.1.0-alpha3.3"
+version = "0.1.0-beta1"
 dependencies = [
  "memmap2",
  "rustix",
@@ -1229,7 +1229,7 @@ dependencies = [
 
 [[package]]
 name = "splinterm-freetype"
-version = "0.1.0-alpha3.3"
+version = "0.1.0-beta1"
 dependencies = [
  "freetype-rs",
  "splinterm-pixman",
@@ -1238,7 +1238,7 @@ dependencies = [
 
 [[package]]
 name = "splinterm-graphical-relay"
-version = "0.1.0-alpha3.3"
+version = "0.1.0-beta1"
 dependencies = [
  "anyhow",
  "tokio",
@@ -1247,7 +1247,7 @@ dependencies = [
 
 [[package]]
 name = "splinterm-mcp"
-version = "0.1.0-alpha3.3"
+version = "0.1.0-beta1"
 dependencies = [
  "anyhow",
  "rmcp",
@@ -1262,7 +1262,7 @@ dependencies = [
 
 [[package]]
 name = "splinterm-pixman"
-version = "0.1.0-alpha3.3"
+version = "0.1.0-beta1"
 dependencies = [
  "libc",
  "pixman-sys",
@@ -1271,7 +1271,7 @@ dependencies = [
 
 [[package]]
 name = "splinterm-protocol"
-version = "0.1.0-alpha3.3"
+version = "0.1.0-beta1"
 dependencies = [
  "base64",
  "rustix",
@@ -1284,7 +1284,7 @@ dependencies = [
 
 [[package]]
 name = "splinterm-pty"
-version = "0.1.0-alpha3.3"
+version = "0.1.0-beta1"
 dependencies = [
  "rustix",
  "thiserror",
@@ -1293,7 +1293,7 @@ dependencies = [
 
 [[package]]
 name = "splinterm-relay"
-version = "0.1.0-alpha3.3"
+version = "0.1.0-beta1"
 dependencies = [
  "anyhow",
  "nix",
@@ -1305,7 +1305,7 @@ dependencies = [
 
 [[package]]
 name = "splinterm-terminal"
-version = "0.1.0-alpha3.3"
+version = "0.1.0-beta1"
 dependencies = [
  "base64",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.1.0-alpha3.3"
+version = "0.1.0-beta1"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT"

--- a/packaging/PKGBUILD
+++ b/packaging/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: OldJobobo
 pkgbase=splinterm
 pkgname=('splinterm' 'splinterm-mcp')
-pkgver=0.1.0alpha3.3
+pkgver=0.1.0beta1
 pkgrel=1
 arch=('x86_64')
 url='https://github.com/oldjobobo/splinterm'

--- a/packaging/aur-bin/PKGBUILD
+++ b/packaging/aur-bin/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: OldJobobo
 pkgbase=splinterm-bin
 pkgname=('splinterm-bin' 'splinterm-mcp-bin')
-pkgver=0.1.0alpha3.3
+pkgver=0.1.0beta1
 pkgrel=1
 _commit=11742b60cb5b502cdadb60a582b9c3c838120d2b
 arch=('x86_64')
@@ -9,8 +9,8 @@ url='https://github.com/oldjobobo/splinterm'
 license=('MIT')
 options=('!strip' '!debug')
 source=(
-  "splinterm-$pkgver-$CARCH.pkg.tar.zst::https://github.com/OldJobobo/splinterm/releases/download/v0.1.0-alpha3.3/splinterm-$_commit-$CARCH.pkg.tar.zst"
-  "splinterm-mcp-$pkgver-$CARCH.pkg.tar.zst::https://github.com/OldJobobo/splinterm/releases/download/v0.1.0-alpha3.3/splinterm-mcp-$_commit-$CARCH.pkg.tar.zst"
+  "splinterm-$pkgver-$CARCH.pkg.tar.zst::https://github.com/OldJobobo/splinterm/releases/download/v0.1.0-beta1/splinterm-$_commit-$CARCH.pkg.tar.zst"
+  "splinterm-mcp-$pkgver-$CARCH.pkg.tar.zst::https://github.com/OldJobobo/splinterm/releases/download/v0.1.0-beta1/splinterm-mcp-$_commit-$CARCH.pkg.tar.zst"
 )
 noextract=(
   "splinterm-$pkgver-$CARCH.pkg.tar.zst"

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -1,8 +1,8 @@
 # Maintainer: OldJobobo
 pkgbase=splinterm
 pkgname=('splinterm' 'splinterm-mcp')
-pkgver=0.1.0alpha3.3
-_upstream_ver=0.1.0-alpha3.3
+pkgver=0.1.0beta1
+_upstream_ver=0.1.0-beta1
 pkgrel=1
 arch=('x86_64')
 url='https://github.com/oldjobobo/splinterm'

--- a/tools/foot-oracle/provenance.json
+++ b/tools/foot-oracle/provenance.json
@@ -59,7 +59,7 @@
   "rust": {
     "rustc": "1.91.0",
     "cargo": "1.91.0",
-    "cargo_lock_sha256": "3644c65fdcb6586371ae3f8eba82c574c8a3a7a762de140c8a2508b6bcb10ad5",
+    "cargo_lock_sha256": "355f0fce0bd86e2ce88f83408786b5c88e54b668ca5d1bd57a3415e7a64cc52a",
     "dependencies": {
       "fontdb": "0.23.0",
       "freetype-rs": "0.38.0",
@@ -112,7 +112,7 @@
     },
     "foreground": "ebebeb",
     "background": "0e1216",
-    "cargo_lock_sha256": "3644c65fdcb6586371ae3f8eba82c574c8a3a7a762de140c8a2508b6bcb10ad5"
+    "cargo_lock_sha256": "355f0fce0bd86e2ce88f83408786b5c88e54b668ca5d1bd57a3415e7a64cc52a"
   },
   "semantic_fixture_schema": "fixtures/terminal/v1/schema.md",
   "final_buffer_schema": "tools/foot-oracle/final-buffer-schema.md",


### PR DESCRIPTION
## Summary
- set the workspace release identity to `0.1.0-beta1`
- set canonical/source/binary Arch recipe identity to `0.1.0beta1-1`
- preserve the existing dependency lock while updating only workspace package versions
- update pinned portable Foot provenance to the exact resulting lockfile
- retain current-public Alpha3.3 documentation until Beta 1 is actually promoted

This is a version-only release-boundary change. No runtime behavior, installation, tag, release, or AUR repository is changed by this PR.

## Validation
- complete serialized workspace tests
- all-target warnings-denied Clippy and formatting
- release/package/automation workflow tests and ShellCheck
- portable Foot provenance and semantic fixtures
- automation/MCP contract fixtures
- 39 oracle tests and 63 benchmark tests
- exact `prepare-candidate.py check` for commit `883d2542fbeb312d93ddfb84fc43761c9165b6c5` and `0.1.0-beta1`
- clean independent read-only release review `34b4c429`
- `git diff --check` and clean worktree