### PR TITLE
Render missing glyphs through Fontconfig fallback

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -89,6 +89,13 @@ represents the requested weight and slant, and has compatible terminal-cell
 metrics. When no compatible style exists, Splinterm warns and deliberately
 reuses the regular face instead of refusing to open a Window.
 
+New clients also resolve Fontconfig's ordered outline fallback set once during
+renderer initialization. Symbols missing from the primary, CJK, and emoji faces
+now use the first installed fallback face that covers the complete cell instead
+of immediately rendering the replacement character. Fallback files are lazily
+mapped through a 24-entry evictable cache alongside the existing bounded glyph
+and raster-face caches.
+
 This corrects startup for families such as CaskaydiaMono and for regular-only
 families. Already-open Windows still retain immutable renderer resources; live
 font-family replacement remains planned for the 0.2 line.

--- a/crates/splinterm/src/renderer/fonts.rs
+++ b/crates/splinterm/src/renderer/fonts.rs
@@ -2,7 +2,7 @@
 
 use std::{
     cell::RefCell,
-    collections::{HashMap, VecDeque},
+    collections::{HashMap, HashSet, VecDeque},
     path::PathBuf,
     process::Command,
     sync::{Arc, OnceLock},
@@ -31,6 +31,7 @@ pub(super) const EMOJI_FONT: &str = "Noto Color Emoji";
 pub(super) const SNAPSHOT_GLYPH_CACHE_BUDGET: usize = 2_048;
 pub(super) const SNAPSHOT_GLYPH_CACHE_BYTE_BUDGET: usize = 64 * 1024 * 1024;
 pub(super) const SNAPSHOT_RASTER_FACE_BUDGET: usize = 24;
+pub(super) const SNAPSHOT_FALLBACK_MAPPING_BUDGET: usize = 24;
 
 pub(super) const SNAPSHOT_PRIMARY_REGULAR: usize = 0;
 pub(super) const SNAPSHOT_PRIMARY_BOLD: usize = 1;
@@ -38,8 +39,35 @@ pub(super) const SNAPSHOT_PRIMARY_ITALIC: usize = 2;
 pub(super) const SNAPSHOT_PRIMARY_BOLD_ITALIC: usize = 3;
 pub(super) const SNAPSHOT_CJK: usize = 4;
 pub(super) const SNAPSHOT_EMOJI: usize = 5;
+pub(super) const SNAPSHOT_FALLBACK_START: usize = 6;
 
-pub(super) static SNAPSHOT_FACES: OnceLock<Result<[FontFace; 6], String>> = OnceLock::new();
+pub(super) static SNAPSHOT_FACES: OnceLock<Result<Vec<FontFace>, String>> = OnceLock::new();
+
+#[derive(Default)]
+pub(super) struct PersistentFontMappingCache {
+    pub(super) mappings: HashMap<PathBuf, Arc<ReadOnlyFileMap>>,
+    pub(super) order: VecDeque<PathBuf>,
+    pub(super) hits: u64,
+    pub(super) misses: u64,
+    pub(super) evictions: u64,
+}
+
+impl PersistentFontMappingCache {
+    fn insert(&mut self, key: PathBuf, mapping: Arc<ReadOnlyFileMap>) -> Arc<ReadOnlyFileMap> {
+        while self.mappings.len() >= SNAPSHOT_FALLBACK_MAPPING_BUDGET {
+            let Some(oldest) = self.order.pop_front() else {
+                break;
+            };
+            if self.mappings.remove(&oldest).is_some() {
+                self.evictions = self.evictions.saturating_add(1);
+            }
+        }
+        self.order.push_back(key.clone());
+        self.mappings.insert(key, Arc::clone(&mapping));
+        mapping
+    }
+}
+
 #[derive(Default)]
 pub(super) struct PersistentGlyphCache {
     pub(super) raster_faces: HashMap<(isize, usize), RasterFace>,
@@ -116,10 +144,15 @@ impl PersistentGlyphCache {
 thread_local! {
     pub(super) static SNAPSHOT_GLYPH_CACHE: RefCell<PersistentGlyphCache> =
         RefCell::new(PersistentGlyphCache::default());
+    pub(super) static SNAPSHOT_FALLBACK_MAPPING_CACHE: RefCell<PersistentFontMappingCache> =
+        RefCell::new(PersistentFontMappingCache::default());
 }
 
 pub(super) fn clear_snapshot_caches() {
     SNAPSHOT_GLYPH_CACHE.with(|cache| *cache.borrow_mut() = PersistentGlyphCache::default());
+    SNAPSHOT_FALLBACK_MAPPING_CACHE.with(|cache| {
+        *cache.borrow_mut() = PersistentFontMappingCache::default();
+    });
 }
 
 pub(super) const CORPUS: &[(CorpusKind, &str)] = &[
@@ -158,7 +191,9 @@ pub(super) struct FontFace {
     pub(super) weight: i32,
     pub(super) slant: i32,
     pub(super) selected_pixel_size_26_6: isize,
-    pub(super) data: OnceLock<Result<ReadOnlyFileMap, String>>,
+    pub(super) outline: bool,
+    pub(super) coverage: Box<[(u32, u32)]>,
+    pub(super) data: Option<OnceLock<Result<ReadOnlyFileMap, String>>>,
 }
 
 impl FontFace {
@@ -172,12 +207,23 @@ impl FontFace {
             weight: self.weight,
             slant: self.slant,
             selected_pixel_size_26_6: self.selected_pixel_size_26_6,
-            data: OnceLock::new(),
+            outline: self.outline,
+            coverage: self.coverage.clone(),
+            data: Some(OnceLock::new()),
         }
     }
 
     fn identity(&self) -> (&std::path::Path, usize) {
         (&self.path, self.index)
+    }
+
+    pub(super) fn covers_text(&self, text: &str) -> bool {
+        text.chars().all(|character| {
+            let codepoint = u32::from(character);
+            self.coverage
+                .iter()
+                .any(|(start, end)| (*start..=*end).contains(&codepoint))
+        })
     }
 }
 
@@ -498,13 +544,13 @@ pub(super) fn cache_glyph(
     Ok(())
 }
 
-pub(super) fn snapshot_faces() -> Result<&'static [FontFace; 6]> {
+pub(super) fn snapshot_faces() -> Result<&'static [FontFace]> {
     SNAPSHOT_FACES
         .get_or_init(|| {
+            let primary_pattern = &renderer_options().font;
             let [regular, bold, italic, bold_italic] =
-                resolve_primary_faces(&renderer_options().font)
-                    .map_err(|error| error.to_string())?;
-            Ok([
+                resolve_primary_faces(primary_pattern).map_err(|error| error.to_string())?;
+            let mut faces = Vec::from([
                 regular,
                 bold,
                 italic,
@@ -513,9 +559,22 @@ pub(super) fn snapshot_faces() -> Result<&'static [FontFace; 6]> {
                     .map_err(|error| error.to_string())?,
                 resolve_face("emoji fallback", EMOJI_FONT, "noto color emoji")
                     .map_err(|error| error.to_string())?,
-            ])
+            ]);
+            let excluded = faces
+                .iter()
+                .map(|face| (face.path.clone(), face.index))
+                .collect::<HashSet<_>>();
+            let fallback_faces = resolve_fallback_faces(primary_pattern, &excluded)
+                .map_err(|error| error.to_string())?;
+            eprintln!(
+                "Resolved {} ordered Fontconfig fallback faces",
+                fallback_faces.len()
+            );
+            faces.extend(fallback_faces);
+            Ok(faces)
         })
         .as_ref()
+        .map(Vec::as_slice)
         .map_err(|error| anyhow::anyhow!(error.clone()))
 }
 
@@ -635,7 +694,7 @@ pub(super) fn snapshot_color_advance(
 }
 
 pub(super) fn reset_snapshot_cache() {
-    SNAPSHOT_GLYPH_CACHE.with(|cache| *cache.borrow_mut() = PersistentGlyphCache::default());
+    clear_snapshot_caches();
 }
 
 pub(super) fn evict_snapshot_glyphs() -> usize {
@@ -668,20 +727,28 @@ pub(super) fn process_rss_bytes() -> Option<u64> {
 /// Returns bounded persistent snapshot-glyph-cache metrics.
 #[must_use]
 pub fn snapshot_cache_metrics() -> serde_json::Value {
-    SNAPSHOT_GLYPH_CACHE.with(|cache| {
-        let cache = cache.borrow();
-        serde_json::json!({
-            "entries": cache.glyphs.len(),
-            "raster_faces": cache.raster_faces.len(),
-            "budget": SNAPSHOT_GLYPH_CACHE_BUDGET,
-            "glyph_budget": SNAPSHOT_GLYPH_CACHE_BUDGET,
-            "glyph_byte_budget": SNAPSHOT_GLYPH_CACHE_BYTE_BUDGET,
-            "raster_face_budget": SNAPSHOT_RASTER_FACE_BUDGET,
-            "hits": cache.hits,
-            "misses": cache.misses,
-            "evictions": cache.evictions,
-            "raster_face_evictions": cache.raster_face_evictions,
-            "approximate_bytes": cache.glyph_bytes,
+    SNAPSHOT_GLYPH_CACHE.with(|glyph_cache| {
+        SNAPSHOT_FALLBACK_MAPPING_CACHE.with(|mapping_cache| {
+            let glyph_cache = glyph_cache.borrow();
+            let mapping_cache = mapping_cache.borrow();
+            serde_json::json!({
+                "entries": glyph_cache.glyphs.len(),
+                "raster_faces": glyph_cache.raster_faces.len(),
+                "fallback_mappings": mapping_cache.mappings.len(),
+                "budget": SNAPSHOT_GLYPH_CACHE_BUDGET,
+                "glyph_budget": SNAPSHOT_GLYPH_CACHE_BUDGET,
+                "glyph_byte_budget": SNAPSHOT_GLYPH_CACHE_BYTE_BUDGET,
+                "raster_face_budget": SNAPSHOT_RASTER_FACE_BUDGET,
+                "fallback_mapping_budget": SNAPSHOT_FALLBACK_MAPPING_BUDGET,
+                "hits": glyph_cache.hits,
+                "misses": glyph_cache.misses,
+                "evictions": glyph_cache.evictions,
+                "raster_face_evictions": glyph_cache.raster_face_evictions,
+                "fallback_mapping_hits": mapping_cache.hits,
+                "fallback_mapping_misses": mapping_cache.misses,
+                "fallback_mapping_evictions": mapping_cache.evictions,
+                "approximate_bytes": glyph_cache.glyph_bytes,
+            })
         })
     })
 }
@@ -1109,17 +1176,106 @@ pub(super) fn ceil_to_i32(value: f32) -> i32 {
     value.ceil() as i32
 }
 
-pub(super) fn resolve_face(
-    label: &'static str,
-    pattern: &str,
-    expected_family_fragment: &str,
-) -> Result<FontFace> {
-    let output = Command::new("fc-match")
-        .args([
-            "-f",
-            "%{file}\\n%{index}\\n%{family[0]}\\n%{style}\\n%{weight}\\n%{slant}\\n%{pixelsize}\\n",
-            pattern,
-        ])
+const FONTCONFIG_FACE_FORMAT: &str = "%{file}\\n%{index}\\n%{family[0]}\\n%{style}\\n%{weight}\\n%{slant}\\n%{pixelsize}\\n%{outline}\\n%{charset}\\n--record--\\n";
+
+fn parse_fontconfig_charset(value: &str) -> Result<Box<[(u32, u32)]>> {
+    value
+        .split_whitespace()
+        .map(|range| {
+            let (start, end) = range.split_once('-').unwrap_or((range, range));
+            let start = u32::from_str_radix(start, 16)
+                .with_context(|| format!("invalid Fontconfig charset start {start:?}"))?;
+            let end = u32::from_str_radix(end, 16)
+                .with_context(|| format!("invalid Fontconfig charset end {end:?}"))?;
+            anyhow::ensure!(
+                start <= end && end <= u32::from(char::MAX),
+                "invalid Fontconfig charset range {range:?}"
+            );
+            Ok((start, end))
+        })
+        .collect::<Result<Vec<_>>>()
+        .map(Vec::into_boxed_slice)
+}
+
+fn parse_fontconfig_faces(label: &'static str, stdout: &[u8]) -> Result<Vec<FontFace>> {
+    let stdout = std::str::from_utf8(stdout).context("fc-match output is not UTF-8")?;
+    stdout
+        .split("--record--\n")
+        .filter(|record| !record.trim().is_empty())
+        .map(|record| {
+            let mut lines = record.lines();
+            let path = PathBuf::from(
+                lines
+                    .next()
+                    .with_context(|| format!("fc-match returned no font path for {label}"))?,
+            );
+            let index = lines
+                .next()
+                .with_context(|| format!("fc-match returned no face index for {label}"))?
+                .parse::<usize>()
+                .with_context(|| {
+                    format!("fc-match returned a non-numeric face index for {label}")
+                })?;
+            let family = lines
+                .next()
+                .with_context(|| format!("fc-match returned no font family for {label}"))?
+                .to_owned();
+            let style = lines
+                .next()
+                .with_context(|| format!("fc-match returned no style for {label}"))?
+                .to_owned();
+            let weight = lines
+                .next()
+                .with_context(|| format!("fc-match returned no weight for {label}"))?
+                .parse::<i32>()
+                .with_context(|| format!("fc-match returned a non-numeric weight for {label}"))?;
+            let slant = lines
+                .next()
+                .with_context(|| format!("fc-match returned no slant for {label}"))?
+                .parse::<i32>()
+                .with_context(|| format!("fc-match returned a non-numeric slant for {label}"))?;
+            let selected_pixel_size = lines
+                .next()
+                .with_context(|| format!("fc-match returned no pixel size for {label}"))?
+                .parse::<f32>()
+                .with_context(|| format!("fc-match returned an invalid pixel size for {label}"))?;
+            let outline = match lines
+                .next()
+                .with_context(|| format!("fc-match returned no outline flag for {label}"))?
+            {
+                "True" => true,
+                "False" => false,
+                value => bail!("fc-match returned an invalid outline flag {value:?} for {label}"),
+            };
+            let coverage = parse_fontconfig_charset(
+                lines
+                    .next()
+                    .with_context(|| format!("fc-match returned no charset for {label}"))?,
+            )?;
+            Ok(FontFace {
+                label,
+                family,
+                style,
+                path,
+                index,
+                weight,
+                slant,
+                selected_pixel_size_26_6: pixel_size_26_6(selected_pixel_size)?,
+                outline,
+                coverage,
+                data: Some(OnceLock::new()),
+            })
+        })
+        .collect()
+}
+
+fn run_fontconfig_faces(label: &'static str, pattern: &str, sorted: bool) -> Result<Vec<FontFace>> {
+    let mut command = Command::new("fc-match");
+    if sorted {
+        command.arg("-s");
+    }
+    let output = command
+        .args(["-f", FONTCONFIG_FACE_FORMAT, pattern])
         .output()
         .with_context(|| format!("run fc-match for {label}"))?;
     if !output.status.success() {
@@ -1128,58 +1284,26 @@ pub(super) fn resolve_face(
             String::from_utf8_lossy(&output.stderr)
         );
     }
-    let stdout = String::from_utf8(output.stdout).context("fc-match output is not UTF-8")?;
-    let mut lines = stdout.lines();
-    let path = PathBuf::from(
-        lines
-            .next()
-            .with_context(|| format!("fc-match returned no font path for {label}"))?,
-    );
-    let index = lines
+    parse_fontconfig_faces(label, &output.stdout)
+}
+
+pub(super) fn resolve_face(
+    label: &'static str,
+    pattern: &str,
+    expected_family_fragment: &str,
+) -> Result<FontFace> {
+    let face = run_fontconfig_faces(label, pattern, false)?
+        .into_iter()
         .next()
-        .with_context(|| format!("fc-match returned no face index for {label}"))?
-        .parse::<usize>()
-        .with_context(|| format!("fc-match returned a non-numeric face index for {label}"))?;
-    let family = lines
-        .next()
-        .with_context(|| format!("fc-match returned no font family for {label}"))?
-        .to_owned();
-    let style = lines
-        .next()
-        .with_context(|| format!("fc-match returned no style for {label}"))?
-        .to_owned();
-    let weight = lines
-        .next()
-        .with_context(|| format!("fc-match returned no weight for {label}"))?
-        .parse::<i32>()
-        .with_context(|| format!("fc-match returned a non-numeric weight for {label}"))?;
-    let slant = lines
-        .next()
-        .with_context(|| format!("fc-match returned no slant for {label}"))?
-        .parse::<i32>()
-        .with_context(|| format!("fc-match returned a non-numeric slant for {label}"))?;
-    let selected_pixel_size = lines
-        .next()
-        .with_context(|| format!("fc-match returned no pixel size for {label}"))?
-        .parse::<f32>()
-        .with_context(|| format!("fc-match returned an invalid pixel size for {label}"))?;
-    let selected_pixel_size_26_6 = pixel_size_26_6(selected_pixel_size)?;
-    let normalized_family = normalize_family(&family);
+        .with_context(|| format!("fc-match returned no face for {label}"))?;
+    let normalized_family = normalize_family(&face.family);
     let normalized_expected = normalize_family(expected_family_fragment);
     if !normalized_expected.is_empty() && !normalized_family.contains(&normalized_expected) {
-        bail!("explicit {label} pattern {pattern:?} resolved unexpectedly to {family:?}");
+        bail!(
+            "explicit {label} pattern {pattern:?} resolved unexpectedly to {:?}",
+            face.family
+        );
     }
-    let face = FontFace {
-        label,
-        family,
-        style,
-        path,
-        index,
-        weight,
-        slant,
-        selected_pixel_size_26_6,
-        data: OnceLock::new(),
-    };
     eprintln!(
         "Resolved {label}: {} {} (face {}, {})",
         face.family,
@@ -1188,6 +1312,21 @@ pub(super) fn resolve_face(
         face.path.display()
     );
     Ok(face)
+}
+
+fn resolve_fallback_faces(
+    pattern: &str,
+    excluded: &HashSet<(PathBuf, usize)>,
+) -> Result<Vec<FontFace>> {
+    let mut identities = excluded.clone();
+    Ok(run_fontconfig_faces("fontconfig fallback", pattern, true)?
+        .into_iter()
+        .filter(|face| face.outline && identities.insert((face.path.clone(), face.index)))
+        .map(|mut face| {
+            face.data = None;
+            face
+        })
+        .collect())
 }
 
 #[derive(Clone, Copy)]
@@ -1326,6 +1465,8 @@ fn resolve_primary_faces(pattern: &str) -> Result<[FontFace; 4]> {
 
 pub(super) fn font_data(face: &FontFace) -> Result<&[u8]> {
     face.data
+        .as_ref()
+        .context("fallback font data requires the bounded mapping cache")?
         .get_or_init(|| {
             ReadOnlyFileMap::open(&face.path)
                 .with_context(|| format!("map {}", face.path.display()))
@@ -1346,6 +1487,41 @@ pub(super) fn font_ref(face: &FontFace) -> Result<FontRef<'_>> {
     })
 }
 
+fn fallback_font_mapping(face: &FontFace) -> Result<Arc<ReadOnlyFileMap>> {
+    let key = face.path.clone();
+    SNAPSHOT_FALLBACK_MAPPING_CACHE.with(|cache| {
+        let mut cache = cache.borrow_mut();
+        if let Some(mapping) = cache.mappings.get(&key).cloned() {
+            cache.hits = cache.hits.saturating_add(1);
+            return Ok(mapping);
+        }
+        cache.misses = cache.misses.saturating_add(1);
+        let mapping = Arc::new(
+            ReadOnlyFileMap::open(&face.path)
+                .with_context(|| format!("map fallback font {}", face.path.display()))?,
+        );
+        Ok(cache.insert(key, mapping))
+    })
+}
+
+pub(super) fn with_font_ref<T>(
+    face: &FontFace,
+    use_font: impl FnOnce(FontRef<'_>) -> Result<T>,
+) -> Result<T> {
+    if face.data.is_some() {
+        return use_font(font_ref(face)?);
+    }
+    let mapping = fallback_font_mapping(face)?;
+    let font = FontRef::from_index(&mapping, face.index).with_context(|| {
+        format!(
+            "parse fallback {} face {} with Swash",
+            face.path.display(),
+            face.index
+        )
+    })?;
+    use_font(font)
+}
+
 pub(super) fn select_glyph(
     faces: &[FontFace; 3],
     kind: CorpusKind,
@@ -1359,7 +1535,11 @@ pub(super) fn select_glyph(
     order
         .iter()
         .find_map(|face_index| {
-            let glyph = font_ref(&faces[*face_index]).ok()?.charmap().map(character);
+            let face = &faces[*face_index];
+            if !face.covers_text(&character.to_string()) {
+                return None;
+            }
+            let glyph = font_ref(face).ok()?.charmap().map(character);
             (glyph != 0).then_some((*face_index, glyph))
         })
         .with_context(|| format!("no explicit font covers U+{:04X}", u32::from(character)))
@@ -1453,8 +1633,47 @@ mod tests {
             weight,
             slant,
             selected_pixel_size_26_6: 12 * 64,
-            data: OnceLock::new(),
+            outline: true,
+            coverage: Box::new([]),
+            data: Some(OnceLock::new()),
         }
+    }
+
+    #[test]
+    fn fontconfig_charset_parser_covers_singletons_ranges_and_non_bmp_codepoints() {
+        let coverage = parse_fontconfig_charset("20-7e 21d5 1f4e6-1f4e7").unwrap();
+        let mut face = synthetic_face("fallback", "Chosen Mono", "/fonts/fallback.ttf", 80, 0);
+        face.coverage = coverage;
+        assert!(face.covers_text("A⇕📦"));
+        assert!(!face.covers_text("A🦀"));
+        assert!(parse_fontconfig_charset("7e-20").is_err());
+        assert!(parse_fontconfig_charset("110000").is_err());
+    }
+
+    #[test]
+    fn fallback_font_mapping_cache_is_bounded_across_face_churn() {
+        reset_snapshot_cache();
+        let faces = snapshot_faces().unwrap();
+        let mut paths = HashSet::new();
+        let mut mapped = 0;
+        for face in faces.iter().skip(SNAPSHOT_FALLBACK_START) {
+            if !paths.insert(face.path.clone()) {
+                continue;
+            }
+            fallback_font_mapping(face).unwrap();
+            mapped += 1;
+            if mapped > SNAPSHOT_FALLBACK_MAPPING_BUDGET {
+                break;
+            }
+        }
+        assert_eq!(mapped, SNAPSHOT_FALLBACK_MAPPING_BUDGET + 1);
+        let metrics = snapshot_cache_metrics();
+        assert_eq!(
+            metrics["fallback_mappings"].as_u64(),
+            Some(SNAPSHOT_FALLBACK_MAPPING_BUDGET as u64)
+        );
+        assert_eq!(metrics["fallback_mapping_evictions"].as_u64(), Some(1));
+        reset_snapshot_cache();
     }
 
     #[test]

--- a/crates/splinterm/src/renderer/fonts.rs
+++ b/crates/splinterm/src/renderer/fonts.rs
@@ -1654,19 +1654,17 @@ mod tests {
     fn fallback_font_mapping_cache_is_bounded_across_face_churn() {
         reset_snapshot_cache();
         let faces = snapshot_faces().unwrap();
-        let mut paths = HashSet::new();
-        let mut mapped = 0;
-        for face in faces.iter().skip(SNAPSHOT_FALLBACK_START) {
-            if !paths.insert(face.path.clone()) {
-                continue;
+        let mapping =
+            Arc::new(ReadOnlyFileMap::open(&faces[SNAPSHOT_PRIMARY_REGULAR].path).unwrap());
+        SNAPSHOT_FALLBACK_MAPPING_CACHE.with(|cache| {
+            let mut cache = cache.borrow_mut();
+            for index in 0..=SNAPSHOT_FALLBACK_MAPPING_BUDGET {
+                cache.insert(
+                    PathBuf::from(format!("/synthetic/font-{index}.ttf")),
+                    Arc::clone(&mapping),
+                );
             }
-            fallback_font_mapping(face).unwrap();
-            mapped += 1;
-            if mapped > SNAPSHOT_FALLBACK_MAPPING_BUDGET {
-                break;
-            }
-        }
-        assert_eq!(mapped, SNAPSHOT_FALLBACK_MAPPING_BUDGET + 1);
+        });
         let metrics = snapshot_cache_metrics();
         assert_eq!(
             metrics["fallback_mappings"].as_u64(),

--- a/crates/splinterm/src/renderer/frame.rs
+++ b/crates/splinterm/src/renderer/frame.rs
@@ -20,12 +20,11 @@ use crate::{
 
 use super::{
     BOX_DRAWING_FACE, CachedGlyph, FontFace, GlyphKey, RenderContext, SNAPSHOT_CJK, SNAPSHOT_EMOJI,
-    SNAPSHOT_PRIMARY_BOLD, SNAPSHOT_PRIMARY_BOLD_ITALIC, SNAPSHOT_PRIMARY_ITALIC,
-    SNAPSHOT_PRIMARY_REGULAR, cell_metrics, compatibility_render_context,
+    SNAPSHOT_FALLBACK_START, SNAPSHOT_PRIMARY_BOLD, SNAPSHOT_PRIMARY_BOLD_ITALIC,
+    SNAPSHOT_PRIMARY_ITALIC, SNAPSHOT_PRIMARY_REGULAR, cell_metrics, compatibility_render_context,
     decorations::{DecorationMetrics, DecorationSpan},
-    font_ref,
     images::{SnapshotImage, prepare_snapshot_images},
-    snapshot_color_advance, snapshot_faces, snapshot_glyph, u32_to_f32,
+    snapshot_color_advance, snapshot_faces, snapshot_glyph, u32_to_f32, with_font_ref,
 };
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -779,18 +778,20 @@ pub(super) fn prepare_snapshot_row(
                 Ok(face_index) => (face_index, cell.content.as_str()),
                 Err(_) => (primary_face_index(&cell.attributes), "\u{fffd}"),
             };
-        let font = font_ref(&faces[face_index])?;
-        let mut shaped_glyphs = Vec::new();
-        let mut shaper = shape_context.builder(font).size(font_size).build();
-        shaper.add_str(content);
-        shaper.shape_with(|cluster| {
-            let advance = cluster.advance();
-            let mut pen = 0.0;
-            for glyph in cluster.glyphs {
-                shaped_glyphs.push((glyph.id, advance, pen + glyph.x, glyph.y));
-                pen += glyph.advance;
-            }
-        });
+        let shaped_glyphs = with_font_ref(&faces[face_index], |font| {
+            let mut shaped_glyphs = Vec::new();
+            let mut shaper = shape_context.builder(font).size(font_size).build();
+            shaper.add_str(content);
+            shaper.shape_with(|cluster| {
+                let advance = cluster.advance();
+                let mut pen = 0.0;
+                for glyph in cluster.glyphs {
+                    shaped_glyphs.push((glyph.id, advance, pen + glyph.x, glyph.y));
+                    pen += glyph.advance;
+                }
+            });
+            Ok(shaped_glyphs)
+        })?;
         for (glyph_id, cluster_advance, x_offset, y_offset) in shaped_glyphs {
             let key = GlyphKey {
                 face: face_index,
@@ -851,13 +852,18 @@ pub(super) fn select_face_for_text(
     let primary = primary_face_index(attributes);
     [primary, SNAPSHOT_CJK, SNAPSHOT_EMOJI]
         .into_iter()
+        .chain(SNAPSHOT_FALLBACK_START..faces.len())
         .find(|index| {
-            font_ref(&faces[*index]).is_ok_and(|font| {
-                text.chars()
-                    .all(|character| font.charmap().map(character) != 0)
-            })
+            let face = &faces[*index];
+            face.covers_text(text)
+                && with_font_ref(face, |font| {
+                    Ok(text
+                        .chars()
+                        .all(|character| font.charmap().map(character) != 0))
+                })
+                .unwrap_or(false)
         })
-        .with_context(|| format!("no explicit font covers snapshot cell {text:?}"))
+        .with_context(|| format!("no Fontconfig face covers snapshot cell {text:?}"))
 }
 
 pub(super) fn primary_face_index(attributes: &CellAttributes) -> usize {

--- a/crates/splinterm/src/renderer/tests.rs
+++ b/crates/splinterm/src/renderer/tests.rs
@@ -1,4 +1,4 @@
-use super::*;
+use super::{frame::select_face_for_text, *};
 
 fn synthetic_row() -> TextRow {
     let key = GlyphKey { face: 0, glyph: 1 };
@@ -734,6 +734,33 @@ fn snapshot_decorations_use_foot_baseline_metrics_in_full_and_row_paints() {
 }
 
 #[test]
+fn fontconfig_fallback_renders_the_prompt_arrow_instead_of_replacement() {
+    let faces = snapshot_faces().unwrap();
+    let attributes = CellAttributes::default();
+    let face_index = select_face_for_text(faces, "⇕", &attributes).unwrap();
+    assert!(
+        face_index >= SNAPSHOT_FALLBACK_START,
+        "the pinned primary, CJK, and emoji faces do not cover U+21D5"
+    );
+    assert!(
+        faces[face_index].data.is_none(),
+        "dynamic fallbacks must use the bounded mapping cache"
+    );
+    let glyph_id = with_font_ref(&faces[face_index], |font| Ok(font.charmap().map('⇕'))).unwrap();
+    assert_ne!(glyph_id, 0);
+
+    let mut snapshot = incremental_snapshot();
+    snapshot.visible_rows[0].cells[0].content = "⇕".to_owned();
+    let frame = SnapshotFrame::load_scaled(&snapshot, 120).unwrap();
+    assert!(
+        frame
+            .glyphs
+            .iter()
+            .any(|glyph| glyph.column == 0 && glyph.row == 0 && glyph.key.face == face_index)
+    );
+}
+
+#[test]
 fn snapshot_styles_select_distinct_primary_faces_and_cache_keys() {
     let mut snapshot = incremental_snapshot();
     snapshot.visible_rows[0].cells[0].content = "A".to_owned();
@@ -843,9 +870,10 @@ fn underline_style_color_partial_mutation_matches_clean_full_rebuild() {
 #[test]
 fn selected_font_bytes_are_loaded_only_when_the_face_is_used() {
     let face = resolve_face("lazy CJK test", CJK_FONT, "noto sans cjk").unwrap();
-    assert!(face.data.get().is_none());
+    let data = face.data.as_ref().expect("explicit face owns stable data");
+    assert!(data.get().is_none());
     assert_ne!(font_ref(&face).unwrap().charmap().map('界'), 0);
-    assert!(face.data.get().is_some_and(Result::is_ok));
+    assert!(data.get().is_some_and(Result::is_ok));
 }
 
 #[test]

--- a/docs/adr/0004-font-and-cpu-renderer.md
+++ b/docs/adr/0004-font-and-cpu-renderer.md
@@ -34,18 +34,22 @@ Use a client-owned CPU renderer backed by:
 - Swash 0.2 for shaping and the current provisional outline/bitmap raster path;
   production grayscale rasterization remains subject to the Phase 8.1 decision
   below;
-- explicit primary, CJK, and emoji fallback ordering;
+- explicit primary, CJK, and emoji ordering followed by Fontconfig's ordered
+  outline fallback set;
 - fixed terminal cell spans independent of fractional glyph advances;
 - scale-specific glyph-image caches;
 - Foot-derived custom geometry for supported box-drawing characters; and
 - direct blending into premultiplied ARGB8888 SHM buffers, opaque by default
   with Foot-compatible default-background alpha when configured.
 
-The current discovery adapter invokes `fc-match` for explicit patterns and
-validates the resolved family/style before reading only the selected files. It
+The current discovery adapter invokes `fc-match` for explicit patterns and once
+for the ordered fallback set. It validates resolved family/style and records
+Fontconfig charset coverage before opening only candidate files whose metadata
+covers a rendered cell. Primary, CJK, and emoji mappings remain immutable;
+dynamic fallback mappings use an evictable 24-entry cache. Fontconfig discovery
 must not run repeatedly on the Wayland dispatch path. Production configuration
-will supply the requested primary pattern; generic `fontdb` monospace selection
-is not authoritative.
+supplies the requested primary pattern; generic `fontdb` monospace selection is
+not authoritative.
 
 Regular, Bold, Italic, and Bold Italic faces must resolve to distinct identities
 and preserve the terminal advance contract. Combining sequences are shaped as


### PR DESCRIPTION
## Problem

Splinterm checked only the selected primary, explicit CJK, and explicit emoji faces. A cell missing from all three was immediately replaced with U+FFFD even when Fontconfig had an installed fallback. This made prompt symbols such as U+21D5 (`⇕`) render as the replacement diamond.

## Change

- resolve Fontconfig's ordered outline fallback set once during renderer initialization;
- use Fontconfig charset metadata before opening candidate faces;
- map dynamic fallback files lazily through a 24-entry evictable cache;
- retain existing bounded glyph and raster-face caches and the explicit color-emoji path;
- add U+21D5 rendering and mapping-churn eviction regressions;
- document the startup and resource-bound behavior in Beta 2 release notes and ADR 0004.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p splinterm --lib --no-fail-fast -- --test-threads=1` — 390 passed, 1 intentional ignore
- `cargo clippy -p splinterm --lib --tests -- -D warnings`
- `cargo test --workspace -- --test-threads=1`
- `cargo clippy --workspace --all-targets -- -D warnings`
- package Python suites — 15 + 5 + 4 + 3 passed
- `tools/package/build-local-package.sh` — full `PKGBUILD check()` and split-package validation passed
- `git diff --check`
- independent read-only review: initial mapping-retention blocker corrected; follow-up PASS

Local validation package SHA256:

- `splinterm-0.1.0beta2-1-x86_64.pkg.tar.zst`: `869278bb43f1cdd51e0a92c3effdae5470f17c64774f99672b5c53d0f3ca7322`
- `splinterm-mcp-0.1.0beta2-1-x86_64.pkg.tar.zst`: `6631174241e7fd6599d694cae601b6a4d4d6e1c1d8ffc5a10a42813afa89abe7`

## Residual risk

Fallback choice remains host-Fontconfig dependent and immutable for an already-open client. The fallback mapping cache is entry-bounded rather than byte-bounded. No graphical validation is claimed in this PR.
