### PR TITLE
Guard daemon against workload exhaustion

### DIFF
--- a/dist/systemd/user/splinterd.service
+++ b/dist/systemd/user/splinterd.service
@@ -10,6 +10,10 @@ ExecStart=/usr/bin/splinterd
 ExecReload=/usr/bin/kill -HUP $MAINPID
 Restart=on-failure
 RestartSec=1
+# Bound aggregate daemon and terminal workload pressure. Per-Dojo isolation is
+# a separate architectural boundary; do not treat MemoryHigh as a hard limit.
+TasksMax=2048
+MemoryHigh=75%
 KillSignal=SIGINT
 KillMode=mixed
 TimeoutStopSec=90

--- a/docs/headless.md
+++ b/docs/headless.md
@@ -37,6 +37,31 @@ service account, or enable the unit. For a dedicated service account, the
 administrator must provision the account, its home/runtime ownership, login or
 lingering policy, and the exact automation executable policy independently.
 
+## Aggregate resource guard
+
+The packaged unit limits the complete daemon cgroup to 2,048 tasks and sets its
+memory-high boundary to 75%. The task ceiling makes a recursive process spawn
+fail before it approaches the user manager's much larger inherited ceiling.
+`MemoryHigh` asks the kernel to reclaim and throttle under sustained pressure;
+it is not a hard memory limit.
+
+These settings cover `splinterd` and every process launched through its PTYs.
+They reduce the blast radius of a runaway command, but they do not isolate one
+Dojo from another. Per-Dojo or per-Splint cgroups require a separate process
+ownership design.
+
+Inspect the effective settings and current use without changing the service:
+
+```bash
+systemctl --user show splinterd.service \
+  -p TasksCurrent -p TasksMax -p MemoryCurrent -p MemoryHigh -p MemoryMax
+```
+
+`MemoryCurrent` includes page cache charged to the service cgroup. Inactive file
+cache is normally reclaimable under pressure, but it is neither immediately
+free nor excluded from cgroup accounting. Do not use `drop_caches` as routine
+Splinterm recovery.
+
 ## Install an owner-only policy
 
 The unit optionally reads `%h/.config/splinterm/daemon.env`. `EnvironmentFile`

--- a/docs/plans/0045-daemon-resource-exhaustion-guard.md
+++ b/docs/plans/0045-daemon-resource-exhaustion-guard.md
@@ -1,6 +1,7 @@
 # Plan 0045: Daemon resource-exhaustion guard
 
