### PR TITLE
Record Beta 1 publication

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-Splinterm is a **public alpha**. Keep changes small, preserve
+Splinterm is a **public beta**. Keep changes small, preserve
 crate and authority boundaries, and add focused tests for domain, protocol,
 terminal, renderer, or lifecycle behavior.
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Splinterm combines a native Wayland terminal with a headless daemon that keeps s
 Humans use that persistent topology through native windows, tabs, and panes. Authorized tools can reach the same sessions through bounded JSON/NDJSON, SSH relay, and MCP interfaces. Splinterm is built in Rust from [Foot](https://codeberg.org/dnkl/foot)'s terminal behavior and designed first for Omarchy and Arch Linux.
 
 > [!IMPORTANT]
-> **Status: public alpha.** Source, immutable versioned GitHub and AUR packages, and documentation are public. Core terminal emulation, persistent sessions, multiplexing, native Wayland presentation, Arch packaging, and bounded automation workflows are implemented and validated for the current x86_64 Omarchy/Arch Linux target. The alpha may make breaking changes; broader compatibility guarantees and stable support have not been released.
+> **Status: public beta.** Source, immutable versioned GitHub and AUR packages, and documentation are public. Core terminal emulation, persistent sessions, multiplexing, native Wayland presentation, Arch packaging, and bounded automation workflows are implemented and validated for the current x86_64 Omarchy/Arch Linux target. The beta may make breaking changes; broader compatibility guarantees and stable support have not been released.
 >
 > See the repository-authoritative [current status](docs/status.md) for the exact capability and availability boundaries.
 
@@ -53,7 +53,7 @@ Foot is Splinterm's behavioral foundation, not just visual inspiration. The term
 | Sixel, practical Kitty static images, and inline iTerm2 PNG | Documented supported subsets |
 | Arch/Omarchy package | Versioned GitHub release and AUR packages validated |
 | Public source and versioned builds | Available |
-| AUR packages | Prebuilt `splinterm-bin` and source-built `splinterm`, both `0.1.0alpha3.3-1` |
+| AUR packages | Prebuilt `splinterm-bin` and source-built `splinterm`, both `0.1.0beta1-1` |
 | Stable support and broader compatibility | Not released |
 | Nix and broader distributions | Planned |
 
@@ -69,7 +69,7 @@ yay -S splinterm-bin
 yay -S splinterm-mcp-bin
 ```
 
-The source-built alternatives are `splinterm` and `splinterm-mcp`. `paru` may be used instead of `yay`. All packages remain alpha software with no stable compatibility or support-duration guarantee.
+The source-built alternatives are `splinterm` and `splinterm-mcp`. `paru` may be used instead of `yay`. All packages remain beta software with no stable compatibility or support-duration guarantee.
 
 For the newest published versioned release package, clone the public repository and run:
 

--- a/TODO.md
+++ b/TODO.md
@@ -11,9 +11,12 @@
 - [x] Pass focused non-graphical validation.
 - [x] Pass the complete serialized boundary and fresh read-only review.
 - [x] Complete separately approved packaged graphical acceptance before release.
-
-Version integration, candidate construction, publication, and AUR distribution
-remain separate release-boundary work.
+- [x] Integrate `0.1.0-beta1`, pass complete release CI and independent release
+  review, and correct the candidate metadata findings before promotion.
+- [x] Publish exact candidate `v0.1.0-beta1` through the protected release
+  environment and verify the public five-asset set byte-for-byte.
+- [x] Publish both AUR package bases as `0.1.0beta1-1` after immutable-source
+  verification.
 
 ## Alpha3.3 numbered default Dojo names
 

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -1,7 +1,7 @@
 # Splinterm Product Requirements Document
 
 - **Status:** Draft
-- **Product maturity:** Public alpha
+- **Product maturity:** Public beta
 - **As of:** 2026-08-11
 - **Strategic direction authority:** [Product roadmap](product-roadmap.md)
 - **Normative requirements authority:** This PRD after review and acceptance
@@ -151,13 +151,13 @@ The following table summarizes the current repository state. “Validated” mea
 | Sixel | Supported Foot-compatible bounded implementation. |
 | Kitty graphics | Supported practical static-image subset; not full Kitty compatibility. |
 | iTerm2 inline images | Supported bounded inline-PNG subset. |
-| JSON/NDJSON automation | Implemented as the publicly documented machine compatibility contract; alpha compatibility remains versioned and may change between releases. |
+| JSON/NDJSON automation | Implemented as the publicly documented machine compatibility contract; beta compatibility remains versioned and may change between releases. |
 | SSH stdio relay | Implemented and validated; no daemon network listener. |
 | Native remote graphical transport | Implemented and validated through Plan 0028: strict profiles, one-authentication multiplexer, endpoint-bound human-interactive workflow, remote-safe launches, namespaced recency, remote no-image/focus enforcement, lifecycle, authentication, failure handling, persistence, and reviewed real-host graphical evidence. |
 | MCP adapter | Implemented and validated as an optional separately identified package. |
 | Arch/Omarchy package and release installer | Immutable versioned GitHub/AUR packages and installation paths implemented and validated. |
 | Public source and documentation | Available. |
-| AUR packages | Prebuilt `splinterm-bin` and source-built `splinterm` available as `0.1.0alpha3.3-1`; stable support remains unreleased. |
+| AUR packages | Prebuilt `splinterm-bin` and source-built `splinterm` available as `0.1.0beta1-1`; stable support remains unreleased. |
 | Stable support policy | Not released. |
 | Nix and broader distribution | Planned. |
 | Public product/documentation website | Implemented and build/link validated; repository `docs/status.md` remains the maturity authority. |
@@ -174,8 +174,8 @@ The following table summarizes the current repository state. “Validated” mea
 - Keep human consent, trusted UI, automation policy, and control ownership visibly distinct.
 - Preserve Foot-derived behavior with reproducible differential evidence.
 - Keep ordinary text-only terminal use efficient and ensure optional image support has bounded resource cost.
-- Package and upgrade the public alpha without silently changing user-owned desktop configuration.
-- Keep current-status, usage, CLI, security, and release documentation explicit throughout the alpha.
+- Package and upgrade the public beta without silently changing user-owned desktop configuration.
+- Keep current-status, usage, CLI, security, and release documentation explicit throughout the beta.
 
 ### 8.2 Stable-release goals
 
@@ -307,7 +307,7 @@ Priority meanings:
 | `FR-PKG-02` | P0 | Installation and upgrade must verify exact artifacts, warn before ending daemon-owned shells, and report the lack of cross-version process continuity. | Implemented |
 | `FR-PKG-03` | P0 | Packaging must not edit user homes, default terminal preference, Omarchy-owned files, SSH policy, or service lingering without an explicit separate action. | Implemented |
 | `FR-PKG-04` | P1 | The MCP adapter must remain an optional exact-version split package and installation alone must grant no authority. | Implemented |
-| `FR-PKG-05` | P0 | Stable distribution must use immutable versioned source/artifact URLs, checksums, and a documented upgrade/support policy. | Public alpha GitHub and AUR artifacts are immutable, versioned, and checksummed; a stable support policy remains pending |
+| `FR-PKG-05` | P0 | Stable distribution must use immutable versioned source/artifact URLs, checksums, and a documented upgrade/support policy. | Public beta GitHub and AUR artifacts are immutable, versioned, and checksummed; a stable support policy remains pending |
 
 ## 11. Security and privacy requirements
 
@@ -403,7 +403,7 @@ Splinterm meets its defining product promise when:
 
 ### 14.2 Stable-release readiness
 
-Graduation from public alpha to a supported stable release is blocked until all
+Graduation from public beta to a supported stable release is blocked until all
 of the following are true:
 
 1. a current status document defines supported environments, validated capabilities, known limitations, deferred work, and open gates;
@@ -425,7 +425,7 @@ A new evaluator should be able to answer within one minute:
 - Why does daemon-owned persistence matter?
 - How do humans and bounded automation share one topology?
 - Which environment and capabilities are validated?
-- Why is it a public alpha rather than a stable release?
+- Why is it a public beta rather than a stable release?
 - What is the first safe workflow?
 
 ## 15. Risks and mitigations
@@ -439,7 +439,7 @@ A new evaluator should be able to answer within one minute:
 | Multiplexer concepts become harder than tmux | Primary workflow becomes inaccessible | Lead with user outcomes, native controls, clear vocabulary, and discoverable trusted menus. |
 | Optional images or history regress ordinary use | Core terminal responsiveness and memory suffer | Preserve explicit budgets, no-image gates, event-driven expiry, and benchmark matrices. |
 | Trusted UI and terminal content blur together | Spoofing or accidental authority | Keep trusted chrome visually distinct and input-isolated; never derive authority from terminal content. |
-| Public alpha packaging is mistaken for stable support | Users depend on compatibility the alpha does not promise | Keep public-alpha labeling and upgrade/lifetime warnings prominent until stable-release gates are met. |
+| Public beta packaging is mistaken for stable support | Users depend on compatibility the beta does not promise | Keep public-beta labeling and upgrade/lifetime warnings prominent until stable-release gates are met. |
 | Platform expansion dilutes the validated Omarchy path | More environments than the project can test | Require separate evidence and support decisions for each platform. |
 
 ## 16. Open product decisions
@@ -508,7 +508,7 @@ This draft synthesizes the current implementation and, principally:
 - [Plan 0036: alpha3 Wayland file-drop path insertion](plans/0036-alpha3-wayland-file-drop-path-insertion.md)
 - [Supported automation contracts](automation.md)
 - [Configuration and Foot migration](configuration.md)
-- [Public alpha packaging](packaging.md)
+- [Public beta packaging](packaging.md)
 - [Terminal image compatibility](images.md)
 
 ## 19. Draft review questions

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -241,7 +241,7 @@ in-Splint agent but are not credentials and are never accepted as proof of
 resource authority. Relaunch replaces the incarnation, and supported clients
 reconcile every hint against current public topology before selection.
 
-## Public alpha deployment
+## Public beta deployment
 
 The main Arch package installs four adjacent runtime executables—`splinterm`,
 `splinterd`, `splinterm-relay`, and `splinterm-pty-child`—plus the public-CLI-only

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -1,13 +1,13 @@
-# Public alpha Arch packaging
+# Public beta Arch packaging
 
 Release authority, candidate construction, approval boundaries, and the future
 n8n notification role are defined in [Release automation](release-automation.md).
 
-Splinterm's `packaging/PKGBUILD` produces the `0.1.0alpha3.3` split packages for
+Splinterm's `packaging/PKGBUILD` produces the `0.1.0beta1` split packages for
 reviewed local and CI builds. Its local source archive and `SKIP` checksum are
 valid only in that workflow. The current public versioned release is
-[`v0.1.0-alpha3.3`](https://github.com/OldJobobo/splinterm/releases/tag/v0.1.0-alpha3.3),
-and both AUR package bases publish `0.1.0alpha3.3-1`.
+[`v0.1.0-beta1`](https://github.com/OldJobobo/splinterm/releases/tag/v0.1.0-beta1),
+and both AUR package bases publish `0.1.0beta1-1`.
 
 The source-built AUR authority is `packaging/aur/PKGBUILD`; candidate
 construction replaces its source-archive checksum with the exact immutable
@@ -52,7 +52,7 @@ and SHA-256 package digests before downloading either package. Historical
 
 An authenticated GitHub CLI session is used when one is already available;
 otherwise the installer uses anonymous GitHub API and release downloads through
-`curl`. Authentication is not required for ordinary public alpha installs.
+`curl`. Authentication is not required for ordinary public beta installs.
 
 Before Pacman installation, the script verifies package checksums and matching
 split-package versions. It rejects a shadowing user-local client, preserves an
@@ -100,8 +100,8 @@ complete package test suite. This is the mode used by `./install.sh --source`;
 Its equivalent manual build from a clean checkout is:
 
 ```bash
-git archive --format=tar.gz --prefix=splinterm-0.1.0alpha3.3/ \
-  -o packaging/splinterm-0.1.0alpha3.3.tar.gz HEAD
+git archive --format=tar.gz --prefix=splinterm-0.1.0beta1/ \
+  -o packaging/splinterm-0.1.0beta1.tar.gz HEAD
 ```
 
 The archive honors `.gitattributes` `export-ignore` entries; website source and
@@ -120,8 +120,8 @@ creates the main package plus the explicitly optional `splinterm-mcp` split
 package without installing either. Inspect them with:
 
 ```bash
-pacman -Qlp packaging/splinterm-0.1.0alpha3.3-1-x86_64.pkg.tar.zst
-pacman -Qlp packaging/splinterm-mcp-0.1.0alpha3.3-1-x86_64.pkg.tar.zst
+pacman -Qlp packaging/splinterm-0.1.0beta1-1-x86_64.pkg.tar.zst
+pacman -Qlp packaging/splinterm-mcp-0.1.0beta1-1-x86_64.pkg.tar.zst
 namcap packaging/PKGBUILD packaging/*.pkg.tar.zst   # optional
 ```
 
@@ -233,7 +233,7 @@ The equivalent manual lifecycle is:
 
 ```bash
 systemctl --user stop splinterd.service
-sudo pacman -U packaging/splinterm-0.1.0alpha3.3-1-x86_64.pkg.tar.zst
+sudo pacman -U packaging/splinterm-0.1.0beta1-1-x86_64.pkg.tar.zst
 systemctl --user daemon-reload
 systemctl --user start splinterd.service
 ```
@@ -241,7 +241,7 @@ systemctl --user start splinterd.service
 Install the adapter only when an MCP host will be configured:
 
 ```bash
-sudo pacman -U packaging/splinterm-mcp-0.1.0alpha3.3-1-x86_64.pkg.tar.zst
+sudo pacman -U packaging/splinterm-mcp-0.1.0beta1-1-x86_64.pkg.tar.zst
 ```
 
 The guarded upgrade script upgrades `splinterm-mcp` only when that optional

--- a/docs/plans/0041-beta1-active-tab-foreground.md
+++ b/docs/plans/0041-beta1-active-tab-foreground.md
@@ -1,8 +1,8 @@
 # Plan 0041: Beta 1 active-tab foreground contrast
 
 - **Status:** Implementation, complete non-graphical validation, fresh review,
-  package validation, and packaged graphical acceptance accepted for
-  `0.1.0-beta.1`
+  package validation, and packaged graphical acceptance accepted and released
+  in `0.1.0-beta1`
 - **Date:** 2026-08-14
 - **Product authority:** Active Dojo-tab chrome derives from standard Omarchy
   and Foot roles without requiring app-specific additions to `colors.toml`; its
@@ -153,7 +153,7 @@ Work:
   Foot selection colors;
 - record focused and serial non-graphical validation;
 - inspect the actual diff and obtain one fresh read-only correctness review;
-- prepare the `0.1.0-beta.1` version/package/provenance changes only after the
+- prepare the `0.1.0-beta1` version/package/provenance changes only after the
   implementation branch is accepted; and
 - keep candidate construction, publication, and AUR distribution behind their
   existing separate approval boundaries.
@@ -226,6 +226,26 @@ temporary file, restored the recorded focus, window geometry, and pointer
 exactly, and ended with `pacman -Qkk splinterm` reporting 56 files and zero
 alterations. Evidence is recorded under
 `docs/benchmarks/artifacts/2026-08-17-plan0041-packaged-graphical/`.
+
+## Beta 1 release evidence
+
+Release-state PR #29 and candidate-metadata correction PR #30 merged into
+`main` as `40ac9d7bb803fc71495e36eb760174de7fcdfff0` and
+`8d95e75704104750f8e8e4585e629010855963c8`. Candidate run `32004316406`
+built the corrected commit once; candidate manifest SHA-256 is
+`a09bef84812c2da3cfe729099d5bcdec2c4a809b234c8a6dc8d1c7f2ccbf018e`.
+Protected promotion run `32004973522` published `v0.1.0-beta1`, redownloaded
+and verified the exact five public assets, and retained publication receipt
+artifact `9279942672`.
+
+The source archive, main package, and MCP package SHA-256 values are
+`72bd626474f2f660cf5cf595f4e9dd040dafacd2f3087d58a81f01a32d39f5ef`,
+`fb25323ca2edbb61243c942c84de4d1f4cb52280fbc7dbd4369243f603288eda`,
+and `ededfa71a10b1bb3f199e78d56c4bfc32c5633f5188c3e89790980bf3803fecc`.
+The source and prebuilt AUR package bases published `0.1.0beta1-1` as commits
+`2052214554e25218f7329e299a3fc0f076d76756` and
+`d902f0bf49f7b454480724612613dd2f35d13bd4` after both recipes passed
+`makepkg --verifysource` against the immutable release assets.
 
 ## Beta 1 acceptance
 

--- a/docs/plans/0042-beta1-wide-splint-grid.md
+++ b/docs/plans/0042-beta1-wide-splint-grid.md
@@ -487,6 +487,15 @@ Abort on input reaching the wrong Window, unrelated output reconfiguration,
 partial terminal state, protocol loop, lost history, incorrect PTY dimensions,
 stale pixels, or incomplete cleanup.
 
+## Beta1 release record
+
+The accepted maintenance implementation and corrective Dojo-picker coverage were
+forward-ported to `main` before release. Corrected candidate run `32004316406`
+built commit `8d95e75704104750f8e8e4585e629010855963c8`; protected promotion run
+`32004973522` published `v0.1.0-beta1`, and both AUR package bases published
+`0.1.0beta1-1`. Exact release hashes and package-base commits are recorded in
+[Current product status](../status.md#beta-1-release).
+
 ## Beta1 acceptance
 
 Plan 0042 is complete only when:

--- a/docs/plans/0043-beta1-sparse-publication-frames.md
+++ b/docs/plans/0043-beta1-sparse-publication-frames.md
@@ -1,9 +1,9 @@
 # Plan 0043: Beta1 sparse terminal publication frames
 
-- **Status:** Graphical aggregate retention gate failed; daemon follow-up required
+- **Status:** Accepted, integrated into maintenance and `main`, and released
 - **Date:** 2026-08-15
-- **Release decision:** Do not tag `0.1.0-beta.1` until this plan passes its
-  non-graphical, graphical, review, integration, and release gates
+- **Release decision:** All non-graphical, graphical, review, integration, and
+  release gates passed; published as `v0.1.0-beta1`
 - **Release line:** `maint/0.1`
 - **Depends on:** accepted and integrated [Plan 0042](0042-beta1-wide-splint-grid.md)
   at maintenance commit `ba8f1cd28f1aca25d83f198c593832b829601a6c`, the retained
@@ -767,3 +767,12 @@ Candidate construction, promotion, package replacement, pushing, AUR
 publication, and release publication remain separate approval boundaries. A
 daemon-only memory win, a client regression, an unaccounted queue, or a failed
 comparative gate remains a Beta1 no-go.
+
+The accepted implementation merged into `maint/0.1` as `41241288c3fbd5b1f5d2471a97b5b071cb565a5f` and
+was forward-ported to `main` as part of
+`ca1e358359d4f6083e5f5f5768950728b79ec096`. Corrected candidate run
+`32004316406` built release commit
+`8d95e75704104750f8e8e4585e629010855963c8`; protected promotion run
+`32004973522` published `v0.1.0-beta1`, and both AUR package bases published
+`0.1.0beta1-1`. Exact release hashes and package-base commits are recorded in
+[Current product status](../status.md#beta-1-release).

--- a/docs/product-roadmap.md
+++ b/docs/product-roadmap.md
@@ -2,7 +2,7 @@
 
 - **Status:** Active strategic direction
 - **Horizon model:** Now / Next / Later / Explore; no date promise
-- **Product maturity:** Public alpha
+- **Product maturity:** Public beta
 - **Current-state authority:** [Current product status](status.md)
 - **Delivery authority:** [Engineering roadmap](roadmap.md) and accepted [plans](plans/)
 
@@ -56,9 +56,9 @@ product; it does not redefine Splinterm as an “AI terminal.”
 
 The labels in this document have deliberate meanings:
 
-- **Now** — product outcomes required to turn the public alpha into a confident
+- **Now** — product outcomes required to turn the public beta into a confident
   daily driver on the validated Omarchy/Arch target.
-- **Next** — outcomes required for a supported 1.0 after the alpha/beta gates are
+- **Next** — outcomes required for a supported 1.0 after the beta gates are
   satisfied.
 - **Later** — strategic expansion that follows a trustworthy primary product.
 - **Explore** — options worth researching, not commitments.
@@ -67,7 +67,7 @@ Moving an item between horizons is a product decision. Implementation plans may
 change without changing the product outcome, but they may not silently promote
 an Explore option into a promise.
 
-## Horizon 1 — Public alpha: prove the foundation (Now)
+## Horizon 1 — Public beta: earn daily-driver confidence (Now)
 
 ### Product promise
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,7 +1,7 @@
 # Engineering roadmap
 
 > This roadmap records completed implementation phases and the dependency-ordered
-> delivery path from public alpha to a supported stable release. It is an
+> delivery path from public beta to a supported stable release. It is an
 > engineering completion ledger and forward plan, not a product strategy,
 > compatibility promise, or release date. Product direction is authoritative in
 > the [`product roadmap`](product-roadmap.md); current maturity and validated
@@ -223,7 +223,7 @@ Part 8.1 parity, scrollback, performance, and Hyprland/Omarchy sign-off are
 complete with durable evidence. Phase 9 produced and isolated-validated a
 initial private Arch prerelease package with coherent binaries, service,
 desktop/theme integration, upgrade handling, documentation, and licenses. The
-repository and immutable versioned GitHub/AUR packages are now public alpha
+repository and immutable versioned GitHub/AUR packages are now public beta
 surfaces; the early rolling edge channel has been retired, and stable-support
 commitments remain post-milestone work.
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -8,13 +8,13 @@ sequence, and this page owns what the product is today.
 
 ## Maturity
 
-**Splinterm is a public alpha.**
+**Splinterm is a public beta.**
 
 Source, documentation, and immutable versioned GitHub and AUR packages are
 publicly available. Core terminal emulation, daemon-owned persistence, multiplexing,
 native Wayland presentation, Arch packaging, and bounded automation workflows
 are implemented and validated in the scopes named below. Public availability is
-not a stable-support promise: alpha interfaces may change, the validated target
+not a stable-support promise: beta interfaces may change, the validated target
 remains narrow, and broader compatibility guarantees have not been released.
 
 Splinterm is **security-conscious**, not absolutely secure. Automation is
@@ -31,19 +31,53 @@ The current product target is:
 - native Wayland under the documented Hyprland environment;
 - Foot 1.27.0 commit `3c5b584b0eafa772eb4376fb6eaf6643399e190e`
   as the terminal-behavior oracle;
-- public Alpha3.3 `0.1.0alpha3.3-1` Arch packages built from clean committed
+- public Beta 1 `0.1.0beta1-1` Arch packages built from clean committed
   source; and
 - guarded installed-package evidence for the Alpha3 command, scrollback,
-  saved-Lair, Wayland file-drop, and Omarchy screensaver workflows, isolated
-  exact-package acceptance for the Alpha3.1 transient-tab hotfixes,
-  non-graphical release/package validation for Alpha3.2, and isolated
-  development-build graphical smoke plus release/package validation for the
-  Alpha3.3 numbered-name patch.
+  saved-Lair, Wayland file-drop, and Omarchy screensaver workflows; isolated
+  exact-package acceptance for the Alpha3.1 transient-tab hotfixes; and accepted
+  Beta 1 graphical, package, provenance, wide-grid, sparse-publication, and
+  active-tab contrast evidence.
 
 Other Linux distributions, compositors, architectures, and package formats are
 not current compatibility promises. Headless `splinterd` does not require a
-graphical environment, but its packaged and remote workflows remain alpha
+graphical environment, but its packaged and remote workflows remain beta
 interfaces on the documented platform.
+
+## Beta 1 release
+
+[`v0.1.0-beta1`](https://github.com/OldJobobo/splinterm/releases/tag/v0.1.0-beta1)
+was published as a GitHub prerelease on 2026-08-17 and distributed through both
+AUR package bases as `0.1.0beta1-1`. Beta 1 accepts wide terminal grids through
+`480×128`, bounds sparse terminal publication ownership and accounting, and
+separates active-tab contrast from terminal selection colors while retaining the
+accepted Alpha3 command, persistence, input, and Omarchy integration behavior.
+
+- Release-state PR #29 merged as
+  `40ac9d7bb803fc71495e36eb760174de7fcdfff0`; candidate-metadata correction
+  PR #30 merged as `8d95e75704104750f8e8e4585e629010855963c8`.
+- Candidate run `32004316406` built corrected commit `8d95e75` once. Candidate
+  manifest SHA-256:
+  `a09bef84812c2da3cfe729099d5bcdec2c4a809b234c8a6dc8d1c7f2ccbf018e`.
+- Protected promotion run `32004973522` created the immutable tag, published and
+  redownloaded the exact five public assets, verified every hash, and retained
+  publication receipt artifact `9279942672`.
+- Source archive SHA-256:
+  `72bd626474f2f660cf5cf595f4e9dd040dafacd2f3087d58a81f01a32d39f5ef`.
+  Main package SHA-256:
+  `fb25323ca2edbb61243c942c84de4d1f4cb52280fbc7dbd4369243f603288eda`.
+  MCP package SHA-256:
+  `ededfa71a10b1bb3f199e78d56c4bfc32c5633f5188c3e89790980bf3803fecc`.
+- AUR source package commit: `2052214554e25218f7329e299a3fc0f076d76756`.
+  AUR prebuilt package commit: `d902f0bf49f7b454480724612613dd2f35d13bd4`.
+  Both public recipes passed `makepkg --verifysource` against the immutable
+  GitHub assets before publication.
+- Complete serialized workspace tests, warnings-denied Clippy, release/package
+  automation, portable Foot provenance, package-content/runtime validation, and
+  accepted Plans 0041–0043 evidence passed. Independent candidate review found
+  alpha-specific install wording and a binary split-package recommendation;
+  both were corrected and regression-covered before the replacement candidate
+  was built or promoted.
 
 ## Alpha3.3 release
 
@@ -182,8 +216,8 @@ post-alpha3, pre-1.0 roadmap milestone.
 | Native remote graphical client | Implemented and validated | Profile-bound OpenSSH transport, native picker/window workflow, control, reconnect diagnostics, and client-local lifecycle; remote image transfer is not supported. See [Plan 0028](plans/0028-remote-graphical-client.md). |
 | MCP adapter | Implemented and validated | Optional, separately packaged, exact-identity adapter over the supported automation surface. See [MCP](mcp.md). |
 | Terminal images | Supported documented subset | Sixel, practical static Kitty, and inline iTerm2 PNG subsets are bounded; full Kitty graphics is not claimed. See [Images](images.md). |
-| Arch/Omarchy packaging | Public alpha packages validated | Immutable versioned GitHub and AUR split packages, service, desktop metadata, upgrade checks, trusted-client identity, and rollback guidance. See [Packaging](packaging.md). |
-| AUR packages | Available | Recommended prebuilt [`splinterm-bin` `0.1.0alpha3.3-1`](https://aur.archlinux.org/packages/splinterm-bin) publishes `splinterm-bin` and optional `splinterm-mcp-bin` from checksummed immutable versioned-release assets without local compilation. Source-built [`splinterm` `0.1.0alpha3.3-1`](https://aur.archlinux.org/packages/splinterm) and `splinterm-mcp` remain available. |
+| Arch/Omarchy packaging | Public beta packages validated | Immutable versioned GitHub and AUR split packages, service, desktop metadata, upgrade checks, trusted-client identity, and rollback guidance. See [Packaging](packaging.md). |
+| AUR packages | Available | Recommended prebuilt [`splinterm-bin` `0.1.0beta1-1`](https://aur.archlinux.org/packages/splinterm-bin) publishes `splinterm-bin` and optional `splinterm-mcp-bin` from checksummed immutable versioned-release assets without local compilation. Source-built [`splinterm` `0.1.0beta1-1`](https://aur.archlinux.org/packages/splinterm) and `splinterm-mcp` remain available. |
 | Public source and versioned releases | Available | The repository, documentation, protected GitHub prereleases, and AUR packages are public. The retired rolling edge channel is no longer produced or consumed. |
 | Stable support | Unreleased | No compatibility window, support duration, or formal support/security-reporting process is promised yet. |
 | Nix and broader distribution | Planned | Not current product behavior or support. |
@@ -218,7 +252,7 @@ behavior; deferred means intentionally outside the present product.
 
 ## Stable-release gates
 
-Before Splinterm can graduate from public alpha to a supported stable release,
+Before Splinterm can graduate from public beta to a supported stable release,
 maintainers must make and validate explicit decisions about:
 
 - release channels, signed/immutable source publication, upgrades, and rollback;
@@ -247,7 +281,7 @@ capabilities above; none may be inferred as a stable-support promise.
 | MCP integration | [MCP](mcp.md) |
 | Image compatibility | [Images](images.md) |
 | Service, persistence, policy, backup, and reset | [Headless operation](headless.md) |
-| Public alpha package installation and upgrades | [Packaging](packaging.md) |
+| Public beta package installation and upgrades | [Packaging](packaging.md) |
 | Product direction, audiences, and outcome horizons | [Product roadmap](product-roadmap.md) |
 | Engineering phases, dependencies, and future delivery work | [Engineering roadmap](roadmap.md) |
 | Development workflow and test guardrails | [`CONTRIBUTING.md`](../CONTRIBUTING.md) |

--- a/site/src/content/docs/docs/index.md
+++ b/site/src/content/docs/docs/index.md
@@ -84,7 +84,7 @@ hero:
 </nav>
 
 <div class="docs-home-footer">
-  <p><span>Public alpha</span> The source is open; the validated environment and compatibility promise remain intentionally narrow.</p>
+  <p><span>Public beta</span> The source is open; the validated environment and compatibility promise remain intentionally narrow.</p>
   <div>
     <a href="/docs/status/">Read current status</a>
     <a href="/docs/roadmap/">Product roadmap</a>

--- a/site/src/content/docs/docs/install.md
+++ b/site/src/content/docs/docs/install.md
@@ -1,9 +1,9 @@
 ---
 title: Installation
-description: Install or update the current Splinterm public alpha on Arch Linux and Omarchy.
+description: Install or update the current Splinterm public beta on Arch Linux and Omarchy.
 ---
 
-The validated installation target is an **x86_64 Omarchy system based on Arch Linux**. Splinterm is a public alpha, not a supported stable release; upgrades may change interfaces and end daemon-owned shells.
+The validated installation target is an **x86_64 Omarchy system based on Arch Linux**. Splinterm is a public beta, not a supported stable release; upgrades may change interfaces and end daemon-owned shells.
 
 ## Install the prebuilt AUR package
 

--- a/site/src/content/docs/docs/mcp.md
+++ b/site/src/content/docs/docs/mcp.md
@@ -8,7 +8,7 @@ description: Install the optional Splinterm MCP adapter, connect a supported hos
 The adapter is an optional, separately identified third-party client—not a trusted part of `splinterd`. Installing or launching it grants nothing until an owner-controlled policy authorizes its exact executable identity, operations, resources, and limits.
 
 :::note
-The MCP adapter is part of the public alpha. The host examples below document the currently validated local environment, not broad host compatibility or a stable API promise.
+The MCP adapter is part of the public beta. The host examples below document the currently validated local environment, not broad host compatibility or a stable API promise.
 :::
 
 ## 1. Verify the installed identity

--- a/site/src/content/docs/docs/quickstart.md
+++ b/site/src/content/docs/docs/quickstart.md
@@ -5,7 +5,7 @@ description: Open a new Splinterm terminal, detach from work, and return to the 
 
 This first workflow demonstrates Splinterm's central behavior: the graphical window can close while the daemon-owned terminal session continues running.
 
-## 1. Install the public alpha
+## 1. Install the public beta
 
 Follow [Installation](/docs/install/) from an x86_64 Omarchy/Arch system.
 

--- a/site/src/content/docs/docs/roadmap.md
+++ b/site/src/content/docs/docs/roadmap.md
@@ -1,13 +1,13 @@
 ---
 title: Roadmap
-description: Product direction from the current public alpha toward a supported persistent workspace.
+description: Product direction from the current public beta toward a supported persistent workspace.
 ---
 
 Splinterm's roadmap uses **Now / Next / Later / Explore** horizons instead of release dates. These horizons describe intended product outcomes. They are not delivery dates, implementation order, compatibility guarantees, or promises that every listed idea will ship.
 
 [Current status](/docs/status/) remains the authority for what works today. The repository [product roadmap](https://github.com/OldJobobo/splinterm/blob/main/docs/product-roadmap.md) contains the full strategic rationale, while the [engineering roadmap](https://github.com/OldJobobo/splinterm/blob/main/docs/roadmap.md) records dependency order and delivery gates.
 
-## Now: make the public alpha a confident daily driver
+## Now: make the public beta a confident daily driver
 
 The current priority is to make persistence understandable, desktop behavior coherent, and installation trustworthy on the validated x86_64 Omarchy/Arch environment.
 

--- a/site/src/content/docs/docs/status.md
+++ b/site/src/content/docs/docs/status.md
@@ -3,9 +3,9 @@ title: Current status
 description: What is implemented, validated, limited, planned, and unreleased in Splinterm.
 ---
 
-Splinterm is a **public alpha**. Source, documentation, and immutable versioned GitHub and AUR packages are public. Substantial core behavior is implemented and validated, while the validated target remains narrow and stable compatibility guarantees have not been released.
+Splinterm is a **public beta**. Source, documentation, and immutable versioned GitHub and AUR packages are public. Substantial core behavior is implemented and validated, while the validated target remains narrow and stable compatibility guarantees have not been released.
 
-[`v0.1.0-alpha3.3`](https://github.com/OldJobobo/splinterm/releases/tag/v0.1.0-alpha3.3) is the current public prerelease. It retains the Alpha3 command/keymap, scrollback, saved-Lair, Wayland file-drop, Omarchy integration, and bounded-input fixes while starting new Lairs at `Dojo 1` and giving later implicitly created Dojos predictable per-Lair names such as `Dojo 2`. Explicit names remain unchanged.
+[`v0.1.0-beta1`](https://github.com/OldJobobo/splinterm/releases/tag/v0.1.0-beta1) is the current public prerelease. It adds wide-grid support through `480×128`, bounded sparse terminal publication frames, and active-tab contrast that remains independent from terminal selection colors, while retaining the accepted Alpha3 command, persistence, input, and Omarchy integration behavior.
 
 ## What that means
 
@@ -35,7 +35,7 @@ Splinterm is a **public alpha**. Source, documentation, and immutable versioned 
 | Sixel, practical Kitty static images, inline iTerm2 PNG | Documented supported subsets |
 | Arch/Omarchy package | Versioned GitHub release and AUR packages validated |
 | Public source and versioned builds | Available |
-| [AUR packages](https://aur.archlinux.org/packages/splinterm-bin) | Recommended prebuilt `splinterm-bin`; source-built `splinterm` also available, both `0.1.0alpha3.3-1` |
+| [AUR packages](https://aur.archlinux.org/packages/splinterm-bin) | Recommended prebuilt `splinterm-bin`; source-built `splinterm` also available, both `0.1.0beta1-1` |
 | Stable support and broader compatibility | Not released |
 | Nix and broader distributions | Planned |
 
@@ -47,4 +47,4 @@ Persistent topology is also separate from graphical presentation. Creating or mu
 
 ## Before depending on it
 
-Review the [public roadmap](/docs/roadmap/) and the exact specialist documentation for the feature you intend to use. Public alpha availability is not a new compatibility guarantee; repository [`docs/status.md`](https://github.com/OldJobobo/splinterm/blob/main/docs/status.md) remains authoritative.
+Review the [public roadmap](/docs/roadmap/) and the exact specialist documentation for the feature you intend to use. Public beta availability is not a new compatibility guarantee; repository [`docs/status.md`](https://github.com/OldJobobo/splinterm/blob/main/docs/status.md) remains authoritative.

--- a/site/src/content/docs/docs/troubleshooting.md
+++ b/site/src/content/docs/docs/troubleshooting.md
@@ -3,7 +3,7 @@ title: Troubleshooting
 description: Diagnose common local Splinterm installation, daemon, session, and configuration problems.
 ---
 
-This page covers the first local checks. Splinterm is a public alpha with a narrow validated Omarchy/Arch environment, so failures outside that target may not have a supported resolution.
+This page covers the first local checks. Splinterm is a public beta with a narrow validated Omarchy/Arch environment, so failures outside that target may not have a supported resolution.
 
 ## Check the installed command
 

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -8,7 +8,7 @@ const capabilities = [
   ['Panes, tabs, and restore', 'Validated'],
   ['Bounded automation', 'Validated'],
   ['Versioned public builds', 'Available'],
-  ['AUR alpha package', 'Available'],
+  ['AUR beta package', 'Available'],
 ];
 ---
 
@@ -19,29 +19,29 @@ const capabilities = [
   <section class="intro-hero" aria-labelledby="intro-title">
     <img class="intro-mark" src="/logo-transparent.png" alt="" width="768" height="768" />
     <h1 id="intro-title" class="intro-wordmark">splinterm</h1>
-    <p class="intro-status">Public alpha · Arch / Omarchy · x86_64</p>
+    <p class="intro-status">Public beta · Arch / Omarchy · x86_64</p>
     <p class="intro-thesis">A native Wayland terminal where the window can close and the work keeps running.</p>
     <div class="intro-actions" aria-label="Get started with Splinterm">
-      <a class="button primary intro-primary" href="/docs/install/">Install the alpha <span aria-hidden="true">↗</span></a>
+      <a class="button primary intro-primary" href="/docs/install/">Install the beta <span aria-hidden="true">↗</span></a>
       <a class="button secondary" href="#workflow">See the workflow <span aria-hidden="true">↓</span></a>
     </div>
     <div class="intro-install" aria-label="Recommended installation command">
       <span>Recommended</span>
       <code><i aria-hidden="true">$</i> yay -S splinterm-bin</code>
-      <a href="/docs/status/">Read alpha limits</a>
+      <a href="/docs/status/">Read beta limits</a>
     </div>
   </section>
 
   <section id="product" class="hero shell-section" aria-labelledby="product-title">
     <div class="hero-copy">
-      <p class="eyebrow"><span>Public alpha</span> · Enter the Lair</p>
+      <p class="eyebrow"><span>Public beta</span> · Enter the Lair</p>
       <h2 id="product-title">Your shell should outlive its <em>window.</em></h2>
       <p class="hero-lede">
         Splinterm keeps your work below the surface: Lairs hold projects, Dojos hold working
         sessions, and Splints keep their shells alive when graphical clients disappear.
       </p>
       <div class="hero-actions">
-        <a class="button primary" href="/docs/install/">Install the alpha <span aria-hidden="true">↗</span></a>
+        <a class="button primary" href="/docs/install/">Install the beta <span aria-hidden="true">↗</span></a>
         <a class="button secondary" href="#workflow">See the three-step workflow</a>
       </div>
       <p class="hero-note">Built in Rust from Foot’s terminal behavior. Quietly disciplined for Omarchy.</p>
@@ -235,7 +235,7 @@ const capabilities = [
     <div class="status-intro">
       <h2 id="status-title">The doors are open.<br />The edges stay marked.</h2>
       <p>
-        Splinterm is a public alpha. Source, documentation, and immutable versioned GitHub and AUR
+        Splinterm is a public beta. Source, documentation, and immutable versioned GitHub and AUR
         packages are open; the validated target remains narrow and stable compatibility guarantees do not exist yet.
       </p>
       <div class="status-actions">
@@ -258,9 +258,9 @@ const capabilities = [
     <div>
       <p class="eyebrow">The ordinary path into the Lair</p>
       <h2 id="workflow-title">Leave the window.<br />Return to the Dojo.</h2>
-      <p>Install the current public alpha from the AUR, open a Splint, then use the Dojo picker whenever you want the running work back.</p>
+      <p>Install the current public beta from the AUR, open a Splint, then use the Dojo picker whenever you want the running work back.</p>
       <div class="hero-actions">
-        <a class="button primary" href="/docs/install/">Install the alpha</a>
+        <a class="button primary" href="/docs/install/">Install the beta</a>
         <a class="button workflow-secondary" href="/docs/quickstart/">Follow the full quickstart <span aria-hidden="true">→</span></a>
       </div>
     </div>

--- a/site/src/pages/roadmap.astro
+++ b/site/src/pages/roadmap.astro
@@ -5,7 +5,7 @@ const horizons = [
   {
     number: '01',
     label: 'Now',
-    stage: 'Public alpha',
+    stage: 'Public beta',
     title: 'Earn daily-driver confidence.',
     summary: 'Make persistence understandable, desktop behavior coherent, and installation trustworthy on the environment Splinterm can validate today.',
     outcomes: [
@@ -73,7 +73,7 @@ const horizons = [
       <p class="eyebrow"><span>Direction, not a deadline</span> · Product roadmap</p>
       <h1 id="roadmap-title">The work persists.<br /><em>The promise grows carefully.</em></h1>
       <p>
-        Splinterm is moving from a capable public alpha toward a supported persistent workspace.
+        Splinterm is moving from a capable public beta toward a supported persistent workspace.
         The horizons below describe outcomes—not dates, feature quotas, or compatibility guarantees.
       </p>
       <div class="hero-actions">
@@ -83,7 +83,7 @@ const horizons = [
     </div>
     <div class="roadmap-compass" aria-label="Current roadmap position">
       <span>Current position</span>
-      <strong>Public alpha</strong>
+      <strong>Public beta</strong>
       <div class="compass-line" aria-hidden="true"><i></i><i></i><i></i><i></i></div>
       <ol>
         <li class="active">Confidence</li>


### PR DESCRIPTION
## Summary
- record the exact corrected candidate, protected promotion, public hashes, and AUR commits for `v0.1.0-beta1`
- mark Plans 0041–0043 released and close the Beta 1 release-boundary TODOs
- update repository, packaging, product, roadmap, and website maturity from public alpha to public beta
- publish current AUR identity `0.1.0beta1-1` across user-facing status surfaces

## Release evidence
- release commit: `8d95e75704104750f8e8e4585e629010855963c8`
- candidate run: `32004316406`
- manifest: `a09bef84812c2da3cfe729099d5bcdec2c4a809b234c8a6dc8d1c7f2ccbf018e`
- promotion run: `32004973522`
- receipt artifact: `9279942672`
- AUR source: `2052214554e25218f7329e299a3fc0f076d76756`
- AUR binary: `d902f0bf49f7b454480724612613dd2f35d13bd4`

## Validation
- release/package workflow tests
- Astro check and static build
- 560 generated local page/asset links
- Cargo formatting and `git diff --check`
- public release byte-identical to approved candidate
- both AUR recipes passed `makepkg --verifysource` before push