### PR TITLE
Bind Beta 2 candidate to Beta 1

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -7,6 +7,10 @@ on:
         description: Exact Cargo SemVer to prepare (for example 0.1.0-alpha3)
         required: true
         type: string
+      previous_version_tag:
+        description: Exact existing predecessor tag (for example v0.1.0-beta1)
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -64,11 +68,13 @@ jobs:
       - name: Fail fast on candidate identity or recipe drift
         env:
           CANDIDATE_VERSION: ${{ inputs.version }}
+          PREVIOUS_VERSION_TAG: ${{ inputs.previous_version_tag }}
         run: |
           python tools/release/prepare-candidate.py check \
             --repository "$GITHUB_REPOSITORY" \
             --commit "${GITHUB_SHA,,}" \
-            --version "$CANDIDATE_VERSION"
+            --version "$CANDIDATE_VERSION" \
+            --previous-version-tag "$PREVIOUS_VERSION_TAG"
 
       - name: Build and validate split packages once
         run: |
@@ -79,6 +85,7 @@ jobs:
       - name: Assemble closed candidate artifact
         env:
           CANDIDATE_VERSION: ${{ inputs.version }}
+          PREVIOUS_VERSION_TAG: ${{ inputs.previous_version_tag }}
         run: |
           main_package=$(find packaging -maxdepth 1 -type f -name 'splinterm-[0-9]*.pkg.tar.zst' -print -quit)
           mcp_package=$(find packaging -maxdepth 1 -type f -name 'splinterm-mcp-[0-9]*.pkg.tar.zst' -print -quit)
@@ -89,6 +96,7 @@ jobs:
             --repository "$GITHUB_REPOSITORY" \
             --commit "${GITHUB_SHA,,}" \
             --version "$CANDIDATE_VERSION" \
+            --previous-version-tag "$PREVIOUS_VERSION_TAG" \
             --workflow-run "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
             --splinterm "$main_package" \
             --splinterm-mcp "$mcp_package" \

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,9 +1,5 @@
 # Splinterm 0.1.0 Beta 2 — Persistence With an Exit
 
-> **Release state:** candidate preparation. Beta 1 remains the current public
-> release until the reviewed Beta 2 candidate passes graphical acceptance and
-> protected promotion.
-
 Splinterm remains persistent by default. Beta 2 adds a deliberate alternative:
 an ordinary unnamed graphical terminal can belong to its Window and disappear
 when that Window closes. The moment you organize that terminal into a named or
@@ -132,10 +128,9 @@ reopen Splinterm windows after the package replacement.
 - Beta 1 tags and packages remain immutable.
 - Beta 2 still targets x86_64 Omarchy/Arch Linux with native Wayland.
 
-## Before publication
+## Validation boundary
 
-The Beta 2 implementation has passed serialized workspace, package,
+The Beta 2 implementation passed serialized workspace, package,
 release-tooling, portable Foot-provenance, documentation, independent review,
-and guarded staged-package graphical boundaries. Candidate construction,
-protected GitHub promotion, AUR distribution, and local system installation
-remain separate approval-gated operations.
+real-systemd workload-placement, local installation, and guarded staged-package
+graphical boundaries before publication.

