### PR TITLE
Correct Beta 1 candidate metadata

### DIFF
--- a/packaging/aur-bin/PKGBUILD
+++ b/packaging/aur-bin/PKGBUILD
@@ -48,7 +48,7 @@ package_splinterm-bin() {
   )
   optdepends=(
     'fcitx5: Wayland text-input support'
-    'splinterm-mcp: explicitly configured MCP stdio adapter'
+    'splinterm-mcp-bin: explicitly configured MCP stdio adapter'
   )
   provides=("splinterm=$pkgver-$pkgrel")
   conflicts=('splinterm')

--- a/packaging/aur-bin/splinterm.install
+++ b/packaging/aur-bin/splinterm.install
@@ -1,5 +1,5 @@
 post_install() {
-  echo 'Splinterm public alpha installed for the documented Arch/Omarchy target.'
+  echo 'Splinterm installed for the documented Arch/Omarchy target.'
   echo 'Active Omarchy Quattro themes are discovered and reloaded automatically; no theme hook is required.'
   echo 'Add com.oldjobobo.splinterm.desktop to ~/.config/xdg-terminals.list when ready to make it preferred.'
   echo 'Optional Omarchy screensaver integration: splinterm integration omarchy-screensaver enable'

--- a/packaging/aur/splinterm.install
+++ b/packaging/aur/splinterm.install
@@ -1,5 +1,5 @@
 post_install() {
-  echo 'Splinterm public alpha installed for the documented Arch/Omarchy target.'
+  echo 'Splinterm installed for the documented Arch/Omarchy target.'
   echo 'Active Omarchy Quattro themes are discovered and reloaded automatically; no theme hook is required.'
   echo 'Add com.oldjobobo.splinterm.desktop to ~/.config/xdg-terminals.list when ready to make it preferred.'
   echo 'Optional Omarchy screensaver integration: splinterm integration omarchy-screensaver enable'

--- a/packaging/splinterm.install
+++ b/packaging/splinterm.install
@@ -1,5 +1,5 @@
 post_install() {
-  echo 'Splinterm public alpha installed for the documented Arch/Omarchy target.'
+  echo 'Splinterm installed for the documented Arch/Omarchy target.'
   echo 'Active Omarchy Quattro themes are discovered and reloaded automatically; no theme hook is required.'
   echo 'Add com.oldjobobo.splinterm.desktop to ~/.config/xdg-terminals.list when ready to make it preferred.'
   echo 'Optional Omarchy screensaver integration: splinterm integration omarchy-screensaver enable'

--- a/tools/release/test_prepare_candidate.py
+++ b/tools/release/test_prepare_candidate.py
@@ -20,6 +20,34 @@ class PrepareCandidateTests(unittest.TestCase):
         version = MODULE.workspace_version()
         self.assertEqual(MODULE.validate_versions(version), version.replace("-", ""))
 
+    def test_candidate_packaging_uses_version_neutral_install_copy_and_matching_split_names(self) -> None:
+        canonical_install = (ROOT / "packaging/splinterm.install").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn(
+            "Splinterm installed for the documented Arch/Omarchy target.",
+            canonical_install,
+        )
+        self.assertNotIn("public alpha", canonical_install)
+        for path in (
+            ROOT / "packaging/aur/splinterm.install",
+            ROOT / "packaging/aur-bin/splinterm.install",
+        ):
+            self.assertEqual(path.read_text(encoding="utf-8"), canonical_install)
+
+        source_recipe = (ROOT / "packaging/aur/PKGBUILD").read_text(encoding="utf-8")
+        binary_recipe = (ROOT / "packaging/aur-bin/PKGBUILD").read_text(encoding="utf-8")
+        self.assertIn(
+            "'splinterm-mcp: explicitly configured MCP stdio adapter'", source_recipe
+        )
+        self.assertIn(
+            "'splinterm-mcp-bin: explicitly configured MCP stdio adapter'",
+            binary_recipe,
+        )
+        self.assertNotIn(
+            "'splinterm-mcp: explicitly configured MCP stdio adapter'", binary_recipe
+        )
+
     def test_website_only_archive_exclusions_are_declared(self) -> None:
         attributes = (ROOT / ".gitattributes").read_text(encoding="utf-8")
         self.assertIn("/site/ export-ignore", attributes)


### PR DESCRIPTION
## Summary
- make the package install notice version-neutral instead of claiming Beta 1 is an alpha
- make `splinterm-bin` recommend its matching `splinterm-mcp-bin` split package
- add release regression coverage for canonical install-copy parity and source/binary split-package identity

These issues were found by exact-candidate review of run `32003240354`. That candidate will not be promoted. A replacement candidate will be built only after this correction merges.

## Validation
- release candidate and workflow unittests
- exact `prepare-candidate.py check` for `0.1.0-beta1`
- identical hashes for all three install scripts
- generated binary `.SRCINFO` contains `optdepends = splinterm-mcp-bin`
- Cargo formatting, ShellCheck, `git diff --check`, and clean worktree
- prior candidate review `c5d591c7` supplied both bounded findings