-- **Status:** Implemented and independently reviewed; awaiting integration
+- **Status:** Implemented and independently reviewed in
+  [PR #34](https://github.com/OldJobobo/splinterm/pull/34); awaiting integration
 - **Date:** 2026-08-22
 - **Scope:** Immediate aggregate service guard and packaged defaults
 - **Follow-up:** Per-Dojo or per-Splint cgroup isolation

--- a/docs/plans/0045-daemon-resource-exhaustion-guard.md
+++ b/docs/plans/0045-daemon-resource-exhaustion-guard.md
@@ -1,0 +1,135 @@
+# Plan 0045: Daemon resource-exhaustion guard
+
+- **Status:** Implemented and independently reviewed; awaiting integration
+- **Date:** 2026-08-22
+- **Scope:** Immediate aggregate service guard and packaged defaults
+- **Follow-up:** Per-Dojo or per-Splint cgroup isolation
+
+## Incident
+
+At 2026-08-22 18:57 PDT, `systemd-oomd` killed
+`splinterd.service`. Systemd recorded 19 GB peak service memory, 25.3 GB peak
+service swap, and 38,074 killed processes while host memory and swap were above
+the 90% kill threshold. The service restarted automatically, but its
+daemon-owned processes were gone and the graphical clients lost their live
+Dojos.
+
+The triggering workload was not a daemon allocator leak. A migration test
+created a `python3` stub, saved a mise shim as the supposed real interpreter,
+and then invoked that shim under a `PATH` which resolved `python3` back to the
+stub. The resulting recursive process storm ran inside a Splint. Because the
+PTY helper and all of its descendants inherit `splinterd.service`'s cgroup, the
+workload and daemon shared one resource boundary. `systemd-oomd` therefore
+selected and killed the complete service cgroup.
+
+## Hotfix decision
+
+Add aggregate limits to the packaged user unit:
+
+```ini
+TasksMax=2048
+MemoryHigh=75%
+```
+
+`TasksMax` is the primary incident guard. It makes a recursive spawn fail with
+resource exhaustion before approaching the user manager's inherited 38,271-task
+ceiling. `MemoryHigh` is a reclaim and throttling boundary which gives the
+kernel earlier pressure feedback; it is not a hard memory ceiling.
+
+Do not add an aggregate `MemoryMax` in this hotfix. All Splints still share the
+service cgroup, so a hard service-level memory event can damage or terminate
+unrelated Dojos. Do not claim that these aggregate settings provide per-Dojo
+isolation.
+
+## Runtime mitigation
+
+The incident host received the equivalent transient properties without
+restarting the daemon:
+
+```bash
+systemctl --user set-property --runtime splinterd.service \
+  TasksMax=2048 \
+  MemoryHigh=75%
+```
+
+The effective cgroup reported `pids.max=2048` and
+`memory.high=25130590208`; `splinterd.service` remained active and its current
+Dojo remained listed. These transient properties disappear when the user
+manager restarts or when explicitly reverted.
+
+## Implementation
+
+1. Add the two limits to `dist/systemd/user/splinterd.service`.
+2. Require the exact settings in the package validator.
+3. Document that the limits cover the aggregate daemon and terminal workload,
+   how to inspect them, and why `MemoryHigh` may include reclaimable page cache.
+4. Keep the triggering migration-test correction in its owning Omarchy
+   repository; do not mix that unrelated source change into this branch.
+
+## Validation
+
+Run the following non-graphical checks:
+
+```bash
+systemd-analyze verify --user dist/systemd/user/splinterd.service
+python tools/package/validate-package.py --help
+python -m unittest discover -s tools/package -p 'test_systemd_unit.py'
+git diff --check
+```
+
+Use the repository's actual focused package command if the validator does not
+expose the assumed test module. Inspect the complete diff before independent
+review. Do not reproduce the original recursive workload. Any exhaustion probe
+must use a separate transient user scope with a small task ceiling, memory
+ceiling, and timeout; graphical testing is out of scope.
+
+## Validation result
+
+The implementation passed the following non-graphical checks on 2026-08-22:
+
+- `python -m unittest discover -s tools/package -p 'test_*.py' -v` — 15 tests
+  passed;
+- `systemd-analyze verify --user dist/systemd/user/splinterd.service` — passed
+  with no diagnostics;
+- `python -m py_compile tools/package/validate-package.py
+  tools/package/test_systemd_unit.py` — passed; and
+- `git diff --check` — passed.
+
+A fresh read-only reviewer inspected the complete scoped files and parent-supplied
+`origin/main` diff. The review decision was `PASS`, with no blocker or fix worth
+doing now. It retained the aggregate-cgroup and non-hard-memory-boundary limits
+below as residual risks.
+
+## Acceptance
+
+- The packaged unit has an aggregate 2,048-task ceiling and 75% memory-high
+  boundary.
+- Package validation fails if either setting is absent.
+- Unit syntax and focused package tests pass.
+- Documentation does not describe page cache as free memory or the aggregate
+  guard as per-Dojo isolation.
+- Independent review finds no blocker.
+
+## Rollback
+
+The live transient guard can be removed without restarting the daemon:
+
+```bash
+systemctl --user set-property --runtime splinterd.service \
+  TasksMax=infinity \
+  MemoryHigh=infinity
+```
+
+A packaged rollback removes the two unit properties, runs
+`systemctl --user daemon-reload`, and leaves restart timing to the user because
+a daemon restart terminates daemon-owned processes on the current release.
+
+## Architectural follow-up
+
+Move terminal workloads out of the daemon control plane's resource boundary.
+Each Dojo or Splint should receive its own delegated cgroup with a bounded task
+count and configurable memory policy. Exhaustion must affect only the offending
+workload while the daemon reconciles its exit and keeps unrelated topology
+alive. That work requires a separate plan covering transient-unit ownership,
+PTY spawn and adoption, daemon handoff, cleanup, persistence, and upgrade
+compatibility.

--- a/site/src/content/docs/docs/troubleshooting.md
+++ b/site/src/content/docs/docs/troubleshooting.md
@@ -29,6 +29,21 @@ systemctl --user start splinterd.service
 
 The default socket is `$XDG_RUNTIME_DIR/splinterm/splinterd.sock`. A development instance may use another path through `SPLINTERM_SOCKET`.
 
+## The daemon restarted after a heavy workload
+
+Check whether systemd recorded an out-of-memory result and inspect the effective aggregate limits:
+
+```bash
+systemctl --user show splinterd.service \
+  -p Result -p NRestarts -p TasksCurrent -p TasksMax \
+  -p MemoryCurrent -p MemoryHigh -p MemoryMax
+journalctl --user-unit splinterd.service -n 50 --no-pager
+```
+
+The packaged task ceiling protects the service from unbounded recursive process creation, while `MemoryHigh` causes reclaim and throttling rather than imposing a hard memory ceiling. Both settings apply to the daemon and all PTY descendants together; they are not per-Dojo isolation. `MemoryCurrent` also includes charged page cache, some of which may be reclaimable under pressure.
+
+After a daemon restart, inspect exited topology with `splinterm list --all`. Restoration is explicit because Splinterm never reruns saved commands automatically.
+
 ## A window exits as unauthorized
 
 Check all of the following:

--- a/tools/package/test_systemd_unit.py
+++ b/tools/package/test_systemd_unit.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Regression tests for the packaged splinterd resource guard."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+VALIDATOR_PATH = ROOT / "tools/package/validate-package.py"
+SPEC = importlib.util.spec_from_file_location(
+    "splinterm_package_validator", VALIDATOR_PATH
+)
+assert SPEC is not None and SPEC.loader is not None
+VALIDATOR = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(VALIDATOR)
+
+
+class SystemdUnitTest(unittest.TestCase):
+    def fixture_root(self, directory: Path, unit: str) -> Path:
+        root = directory / "root"
+        target = root / "usr/lib/systemd/user/splinterd.service"
+        target.parent.mkdir(parents=True)
+        target.write_text(unit, encoding="utf-8")
+        return root
+
+    def test_packaged_unit_passes_resource_validation(self) -> None:
+        unit = (ROOT / "dist/systemd/user/splinterd.service").read_text(
+            encoding="utf-8"
+        )
+        with tempfile.TemporaryDirectory(prefix="splinterm-unit-") as value:
+            VALIDATOR.validate_systemd_unit(self.fixture_root(Path(value), unit))
+
+    def test_validator_rejects_each_missing_resource_guard(self) -> None:
+        unit = (ROOT / "dist/systemd/user/splinterd.service").read_text(
+            encoding="utf-8"
+        )
+        for setting in ("TasksMax=2048", "MemoryHigh=75%"):
+            with self.subTest(setting=setting):
+                candidate = unit.replace(f"{setting}\n", "", 1)
+                with tempfile.TemporaryDirectory(prefix="splinterm-unit-") as value:
+                    with self.assertRaisesRegex(AssertionError, setting):
+                        VALIDATOR.validate_systemd_unit(
+                            self.fixture_root(Path(value), candidate)
+                        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/package/validate-package.py
+++ b/tools/package/validate-package.py
@@ -194,12 +194,17 @@ def validate_systemd_unit(root: Path) -> None:
         "UnsetEnvironment=SPLINTERM_ENABLE_DEV_ATTACH",
         "ExecStart=/usr/bin/splinterd",
         "ExecReload=/usr/bin/kill -HUP $MAINPID",
+        "TasksMax=2048",
+        "MemoryHigh=75%",
         "KillSignal=SIGINT",
         "KillMode=mixed",
         "TimeoutStopSec=90",
     }
     missing = {line for line in required if line not in unit.splitlines()}
-    assert not missing, f"systemd unit is missing headless safety settings: {sorted(missing)}"
+    assert not missing, (
+        "systemd unit is missing headless safety or resource settings: "
+        f"{sorted(missing)}"
+    )
     assert "graphical-session.target" not in unit
     unset_environment = {
         name


### PR DESCRIPTION
## Problem

A recursive process-spawn storm inside a Splint reached 38,074 processes and drove the shared `splinterd.service` cgroup into severe memory and swap pressure. `systemd-oomd` killed the complete service, which restarted without its former live Dojos.

The immediate trigger was an external migration-test interpreter recursion rather than a daemon allocator leak. Splinterm amplified the blast radius because the daemon and every PTY descendant shared the unit's effectively unbounded resource boundary.

## Change

- set aggregate packaged service guards:
  - `TasksMax=2048`
  - `MemoryHigh=75%`
- require both directives in package validation
- add regression coverage proving validation rejects either missing guard
- document aggregate cgroup behavior, page-cache accounting, diagnostics, rollback, and the per-Dojo isolation limitation
- record Plan 0045 and retain per-Dojo/per-Splint cgroups as a separate architectural follow-up

This intentionally does **not** add an aggregate `MemoryMax`; a hard limit on the still-shared service cgroup could terminate unrelated Dojos.

## Validation

- `python -m unittest discover -s tools/package -p 'test_*.py' -v` — 15 passed
- `systemd-analyze verify --user dist/systemd/user/splinterd.service` — passed with no diagnostics
- `python -m py_compile tools/package/validate-package.py tools/package/test_systemd_unit.py` — passed
- `git diff --check` — passed
- fresh independent read-only review — **PASS**, no blockers or fixes worth doing now

## Runtime evidence

The equivalent transient properties were applied to the incident host without restarting the daemon. The effective cgroup reported `pids.max=2048` and `memory.high=25130590208`; the daemon remained active and its current Dojo remained listed.

## Residual risk

The limits remain aggregate. Task exhaustion or memory throttling can affect unrelated Dojos, and `MemoryHigh` does not guarantee prevention of a later OOM event. True fault isolation requires the separately planned per-Dojo or per-Splint cgroup boundary.

## Release

Please include this hotfix in the next release from `main`.