--- a/crates/splinterd/src/main.rs
+++ b/crates/splinterd/src/main.rs
@@ -9869,9 +9869,14 @@ mod tests {
         cleanup_connection(&state, owner_id).await;
         assert!(state.topology.read().await.find_lair(lair.id).is_some());
         let runtimes = state.runtimes.lock().await.drain();
+        state.exit_observers.close();
         for runtime in runtimes {
             let _ = runtime.shutdown().await;
         }
+        time::timeout(EXIT_OBSERVER_TIMEOUT, state.exit_observers.wait())
+            .await
+            .expect("exit observers did not finish before metadata cleanup");
+        drop(state);
         std::fs::remove_dir_all(base).unwrap();
     }
 

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -7,7 +7,10 @@ Splinterm's `packaging/PKGBUILD` prepares the `0.1.0beta2` split packages for
 reviewed local and CI candidate builds. Its local source archive and `SKIP` checksum are
 valid only in that workflow. The current public versioned release is
 [`v0.1.0-beta1`](https://github.com/OldJobobo/splinterm/releases/tag/v0.1.0-beta1),
-and both AUR package bases publish `0.1.0beta1-1`.
+and both AUR package bases publish `0.1.0beta1-1`. The closed
+`packaging/release-state.json` record is the machine-readable authority for that
+current public predecessor; candidate construction rejects a different supplied
+tag even when it exists.
 
 The source-built AUR authority is `packaging/aur/PKGBUILD`; candidate
 construction replaces its source-archive checksum with the exact immutable

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -9,8 +9,11 @@ valid only in that workflow. The current public versioned release is
 [`v0.1.0-beta1`](https://github.com/OldJobobo/splinterm/releases/tag/v0.1.0-beta1),
 and both AUR package bases publish `0.1.0beta1-1`. The closed
 `packaging/release-state.json` record is the machine-readable authority for that
-current public predecessor; candidate construction rejects a different supplied
-tag even when it exists.
+current public predecessor; candidate construction and promotion both reject a
+different supplied tag even when it exists. `docs/status.md` carries the same
+exact current-version marker, and release tooling rejects disagreement. The
+post-publication release-record PR must update both files atomically before any
+later candidate is prepared.
 
 The source-built AUR authority is `packaging/aur/PKGBUILD`; candidate
 construction replaces its source-archive checksum with the exact immutable

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,5 +1,7 @@
 # Current product status
 
+- **Current public version tag:** `v0.1.0-beta1`
+
 This document is the repository authority for Splinterm's current maturity,
 validated product scope, availability, and release gates. The [product roadmap](product-roadmap.md)
 owns strategic direction, and this page owns what the product is today.

--- a/packaging/release-state.json
+++ b/packaging/release-state.json
@@ -1,0 +1,4 @@
+{
+  "schema": 1,
+  "current_version_tag": "v0.1.0-beta1"
+}

--- a/tools/release/prepare-candidate.py
+++ b/tools/release/prepare-candidate.py
@@ -175,19 +175,22 @@ def create_source_archive(commit: str, version: str, output: Path) -> None:
         raise ValueError("source archive is missing package build inputs")
 
 
-def create_notes(commit: str, version: str, output: Path) -> str | None:
-    tags = run(
-        ["git", "tag", "--sort=-version:refname", "--merged", commit]
-    ).splitlines()
-    version_tags = [
-        tag for tag in tags if tag.startswith("v") and SEMVER.fullmatch(tag[1:])
-    ]
-    previous = version_tags[0] if version_tags else None
-    range_spec = f"{previous}..{commit}" if previous else commit
-    entries = run(["git", "log", "--format=- %s (`%h`)", range_spec])
-    lines = [f"# Splinterm {version}", "", "## Changes", "", entries or "- Initial release", ""]
-    output.write_text("\n".join(lines), encoding="utf-8")
+def validate_previous_version_tag(previous: str, release_tag: str) -> str:
+    if not previous.startswith("v") or SEMVER.fullmatch(previous[1:]) is None:
+        raise ValueError("previous version tag must be a complete v-prefixed SemVer value")
+    if previous == release_tag:
+        raise ValueError("previous version tag must differ from the candidate tag")
+    resolved = run(["git", "rev-parse", f"refs/tags/{previous}^{{commit}}"])
+    if COMMIT.fullmatch(resolved) is None:
+        raise ValueError("previous version tag does not resolve to a commit")
     return previous
+
+
+def create_notes(commit: str, output: Path) -> None:
+    notes = run(["git", "show", f"{commit}:RELEASE_NOTES.md"])
+    if not notes:
+        raise ValueError("candidate RELEASE_NOTES.md is empty")
+    output.write_text(notes + "\n", encoding="utf-8")
 
 
 def asset_record(path: Path, kind: str, root: Path) -> dict[str, str]:
@@ -198,7 +201,9 @@ def asset_record(path: Path, kind: str, root: Path) -> dict[str, str]:
     }
 
 
-def validate_candidate(repository: str, commit: str, version: str) -> tuple[str, str]:
+def validate_candidate(
+    repository: str, commit: str, version: str, previous_version_tag: str
+) -> tuple[str, str, str]:
     if REPOSITORY.fullmatch(repository) is None:
         raise ValueError("repository must be an owner/name pair")
     commit = commit.lower()
@@ -210,12 +215,16 @@ def validate_candidate(repository: str, commit: str, version: str) -> tuple[str,
     tag = f"v{version}"
     if run(["git", "tag", "--list", tag]):
         raise ValueError(f"release tag already exists: {tag}")
-    return commit, package_version
+    previous_version_tag = validate_previous_version_tag(previous_version_tag, tag)
+    return commit, package_version, previous_version_tag
 
 
 def assemble(arguments: argparse.Namespace) -> dict[str, Any]:
-    commit, package_version = validate_candidate(
-        arguments.repository, arguments.commit, arguments.version
+    commit, package_version, previous_version_tag = validate_candidate(
+        arguments.repository,
+        arguments.commit,
+        arguments.version,
+        arguments.previous_version_tag,
     )
     tag = f"v{arguments.version}"
     output = arguments.output.resolve()
@@ -255,7 +264,7 @@ def assemble(arguments: argparse.Namespace) -> dict[str, Any]:
     binary_srcinfo = write_srcinfo(binary_recipe)
 
     notes = output / "RELEASE-NOTES.md"
-    previous_tag = create_notes(commit, arguments.version, notes)
+    create_notes(commit, notes)
     assets = [
         asset_record(source_archive, "source-archive", output),
         asset_record(main_package, "arch-package", output),
@@ -279,7 +288,7 @@ def assemble(arguments: argparse.Namespace) -> dict[str, Any]:
         "package_version": package_version,
         "tag": tag,
         "architecture": "x86_64",
-        "previous_version_tag": previous_tag,
+        "previous_version_tag": previous_version_tag,
         "workflow_run": arguments.workflow_run,
         "assets": assets,
     }
@@ -302,6 +311,7 @@ def parser() -> argparse.ArgumentParser:
         command.add_argument("--repository", required=True)
         command.add_argument("--commit", required=True)
         command.add_argument("--version", required=True)
+        command.add_argument("--previous-version-tag", required=True)
     create.add_argument("--workflow-run", required=True)
     create.add_argument("--splinterm", type=Path, required=True)
     create.add_argument("--splinterm-mcp", type=Path, required=True)
@@ -313,10 +323,21 @@ def main() -> int:
     arguments = parser().parse_args()
     try:
         if arguments.command == "check":
-            commit, package_version = validate_candidate(
-                arguments.repository, arguments.commit, arguments.version
+            commit, package_version, previous_version_tag = validate_candidate(
+                arguments.repository,
+                arguments.commit,
+                arguments.version,
+                arguments.previous_version_tag,
             )
-            print(json.dumps({"commit": commit, "package_version": package_version}))
+            print(
+                json.dumps(
+                    {
+                        "commit": commit,
+                        "package_version": package_version,
+                        "previous_version_tag": previous_version_tag,
+                    }
+                )
+            )
         else:
             manifest = assemble(arguments)
             print(json.dumps(manifest, sort_keys=True))

--- a/tools/release/prepare-candidate.py
+++ b/tools/release/prepare-candidate.py
@@ -175,11 +175,27 @@ def create_source_archive(commit: str, version: str, output: Path) -> None:
         raise ValueError("source archive is missing package build inputs")
 
 
+def current_public_release_tag() -> str:
+    path = ROOT / "packaging/release-state.json"
+    try:
+        state = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise ValueError("packaging/release-state.json is invalid") from error
+    if set(state) != {"schema", "current_version_tag"} or state["schema"] != 1:
+        raise ValueError("packaging/release-state.json has an unexpected shape")
+    tag = state["current_version_tag"]
+    if not isinstance(tag, str) or not tag.startswith("v") or SEMVER.fullmatch(tag[1:]) is None:
+        raise ValueError("current public release tag must be a complete v-prefixed SemVer value")
+    return tag
+
+
 def validate_previous_version_tag(previous: str, release_tag: str) -> str:
     if not previous.startswith("v") or SEMVER.fullmatch(previous[1:]) is None:
         raise ValueError("previous version tag must be a complete v-prefixed SemVer value")
     if previous == release_tag:
         raise ValueError("previous version tag must differ from the candidate tag")
+    if previous != current_public_release_tag():
+        raise ValueError("previous version tag does not match the current public release")
     resolved = run(["git", "rev-parse", f"refs/tags/{previous}^{{commit}}"])
     if COMMIT.fullmatch(resolved) is None:
         raise ValueError("previous version tag does not resolve to a commit")

--- a/tools/release/prepare-candidate.py
+++ b/tools/release/prepare-candidate.py
@@ -186,6 +186,12 @@ def current_public_release_tag() -> str:
     tag = state["current_version_tag"]
     if not isinstance(tag, str) or not tag.startswith("v") or SEMVER.fullmatch(tag[1:]) is None:
         raise ValueError("current public release tag must be a complete v-prefixed SemVer value")
+    status = (ROOT / "docs/status.md").read_text(encoding="utf-8")
+    matches = re.findall(
+        r"^- \*\*Current public version tag:\*\* `([^`]+)`$", status, re.MULTILINE
+    )
+    if matches != [tag]:
+        raise ValueError("documented and machine-readable public release tags disagree")
     return tag
 
 

--- a/tools/release/promote-release.py
+++ b/tools/release/promote-release.py
@@ -26,6 +26,7 @@ EXPECTED_KINDS = {
     "release-notes-draft": 1,
 }
 RELEASE_BRANCHES = {"main", "maint/0.1"}
+ROOT = Path(__file__).resolve().parents[2]
 
 
 def sha256(path: Path) -> str:
@@ -48,6 +49,16 @@ def load_json(path: Path, label: str) -> dict[str, Any]:
     if not isinstance(value, dict):
         raise ValueError(f"{label} must be a JSON object")
     return value
+
+
+def current_public_release_tag() -> str:
+    state = load_json(ROOT / "packaging/release-state.json", "release state")
+    if set(state) != {"schema", "current_version_tag"} or state["schema"] != 1:
+        raise ValueError("release state has an unexpected shape")
+    tag = state["current_version_tag"]
+    if not isinstance(tag, str) or not tag.startswith("v") or SEMVER.fullmatch(tag[1:]) is None:
+        raise ValueError("current public release tag is malformed")
+    return tag
 
 
 def safe_relative(value: Any) -> str:
@@ -174,8 +185,10 @@ def verify_candidate(
     if manifest["tag"] != f"v{version}" or manifest["architecture"] != "x86_64":
         raise ValueError("candidate tag or architecture does not match")
     previous = manifest["previous_version_tag"]
-    if previous is not None and (not isinstance(previous, str) or not previous.startswith("v") or SEMVER.fullmatch(previous[1:]) is None):
+    if not isinstance(previous, str) or not previous.startswith("v") or SEMVER.fullmatch(previous[1:]) is None:
         raise ValueError("candidate previous version tag is malformed")
+    if previous != current_public_release_tag():
+        raise ValueError("candidate predecessor does not match current public release state")
     run_match = RUN_URL.fullmatch(manifest["workflow_run"] if isinstance(manifest["workflow_run"], str) else "")
     if run_match is None or run_match.group(1).lower() != repository.lower() or int(run_match.group(2)) != run_id:
         raise ValueError("candidate workflow run does not match approval input")

--- a/tools/release/test_prepare_candidate.py
+++ b/tools/release/test_prepare_candidate.py
@@ -164,11 +164,21 @@ class PrepareCandidateTests(unittest.TestCase):
             MODULE.validate_previous_version_tag("0.1.0-beta1", release_tag)
         with self.assertRaisesRegex(ValueError, "must differ"):
             MODULE.validate_previous_version_tag(release_tag, release_tag)
+        with self.assertRaisesRegex(ValueError, "current public release"):
+            MODULE.validate_previous_version_tag("v0.1.0-alpha3.3", release_tag)
         with (
             mock.patch.object(MODULE, "run", side_effect=ValueError("missing tag")),
             self.assertRaisesRegex(ValueError, "missing tag"),
         ):
-            MODULE.validate_previous_version_tag("v9.9.9-beta1", release_tag)
+            MODULE.validate_previous_version_tag("v0.1.0-beta1", release_tag)
+
+    def test_public_release_state_is_closed_and_versioned(self) -> None:
+        self.assertEqual(MODULE.current_public_release_tag(), "v0.1.0-beta1")
+        state = json.loads(
+            (ROOT / "packaging/release-state.json").read_text(encoding="utf-8")
+        )
+        self.assertEqual(set(state), {"schema", "current_version_tag"})
+        self.assertEqual(state["schema"], 1)
 
     def test_release_notes_are_read_from_the_exact_candidate_commit(self) -> None:
         commit = MODULE.run(["git", "rev-parse", "HEAD"])

--- a/tools/release/test_prepare_candidate.py
+++ b/tools/release/test_prepare_candidate.py
@@ -138,12 +138,43 @@ class PrepareCandidateTests(unittest.TestCase):
             self.skipTest(f"repository does not contain historical tag {tag}")
         commit = MODULE.run(["git", "rev-parse", "HEAD"])
         with self.assertRaisesRegex(ValueError, "release tag already exists"):
-            MODULE.validate_candidate("OldJobobo/splinterm", commit, version)
+            MODULE.validate_candidate(
+                "OldJobobo/splinterm", commit, version, "v0.1.0-beta1"
+            )
 
     def test_mismatched_version_fails_before_build(self) -> None:
         commit = MODULE.run(["git", "rev-parse", "HEAD"])
         with self.assertRaisesRegex(ValueError, "does not match Cargo.toml"):
-            MODULE.validate_candidate("OldJobobo/splinterm", commit, "9.9.9-alpha9")
+            MODULE.validate_candidate(
+                "OldJobobo/splinterm",
+                commit,
+                "9.9.9-alpha9",
+                "v0.1.0-beta1",
+            )
+
+    def test_previous_release_is_explicit_existing_and_distinct(self) -> None:
+        release_tag = "v9.9.9-beta2"
+        self.assertEqual(
+            MODULE.validate_previous_version_tag("v0.1.0-beta1", release_tag),
+            "v0.1.0-beta1",
+        )
+        with self.assertRaisesRegex(ValueError, "v-prefixed SemVer"):
+            MODULE.validate_previous_version_tag("0.1.0-beta1", release_tag)
+        with self.assertRaisesRegex(ValueError, "must differ"):
+            MODULE.validate_previous_version_tag(release_tag, release_tag)
+        with self.assertRaisesRegex(ValueError, "command failed"):
+            MODULE.validate_previous_version_tag("v9.9.9-beta1", release_tag)
+
+    def test_release_notes_are_read_from_the_exact_candidate_commit(self) -> None:
+        commit = MODULE.run(["git", "rev-parse", "HEAD"])
+        with tempfile.TemporaryDirectory(prefix="splinterm-release-notes-") as value:
+            output = Path(value) / "RELEASE-NOTES.md"
+            MODULE.create_notes(commit, output)
+            self.assertEqual(
+                output.read_text(encoding="utf-8"),
+                MODULE.run(["git", "show", f"{commit}:RELEASE_NOTES.md"]) + "\n",
+            )
+            self.assertIn("Workload isolation", output.read_text(encoding="utf-8"))
 
     def test_manifest_example_is_json_serializable(self) -> None:
         manifest = {

--- a/tools/release/test_prepare_candidate.py
+++ b/tools/release/test_prepare_candidate.py
@@ -179,6 +179,10 @@ class PrepareCandidateTests(unittest.TestCase):
         )
         self.assertEqual(set(state), {"schema", "current_version_tag"})
         self.assertEqual(state["schema"], 1)
+        status = (ROOT / "docs/status.md").read_text(encoding="utf-8")
+        self.assertEqual(
+            status.count("**Current public version tag:** `v0.1.0-beta1`"), 1
+        )
 
     def test_release_notes_are_read_from_the_exact_candidate_commit(self) -> None:
         commit = MODULE.run(["git", "rev-parse", "HEAD"])

--- a/tools/release/test_prepare_candidate.py
+++ b/tools/release/test_prepare_candidate.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import subprocess
 import tempfile
 import unittest
+from unittest import mock
 
 ROOT = Path(__file__).resolve().parents[2]
 SCRIPT = ROOT / "tools/release/prepare-candidate.py"
@@ -154,15 +155,19 @@ class PrepareCandidateTests(unittest.TestCase):
 
     def test_previous_release_is_explicit_existing_and_distinct(self) -> None:
         release_tag = "v9.9.9-beta2"
-        self.assertEqual(
-            MODULE.validate_previous_version_tag("v0.1.0-beta1", release_tag),
-            "v0.1.0-beta1",
-        )
+        with mock.patch.object(MODULE, "run", return_value="a" * 40):
+            self.assertEqual(
+                MODULE.validate_previous_version_tag("v0.1.0-beta1", release_tag),
+                "v0.1.0-beta1",
+            )
         with self.assertRaisesRegex(ValueError, "v-prefixed SemVer"):
             MODULE.validate_previous_version_tag("0.1.0-beta1", release_tag)
         with self.assertRaisesRegex(ValueError, "must differ"):
             MODULE.validate_previous_version_tag(release_tag, release_tag)
-        with self.assertRaisesRegex(ValueError, "command failed"):
+        with (
+            mock.patch.object(MODULE, "run", side_effect=ValueError("missing tag")),
+            self.assertRaisesRegex(ValueError, "missing tag"),
+        ):
             MODULE.validate_previous_version_tag("v9.9.9-beta1", release_tag)
 
     def test_release_notes_are_read_from_the_exact_candidate_commit(self) -> None:

--- a/tools/release/test_promote_release.py
+++ b/tools/release/test_promote_release.py
@@ -21,7 +21,9 @@ RUN_ID = 12345
 
 
 class CandidateFixture:
-    def __init__(self, root: Path) -> None:
+    def __init__(
+        self, root: Path, previous_version_tag: str = "v0.1.0-beta1"
+    ) -> None:
         self.root = root
         self.assets = MODULE.expected_assets(COMMIT, VERSION)
         records = []
@@ -43,7 +45,7 @@ class CandidateFixture:
             "package_version": VERSION.replace("-", ""),
             "tag": f"v{VERSION}",
             "architecture": "x86_64",
-            "previous_version_tag": "v1.2.3-alpha3",
+            "previous_version_tag": previous_version_tag,
             "workflow_run": f"https://github.com/{REPOSITORY}/actions/runs/{RUN_ID}",
             "assets": records,
         }
@@ -122,6 +124,18 @@ class PromoteReleaseTests(unittest.TestCase):
             self.assertIn("candidate-manifest.json", promotion["public_assets"])
             self.assertIn("SHA256SUMS", promotion["public_assets"])
             self.assertNotIn("aur-source/PKGBUILD", promotion["public_assets"])
+
+    def test_candidate_rejects_a_stale_predecessor_even_when_well_formed(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="splinterm-promotion-") as value:
+            fixture = CandidateFixture(Path(value), "v0.1.0-alpha3.3")
+            with self.assertRaisesRegex(ValueError, "current public release state"):
+                MODULE.verify_candidate(
+                    fixture.root,
+                    REPOSITORY,
+                    RUN_ID,
+                    COMMIT,
+                    fixture.manifest_sha256,
+                )
 
     def test_candidate_rejects_tampering_extra_files_and_unsafe_paths(self) -> None:
         with tempfile.TemporaryDirectory(prefix="splinterm-promotion-") as value:

--- a/tools/release/test_release_candidate_workflow.py
+++ b/tools/release/test_release_candidate_workflow.py
@@ -15,6 +15,8 @@ class ReleaseCandidateWorkflowTests(unittest.TestCase):
         self.assertNotIn("\n  pull_request:", workflow)
         self.assertIn("permissions:\n  contents: read", workflow)
         self.assertIn("refs/heads/main|refs/heads/maint/0.1", workflow)
+        self.assertIn("previous_version_tag:", workflow)
+        self.assertEqual(workflow.count("--previous-version-tag"), 2)
         self.assertNotIn("contents: write", workflow)
         self.assertNotIn("environment:", workflow)
         self.assertNotIn("secrets.", workflow)


### PR DESCRIPTION
## Summary

- require an explicit existing previous SemVer tag for release-candidate construction
- bind that predecessor into the closed candidate manifest instead of inferring ancestry
- copy reviewed `RELEASE_NOTES.md` from the exact candidate commit
- preserve the non-publishing candidate and protected promotion boundaries

## Why

The reviewed `maint/0.1` line and published `v0.1.0-beta1` tag have divergent ancestry. Automatic `--merged` discovery therefore selected `v0.1.0-alpha3.3` for the otherwise valid Beta 2 candidate. The release must explicitly identify Beta 1 as its predecessor.

## Validation

- 28 release automation tests (one expected existing-tag skip)
- exact candidate preflight with `v0.1.0-beta1`
- Python compilation and workflow YAML parsing
- `git diff --check`
