### PR TITLE
Add production PTY handoff quiescence

### DIFF
--- a/crates/splinterd/src/lib.rs
+++ b/crates/splinterd/src/lib.rs
@@ -27,6 +27,6 @@ pub fn inspect_policy_file(path: &Path) -> Result<(usize, serde_json::Value)> {
 pub use live::{
     CompactSubscription, LiveCell, LiveError, LiveEvent, LiveRow, LiveRuntimeMetrics,
     LiveScrollbackPage, LiveSearchPage, LiveSnapshot, LiveSplintConfig, LiveSplintHandle,
-    LiveSplintRuntime, ProcessExit, ProcessIncarnation, ProcessPlacement, Subscription,
-    SubscriptionReceive, TerminalPublicationMemoryLease,
+    LiveSplintRuntime, PreparedPtyHandoff, ProcessExit, ProcessIncarnation, ProcessPlacement,
+    Subscription, SubscriptionReceive, TerminalPublicationMemoryLease,
 };

--- a/crates/splinterd/src/live.rs
+++ b/crates/splinterd/src/live.rs
@@ -11,11 +11,14 @@ use std::{
     time::Duration,
 };
 
+#[cfg(test)]
+use std::os::fd::AsRawFd;
+
 use splinterm_core::SplintId;
 use splinterm_protocol::perf_trace::{PerfTraceEvent, emit_perf_trace, perf_trace_enabled};
 use splinterm_pty::{
-    LinuxPtyBackend, LinuxPtyIdentity, LinuxPtySession, PtyCommand, PtyError, PtySession,
-    PtySignal, PtySize,
+    AdoptableLinuxPtySession, LinuxPtyBackend, LinuxPtyIdentity, LinuxPtySession, PtyCommand,
+    PtyError, PtySession, PtySignal, PtySize,
 };
 use splinterm_terminal::{
     ActiveScreen, CellAttributesSnapshot, CellSnapshotContent, CursorSnapshot, Dimensions,
@@ -2433,6 +2436,76 @@ pub enum LiveError {
 
 type Reply<T> = oneshot::Sender<Result<T, LiveError>>;
 
+#[derive(Debug)]
+struct PtyResume {
+    session: AdoptableLinuxPtySession,
+    acknowledged: Option<Reply<()>>,
+}
+
+/// Exclusive ownership of one quiesced actor's canonical PTY master.
+///
+/// The actor stops reading commands and PTY I/O until this lease is resumed or
+/// dropped. Dropping it returns the unchanged descriptor automatically, keeping
+/// cancellation before daemon exec recoverable.
+#[derive(Debug)]
+pub struct PreparedPtyHandoff {
+    identity: LinuxPtyIdentity,
+    master_raw_fd: i32,
+    #[cfg(test)]
+    retired_reader_raw_fd: i32,
+    session: Option<AdoptableLinuxPtySession>,
+    resume: Option<oneshot::Sender<PtyResume>>,
+}
+
+impl PreparedPtyHandoff {
+    #[must_use]
+    pub const fn identity(&self) -> LinuxPtyIdentity {
+        self.identity
+    }
+
+    #[must_use]
+    pub const fn master_raw_fd(&self) -> i32 {
+        self.master_raw_fd
+    }
+
+    #[cfg(test)]
+    #[must_use]
+    const fn retired_reader_raw_fd(&self) -> i32 {
+        self.retired_reader_raw_fd
+    }
+
+    /// Returns the unchanged canonical PTY master to its actor and waits until
+    /// one replacement async reader is active.
+    ///
+    /// # Errors
+    /// Returns [`LiveError::Closed`] when the actor ends or cannot restore its
+    /// validated PTY session and replacement reader.
+    pub async fn resume(mut self) -> Result<(), LiveError> {
+        let session = self.session.take().ok_or(LiveError::Closed)?;
+        let resume = self.resume.take().ok_or(LiveError::Closed)?;
+        let (acknowledged, receiver) = oneshot::channel();
+        resume
+            .send(PtyResume {
+                session,
+                acknowledged: Some(acknowledged),
+            })
+            .map_err(|_| LiveError::Closed)?;
+        receiver.await.map_err(|_| LiveError::Closed)?
+    }
+}
+
+impl Drop for PreparedPtyHandoff {
+    fn drop(&mut self) {
+        let (Some(session), Some(resume)) = (self.session.take(), self.resume.take()) else {
+            return;
+        };
+        let _ = resume.send(PtyResume {
+            session,
+            acknowledged: None,
+        });
+    }
+}
+
 enum Command {
     Input(Vec<u8>, Reply<()>),
     Resize(PtySize, Reply<()>),
@@ -2444,6 +2517,7 @@ enum Command {
     Attach(usize, usize, Reply<(LiveSnapshot, Subscription)>),
     SubscribeCompact(usize, usize, Reply<CompactSubscription>),
     AttachCompact(usize, usize, Reply<(LiveSnapshot, CompactSubscription)>),
+    PreparePtyHandoff(Reply<PreparedPtyHandoff>),
     Shutdown(oneshot::Sender<()>),
 }
 
@@ -3064,6 +3138,19 @@ impl LiveSplintHandle {
         }
     }
 
+    /// Fences later commands, drains accepted PTY writes, closes the cloned
+    /// async reader, and returns exclusive ownership of the canonical master.
+    ///
+    /// Dropping the returned lease resumes the actor automatically. Call
+    /// [`PreparedPtyHandoff::resume`] when recovery must be acknowledged.
+    ///
+    /// # Errors
+    /// Returns a PTY identity/exit error when the live session cannot be safely
+    /// converted, or [`LiveError::Closed`] when the actor has ended.
+    pub async fn prepare_pty_handoff(&self) -> Result<PreparedPtyHandoff, LiveError> {
+        self.request(Command::PreparePtyHandoff).await
+    }
+
     pub async fn shutdown(&self) -> Result<(), LiveError> {
         let (sender, receiver) = oneshot::channel();
         self.commands
@@ -3496,6 +3583,10 @@ enum ShutdownStage {
     Kill,
 }
 
+fn restore_actor_io(session: &LinuxPtySession) -> Result<AsyncFd<std::fs::File>, LiveError> {
+    Ok(AsyncFd::new(session.try_clone_reader()?)?)
+}
+
 #[allow(
     clippy::too_many_arguments,
     reason = "the actor exclusively owns its runtime state"
@@ -3503,7 +3594,7 @@ enum ShutdownStage {
 async fn run_actor(
     splint_id: SplintId,
     incarnation: ProcessIncarnation,
-    mut session: LinuxPtySession,
+    session: LinuxPtySession,
     io: AsyncFd<std::fs::File>,
     terminal: Terminal,
     commands: mpsc::Receiver<Command>,
@@ -3512,6 +3603,7 @@ async fn run_actor(
     metrics: Arc<RuntimeMetrics>,
     exit_sender: watch::Sender<Option<ProcessExit>>,
 ) -> Result<ProcessExit, LiveError> {
+    let mut session = Some(session);
     let result = run_actor_body(
         splint_id,
         incarnation,
@@ -3525,7 +3617,11 @@ async fn run_actor(
     )
     .await;
     let forced_status = if result.is_err() {
-        force_reap(&mut session).await
+        if let Some(session) = session.as_mut() {
+            force_reap(session).await
+        } else {
+            None
+        }
     } else {
         None
     };
@@ -3543,7 +3639,7 @@ async fn run_actor(
 async fn run_actor_body(
     splint_id: SplintId,
     incarnation: ProcessIncarnation,
-    session: &mut LinuxPtySession,
+    session: &mut Option<LinuxPtySession>,
     io: AsyncFd<std::fs::File>,
     mut terminal: Terminal,
     mut commands: mpsc::Receiver<Command>,
@@ -3564,8 +3660,97 @@ async fn run_actor_body(
     let mut shutdown_replies = Vec::new();
     let mut read_buffer = vec![0_u8; READ_BUFFER];
     let mut commands_open = true;
+    let mut io = Some(io);
+    let mut pending_handoff = None::<Reply<PreparedPtyHandoff>>;
 
     loop {
+        if pending_handoff
+            .as_ref()
+            .is_some_and(oneshot::Sender::is_closed)
+        {
+            pending_handoff = None;
+        }
+        if pending_handoff.is_some() && user_writes.is_empty() && reply_writes.is_empty() {
+            let reply = pending_handoff
+                .take()
+                .expect("pending PTY handoff checked as present");
+            #[cfg(test)]
+            let retired_reader_raw_fd = io
+                .as_ref()
+                .expect("active actor owns one PTY reader")
+                .get_ref()
+                .as_raw_fd();
+            drop(io.take().expect("active actor owns one PTY reader"));
+            let active_session = session
+                .take()
+                .expect("active actor owns one canonical PTY session");
+            let adoptable = match active_session.try_into_adoptable() {
+                Ok(adoptable) => adoptable,
+                Err((error, active_session)) => {
+                    let restored_io = match restore_actor_io(&active_session) {
+                        Ok(restored_io) => restored_io,
+                        Err(error) => {
+                            *session = Some(active_session);
+                            return Err(error);
+                        }
+                    };
+                    *session = Some(active_session);
+                    io = Some(restored_io);
+                    let _ = reply.send(Err(error.into()));
+                    continue;
+                }
+            };
+            let identity = adoptable.identity();
+            let master_raw_fd = adoptable.master_raw_fd();
+            let (resume, resumed) = oneshot::channel();
+            let prepared = PreparedPtyHandoff {
+                identity,
+                master_raw_fd,
+                #[cfg(test)]
+                retired_reader_raw_fd,
+                session: Some(adoptable),
+                resume: Some(resume),
+            };
+            if let Err(returned) = reply.send(Ok(prepared))
+                && let Ok(prepared) = returned
+            {
+                drop(prepared);
+            }
+            let PtyResume {
+                session: adoptable,
+                acknowledged,
+            } = resumed.await.map_err(|_| LiveError::Closed)?;
+            let active_session = match adoptable.try_adopt() {
+                Ok(active_session) => active_session,
+                Err((_error, retained)) => {
+                    let status =
+                        tokio::task::spawn_blocking(move || retained.kill_child_and_wait())
+                            .await??;
+                    child_exit = Some(status.into());
+                    if let Some(acknowledged) = acknowledged {
+                        let _ = acknowledged.send(Err(LiveError::Closed));
+                    }
+                    break;
+                }
+            };
+            let restored_io = match restore_actor_io(&active_session) {
+                Ok(restored_io) => restored_io,
+                Err(error) => {
+                    *session = Some(active_session);
+                    if let Some(acknowledged) = acknowledged {
+                        let _ = acknowledged.send(Err(LiveError::Closed));
+                    }
+                    return Err(error);
+                }
+            };
+            *session = Some(active_session);
+            io = Some(restored_io);
+            if let Some(acknowledged) = acknowledged {
+                let _ = acknowledged.send(Ok(()));
+            }
+            continue;
+        }
+
         let shutdown_settled = shutdown.is_none() || matches!(shutdown, Some(ShutdownStage::Kill));
         if child_exit.is_some()
             && (eof
@@ -3576,13 +3761,24 @@ async fn run_actor_body(
         }
 
         tokio::select! {
-            command = commands.recv(), if commands_open => {
-                if let Some(command) = command {
+            () = async {
+                pending_handoff
+                    .as_mut()
+                    .expect("pending handoff branch requires a sender")
+                    .closed()
+                    .await;
+            }, if pending_handoff.is_some() => {
+                pending_handoff = None;
+            }
+            command = commands.recv(), if commands_open && pending_handoff.is_none() => {
+                if let Some(Command::PreparePtyHandoff(reply)) = command {
+                    pending_handoff = Some(reply);
+                } else if let Some(command) = command {
                     handle_command(
                         command,
                         splint_id,
                         incarnation,
-                        session,
+                        session.as_mut().expect("active actor owns its PTY session"),
                         &mut terminal,
                         &mut subscribers,
                         &mut publication,
@@ -3601,12 +3797,15 @@ async fn run_actor_body(
                 } else {
                     commands_open = false;
                     if shutdown.is_none() {
-                        let _ = session.signal_process_group(PtySignal::Hangup);
+                        let _ = session
+                            .as_ref()
+                            .expect("active actor owns its PTY session")
+                            .signal_process_group(PtySignal::Hangup);
                         shutdown = Some(ShutdownStage::Hangup(Instant::now() + config.hangup_grace));
                     }
                 }
             }
-            ready = io.readable(), if !eof => {
+            ready = io.as_ref().expect("active actor owns one PTY reader").readable(), if !eof => {
                 let mut ready = ready?;
                 let result = ready.try_io(|inner| inner.get_ref().read(&mut read_buffer));
                 if let Ok(result) = result {
@@ -3676,7 +3875,7 @@ async fn run_actor_body(
                     }
                 }
             }
-            ready = io.writable(), if !reply_writes.is_empty() || !user_writes.is_empty() => {
+            ready = io.as_ref().expect("active actor owns one PTY reader").writable(), if !reply_writes.is_empty() || !user_writes.is_empty() => {
                 let mut ready = ready?;
                 let queue = if reply_writes.is_empty() {
                     &mut user_writes
@@ -3710,6 +3909,9 @@ async fn run_actor_body(
                 );
             }
             _ = interval.tick() => {
+                let session = session
+                    .as_mut()
+                    .expect("active actor owns its PTY session");
                 if child_exit.is_none() && let Some(status) = session.try_wait()? {
                     child_exit = Some(status.into());
                     drain_deadline = Some(Instant::now() + config.exit_drain_timeout);
@@ -4088,6 +4290,9 @@ fn handle_command(
                 materialization: Box::new(materialization),
             };
             let _ = reply.send(Ok((snapshot, subscription)));
+        }
+        Command::PreparePtyHandoff(_) => {
+            unreachable!("PTY handoff is intercepted by the actor loop")
         }
         Command::Shutdown(reply) => {
             shutdown_replies.push(reply);
@@ -8051,6 +8256,199 @@ mod tests {
         let snapshot = handle.snapshot().await.unwrap();
         assert!(snapshot_text(&snapshot).contains("detached-marker"));
         assert!(snapshot.revision.value() > 0);
+        assert_eq!(runtime.wait().await.unwrap().code, Some(0));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn prepared_pty_handoff_fences_commands_and_resumes_one_reader() {
+        let runtime = LiveSplintRuntime::spawn(
+            SplintId::new(),
+            backend(),
+            shell(
+                "printf ready; read first; printf '<%s>' \"$first\"; read second; printf '<%s>' \"$second\"; sleep 0.2",
+            ),
+            fast_config(),
+        )
+        .await
+        .unwrap();
+        let handle = runtime.handle();
+        time::sleep(Duration::from_millis(50)).await;
+        assert!(snapshot_text(&handle.snapshot().await.unwrap()).contains("ready"));
+
+        handle.input(b"before-handoff\n".to_vec()).await.unwrap();
+        let prepared = handle.prepare_pty_handoff().await.unwrap();
+        assert_eq!(prepared.identity().child_pid(), handle.child_pid());
+        assert!(PathBuf::from(format!("/proc/self/fd/{}", prepared.master_raw_fd())).exists());
+        assert!(
+            !PathBuf::from(format!(
+                "/proc/self/fd/{}",
+                prepared.retired_reader_raw_fd()
+            ))
+            .exists(),
+            "the actor reader must be closed before the PTY master is exposed"
+        );
+
+        let resize_handle = handle.clone();
+        let mut queued_resize =
+            tokio::spawn(async move { resize_handle.resize(PtySize::cells(55, 9)).await });
+        assert!(
+            time::timeout(Duration::from_millis(40), &mut queued_resize)
+                .await
+                .is_err(),
+            "commands after handoff preparation must remain fenced"
+        );
+
+        prepared.resume().await.unwrap();
+        queued_resize.await.unwrap().unwrap();
+        handle.input(b"after-handoff\n".to_vec()).await.unwrap();
+        time::sleep(Duration::from_millis(50)).await;
+        let snapshot = handle.snapshot().await.unwrap();
+        assert_eq!(
+            snapshot.dimensions,
+            Dimensions {
+                columns: 55,
+                rows: 9,
+            }
+        );
+        let text = snapshot_text(&snapshot);
+        assert!(text.contains("<before-handoff>"));
+        assert!(text.contains("<after-handoff>"));
+        assert_eq!(runtime.wait().await.unwrap().code, Some(0));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn child_exit_while_handoff_is_held_is_published_and_reaped() {
+        let runtime = LiveSplintRuntime::spawn(
+            SplintId::new(),
+            backend(),
+            shell("sleep 0.5; exit 7"),
+            fast_config(),
+        )
+        .await
+        .unwrap();
+        let handle = runtime.handle();
+        let child_pid = handle.child_pid();
+        let prepared = handle.prepare_pty_handoff().await.unwrap();
+        time::sleep(Duration::from_millis(650)).await;
+
+        prepared.resume().await.unwrap();
+        assert_eq!(runtime.wait().await.unwrap().code, Some(7));
+        assert!(!PathBuf::from(format!("/proc/{child_pid}")).exists());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn invalid_handoff_recovery_kills_and_reaps_only_the_exact_child() {
+        let runtime = LiveSplintRuntime::spawn(
+            SplintId::new(),
+            backend(),
+            shell("trap '' HUP TERM; sleep 30"),
+            fast_config(),
+        )
+        .await
+        .unwrap();
+        let handle = runtime.handle();
+        let child_pid = handle.child_pid();
+        let mut prepared = handle.prepare_pty_handoff().await.unwrap();
+        let adoptable = prepared
+            .session
+            .take()
+            .expect("prepared test lease owns the canonical master");
+        let (_, master) = adoptable.into_parts();
+        let mismatched =
+            LinuxPtyIdentity::from_raw(child_pid, child_pid.checked_add(1).unwrap(), child_pid)
+                .unwrap();
+        prepared.identity = mismatched;
+        prepared.session = Some(AdoptableLinuxPtySession::from_parts(mismatched, master));
+
+        assert!(matches!(prepared.resume().await, Err(LiveError::Closed)));
+        assert_eq!(runtime.wait().await.unwrap().signal, Some(9));
+        assert!(!PathBuf::from(format!("/proc/{child_pid}")).exists());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn cancelled_preparation_unfences_a_saturated_writer() {
+        let mut config = fast_config();
+        config.command_capacity = 4;
+        config.input_byte_limit = 1024 * 1024;
+        config.poll_interval = Duration::from_millis(500);
+        let runtime = LiveSplintRuntime::spawn(
+            SplintId::new(),
+            backend(),
+            shell("trap '' HUP TERM; sleep 30"),
+            config,
+        )
+        .await
+        .unwrap();
+        let handle = runtime.handle();
+        let child_pid = handle.child_pid();
+        handle.input(vec![b'x'; 256 * 1024]).await.unwrap();
+
+        let prepare_handle = handle.clone();
+        let prepare = tokio::spawn(async move { prepare_handle.prepare_pty_handoff().await });
+        time::sleep(Duration::from_millis(50)).await;
+        let resize_handle = handle.clone();
+        let mut resize =
+            tokio::spawn(async move { resize_handle.resize(PtySize::cells(57, 11)).await });
+        assert!(
+            time::timeout(Duration::from_millis(40), &mut resize)
+                .await
+                .is_err(),
+            "the handoff request must fence commands while accepted writes are blocked"
+        );
+
+        prepare.abort();
+        assert!(prepare.await.unwrap_err().is_cancelled());
+        time::timeout(Duration::from_millis(300), &mut resize)
+            .await
+            .expect("cancelling preparation must release the actor fence directly")
+            .unwrap()
+            .unwrap();
+        let snapshot = handle.snapshot().await.unwrap();
+        assert_eq!(
+            snapshot.dimensions,
+            Dimensions {
+                columns: 57,
+                rows: 11,
+            }
+        );
+        drop(handle);
+        drop(runtime);
+        let process = PathBuf::from(format!("/proc/{child_pid}"));
+        time::timeout(Duration::from_secs(3), async {
+            while process.exists() {
+                time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("cancelled preparation cleanup must reap the blocked child");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn dropping_prepared_pty_handoff_recovers_the_actor() {
+        let runtime = LiveSplintRuntime::spawn(
+            SplintId::new(),
+            backend(),
+            shell("printf ready; read value; printf '<%s>' \"$value\"; sleep 0.2"),
+            fast_config(),
+        )
+        .await
+        .unwrap();
+        let handle = runtime.handle();
+        time::sleep(Duration::from_millis(50)).await;
+        let prepared = handle.prepare_pty_handoff().await.unwrap();
+        assert!(PathBuf::from(format!("/proc/self/fd/{}", prepared.master_raw_fd())).exists());
+        assert!(
+            !PathBuf::from(format!(
+                "/proc/self/fd/{}",
+                prepared.retired_reader_raw_fd()
+            ))
+            .exists()
+        );
+        drop(prepared);
+
+        handle.input(b"drop-recovers\n".to_vec()).await.unwrap();
+        time::sleep(Duration::from_millis(50)).await;
+        assert!(snapshot_text(&handle.snapshot().await.unwrap()).contains("<drop-recovers>"));
         assert_eq!(runtime.wait().await.unwrap().code, Some(0));
     }
 

--- a/crates/splinterd/src/live.rs
+++ b/crates/splinterd/src/live.rs
@@ -3805,7 +3805,7 @@ async fn run_actor_body(
                     }
                 }
             }
-            ready = io.as_ref().expect("active actor owns one PTY reader").readable(), if !eof => {
+            ready = io.as_ref().expect("active actor owns one PTY reader").readable(), if !eof && pending_handoff.is_none() => {
                 let mut ready = ready?;
                 let result = ready.try_io(|inner| inner.get_ref().read(&mut read_buffer));
                 if let Ok(result) = result {
@@ -8317,6 +8317,34 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn pending_handoff_stops_accepting_reply_generating_pty_reads() {
+        let mut config = fast_config();
+        config.command_capacity = 4;
+        config.input_byte_limit = 1024 * 1024;
+        config.poll_interval = Duration::from_millis(500);
+        let runtime = LiveSplintRuntime::spawn(
+            SplintId::new(),
+            backend(),
+            shell(
+                "sleep 0.03; (while :; do printf '\\033[5n\\033[5n\\033[5n\\033[5n\\033[5n\\033[5n\\033[5n\\033[5n'; done) & while :; do dd bs=4096 count=1 >/dev/null 2>/dev/null; done",
+            ),
+            config,
+        )
+        .await
+        .unwrap();
+        let handle = runtime.handle();
+        handle.input(vec![b'x'; 256 * 1024]).await.unwrap();
+
+        let prepared = time::timeout(Duration::from_secs(1), handle.prepare_pty_handoff())
+            .await
+            .expect("reply-generating reads after the fence must not starve preparation")
+            .unwrap();
+        drop(prepared);
+        drop(handle);
+        drop(runtime);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn child_exit_while_handoff_is_held_is_published_and_reaped() {
         let runtime = LiveSplintRuntime::spawn(
             SplintId::new(),
@@ -8381,16 +8409,18 @@ mod tests {
         .unwrap();
         let handle = runtime.handle();
         let child_pid = handle.child_pid();
-        handle.input(vec![b'x'; 256 * 1024]).await.unwrap();
+        for _ in 0..4 {
+            handle.input(vec![b'x'; 256 * 1024]).await.unwrap();
+        }
 
         let prepare_handle = handle.clone();
         let prepare = tokio::spawn(async move { prepare_handle.prepare_pty_handoff().await });
-        time::sleep(Duration::from_millis(50)).await;
+        time::sleep(Duration::from_millis(5)).await;
         let resize_handle = handle.clone();
         let mut resize =
             tokio::spawn(async move { resize_handle.resize(PtySize::cells(57, 11)).await });
         assert!(
-            time::timeout(Duration::from_millis(40), &mut resize)
+            time::timeout(Duration::from_millis(5), &mut resize)
                 .await
                 .is_err(),
             "the handoff request must fence commands while accepted writes are blocked"
@@ -8398,7 +8428,7 @@ mod tests {
 
         prepare.abort();
         assert!(prepare.await.unwrap_err().is_cancelled());
-        time::timeout(Duration::from_millis(300), &mut resize)
+        time::timeout(Duration::from_secs(1), &mut resize)
             .await
             .expect("cancelling preparation must release the actor fence directly")
             .unwrap()

--- a/crates/splinterm-pty/src/lib.rs
+++ b/crates/splinterm-pty/src/lib.rs
@@ -450,6 +450,11 @@ impl LinuxPtyIdentity {
     }
 
     fn validate(self, master: &File) -> Result<()> {
+        self.validate_process()?;
+        self.validate_terminal(master)
+    }
+
+    fn validate_process(self) -> Result<()> {
         if self.child != self.process_group || self.child != self.session {
             return Err(PtyError::IdentityMismatch);
         }
@@ -457,12 +462,7 @@ impl LinuxPtyIdentity {
             .map_err(|error| PtyError::io("validate child process group", error))?;
         let observed_session = process::getsid(Some(self.child))
             .map_err(|error| PtyError::io("validate child session", error))?;
-        let terminal_session = termios::tcgetsid(master)
-            .map_err(|error| PtyError::io("validate controlling terminal session", error))?;
-        if observed_group != self.process_group
-            || observed_session != self.session
-            || terminal_session != self.session
-        {
+        if observed_group != self.process_group || observed_session != self.session {
             return Err(PtyError::IdentityMismatch);
         }
         process::waitid(
@@ -472,6 +472,15 @@ impl LinuxPtyIdentity {
                 | process::WaitIdOptions::NOWAIT,
         )
         .map_err(|error| PtyError::io("validate direct child authority", error))?;
+        Ok(())
+    }
+
+    fn validate_terminal(self, master: &File) -> Result<()> {
+        let terminal_session = termios::tcgetsid(master)
+            .map_err(|error| PtyError::io("validate controlling terminal session", error))?;
+        if terminal_session != self.session {
+            return Err(PtyError::IdentityMismatch);
+        }
         Ok(())
     }
 }
@@ -493,6 +502,11 @@ impl AdoptableLinuxPtySession {
     }
 
     #[must_use]
+    pub fn master_raw_fd(&self) -> i32 {
+        self.master.as_raw_fd()
+    }
+
+    #[must_use]
     pub fn into_parts(self) -> (LinuxPtyIdentity, OwnedFd) {
         (self.identity, self.master)
     }
@@ -508,14 +522,111 @@ impl AdoptableLinuxPtySession {
     /// Returns an error when process, parent/reaping, session, process-group, or
     /// controlling-terminal identity no longer matches the manifest.
     pub fn adopt(self) -> Result<LinuxPtySession> {
+        self.try_adopt().map_err(|(error, _)| error)
+    }
+
+    /// Validates and reconstructs runtime PTY authority without discarding the
+    /// inherited descriptor when validation fails.
+    ///
+    /// # Errors
+    /// Returns the error together with the unchanged adoptable session so a
+    /// coordinator can retain descriptor ownership while choosing rollback.
+    pub fn try_adopt(
+        self,
+    ) -> std::result::Result<LinuxPtySession, (PtyError, AdoptableLinuxPtySession)> {
+        let identity = self.identity;
         let master = File::from(self.master);
-        self.identity.validate(&master)?;
-        ensure_close_on_exec(&master)?;
+        if let Err(error) = identity.validate_process() {
+            return Err((
+                error,
+                AdoptableLinuxPtySession {
+                    identity,
+                    master: master.into(),
+                },
+            ));
+        }
+        let child_exited = match process::waitid(
+            process::WaitId::Pid(identity.child),
+            process::WaitIdOptions::EXITED
+                | process::WaitIdOptions::NOHANG
+                | process::WaitIdOptions::NOWAIT,
+        ) {
+            Ok(status) => status.is_some(),
+            Err(error) => {
+                return Err((
+                    PtyError::io("inspect adopted child", error),
+                    AdoptableLinuxPtySession {
+                        identity,
+                        master: master.into(),
+                    },
+                ));
+            }
+        };
+        if !child_exited && let Err(error) = identity.validate_terminal(&master) {
+            return Err((
+                error,
+                AdoptableLinuxPtySession {
+                    identity,
+                    master: master.into(),
+                },
+            ));
+        }
+        let observed_exit = match restore_descriptor_before_status_consumption(
+            || ensure_close_on_exec(&master),
+            || {
+                if child_exited {
+                    match process::waitpid(Some(identity.child), process::WaitOptions::NOHANG) {
+                        Ok(Some((_, status))) => Ok(Some(ExitStatus::from_raw(status.as_raw()))),
+                        Ok(None) => Err(PtyError::IdentityMismatch),
+                        Err(error) => Err(PtyError::io("reap adopted child", error)),
+                    }
+                } else {
+                    Ok(None)
+                }
+            },
+        ) {
+            Ok(observed_exit) => observed_exit,
+            Err(error) => {
+                return Err((
+                    error,
+                    AdoptableLinuxPtySession {
+                        identity,
+                        master: master.into(),
+                    },
+                ));
+            }
+        };
         Ok(LinuxPtySession {
             master,
-            identity: self.identity,
-            exit_status: None,
+            identity,
+            exit_status: observed_exit,
         })
+    }
+
+    /// Kills and reaps the exact retained child when adoption cannot safely
+    /// restore the live session.
+    ///
+    /// This fallback targets the child PID rather than a potentially changed or
+    /// reused process group. It is reserved for failed recovery paths.
+    ///
+    /// # Errors
+    /// Returns an error when the exact child cannot be signaled or reaped.
+    pub fn kill_child_and_wait(self) -> Result<ExitStatus> {
+        if let Some((_, status)) =
+            process::waitpid(Some(self.identity.child), process::WaitOptions::NOHANG)
+                .map_err(|error| PtyError::io("verify adopted child authority", error))?
+        {
+            return Ok(ExitStatus::from_raw(status.as_raw()));
+        }
+        match process::kill_process(self.identity.child, PtySignal::Kill.rustix()) {
+            Ok(()) | Err(rustix::io::Errno::SRCH) => {}
+            Err(error) => return Err(PtyError::io("kill adopted child", error)),
+        }
+        let (_, status) =
+            process::waitpid(Some(self.identity.child), process::WaitOptions::empty())
+                .map_err(|error| PtyError::io("reap adopted child", error))?
+                .ok_or(PtyError::IdentityMismatch)?;
+        Ok(ExitStatus::from_raw(status.as_raw()))
     }
 }
 
@@ -653,6 +764,14 @@ fn pid_from_u32(raw: u32) -> Result<Pid> {
 
 fn pid_to_u32(pid: Pid) -> u32 {
     u32::try_from(pid.as_raw_pid()).expect("positive Linux PID fits u32")
+}
+
+fn restore_descriptor_before_status_consumption<T>(
+    restore: impl FnOnce() -> Result<()>,
+    consume_status: impl FnOnce() -> Result<T>,
+) -> Result<T> {
+    restore()?;
+    consume_status()
 }
 
 fn ensure_close_on_exec(fd: &impl std::os::fd::AsFd) -> Result<()> {
@@ -816,6 +935,21 @@ mod tests {
     }
 
     use std::ffi::OsStr;
+
+    #[test]
+    fn descriptor_restore_failure_precedes_exit_status_consumption() {
+        let status_consumed = std::cell::Cell::new(false);
+        let result = restore_descriptor_before_status_consumption(
+            || Err(PtyError::IdentityMismatch),
+            || {
+                status_consumed.set(true);
+                Ok(())
+            },
+        );
+
+        assert!(matches!(result, Err(PtyError::IdentityMismatch)));
+        assert!(!status_consumed.get());
+    }
 
     #[test]
     fn default_terminal_type_matches_the_supported_keyboard_contract() {

--- a/crates/splinterm-pty/tests/linux_pty.rs
+++ b/crates/splinterm-pty/tests/linux_pty.rs
@@ -1,8 +1,9 @@
 use std::{
     fs,
     io::{ErrorKind, Read},
-    os::unix::process::ExitStatusExt,
+    os::{fd::OwnedFd, unix::process::ExitStatusExt},
     path::Path,
+    process::Command,
     sync::{
         Arc,
         atomic::{AtomicU32, Ordering},
@@ -241,6 +242,101 @@ fn live_session_identity_and_single_master_adoption_round_trip() {
     let status = adopted.wait().unwrap();
     assert!(status.success());
     assert_eq!(adopted.try_wait().unwrap(), Some(status));
+}
+
+#[test]
+fn failed_post_exec_adoption_retains_the_canonical_master() {
+    let cwd = std::env::current_dir().unwrap();
+    let session = backend()
+        .spawn(&command("resize", &cwd), PtySize::cells(40, 10))
+        .unwrap();
+    let identity = session.identity();
+    let adoptable = session.try_into_adoptable().unwrap();
+    let master_raw_fd = adoptable.master_raw_fd();
+    let (manifest_identity, master) = adoptable.into_parts();
+    let mismatched_identity = splinterm_pty::LinuxPtyIdentity::from_raw(
+        manifest_identity.child_pid(),
+        manifest_identity.child_pid().saturating_add(1),
+        manifest_identity.session_id(),
+    )
+    .unwrap();
+    let (error, retained) =
+        splinterm_pty::AdoptableLinuxPtySession::from_parts(mismatched_identity, master)
+            .try_adopt()
+            .unwrap_err();
+    assert!(matches!(error, PtyError::IdentityMismatch));
+    assert_eq!(retained.master_raw_fd(), master_raw_fd);
+
+    let (_, master) = retained.into_parts();
+    let mut recovered = splinterm_pty::AdoptableLinuxPtySession::from_parts(identity, master)
+        .adopt()
+        .unwrap();
+    recovered.signal_process_group(PtySignal::Hangup).unwrap();
+    assert_eq!(recovered.wait().unwrap().signal(), Some(1));
+}
+
+#[test]
+fn adoption_reaps_a_child_that_exits_while_the_master_is_held() {
+    let cwd = std::env::current_dir().unwrap();
+    let session = backend()
+        .spawn(
+            &PtyCommand::new("/bin/sh", cwd).args(["-c", "sleep 0.05; exit 7"]),
+            PtySize::cells(40, 10),
+        )
+        .unwrap();
+    let child_pid = session.child_id();
+    let adoptable = session.try_into_adoptable().unwrap();
+    thread::sleep(Duration::from_millis(100));
+
+    let mut adopted = adoptable.try_adopt().unwrap();
+    assert_eq!(adopted.wait().unwrap().code(), Some(7));
+    assert_eq!(adopted.try_wait().unwrap().unwrap().code(), Some(7));
+    assert!(!Path::new(&format!("/proc/{child_pid}")).exists());
+}
+
+#[test]
+fn failed_recovery_kills_and_reaps_a_verified_exact_child() {
+    let cwd = std::env::current_dir().unwrap();
+    let session = backend()
+        .spawn(
+            &PtyCommand::new("/bin/sh", cwd).args(["-c", "trap '' HUP TERM; sleep 30"]),
+            PtySize::cells(40, 10),
+        )
+        .unwrap();
+    let child_pid = session.child_id();
+    let status = session
+        .try_into_adoptable()
+        .unwrap()
+        .kill_child_and_wait()
+        .unwrap();
+    assert_eq!(status.signal(), Some(9));
+    assert!(!Path::new(&format!("/proc/{child_pid}")).exists());
+}
+
+#[test]
+fn failed_recovery_refuses_to_signal_without_child_authority() {
+    let output = Command::new("/bin/sh")
+        .args(["-c", "sleep 30 </dev/null >/dev/null 2>&1 & printf '%s' $!"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let unrelated_pid = String::from_utf8(output.stdout)
+        .unwrap()
+        .parse::<u32>()
+        .unwrap();
+    let identity =
+        splinterm_pty::LinuxPtyIdentity::from_raw(unrelated_pid, unrelated_pid, unrelated_pid)
+            .unwrap();
+    let master: OwnedFd = fs::File::open("/dev/null").unwrap().into();
+    let error = splinterm_pty::AdoptableLinuxPtySession::from_parts(identity, master)
+        .kill_child_and_wait()
+        .unwrap_err();
+    assert!(matches!(error, PtyError::Io { .. }));
+    assert!(Path::new(&format!("/proc/{unrelated_pid}")).exists());
+
+    let _ = Command::new("/bin/kill")
+        .args(["-KILL", &unrelated_pid.to_string()])
+        .status();
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add an exclusive actor lease that fences later commands, drains accepted PTY writes, retires the cloned reader, and exposes the canonical adoptable master
- resume exactly one reader explicitly or on lease drop, including cancellation and exited-child recovery
- retain failed adoption authority and fail closed through verified exact-child cleanup
- preserve current nested-cgroup `ProcessPlacement` ownership and keep checkpoint/coordinator/package scope deferred

## Context
The base adoptable Linux PTY milestone already merged in PR #33. This fresh branch re-authors only the immediately following production actor-quiescence seam against current `main`; it does not merge or cherry-pick the retained Plan 0037 aggregate.

## Validation
- `cargo fmt --all --check`
- `cargo test --frozen -p splinterm-pty --all-targets --all-features -- --test-threads=1` (21 passed)
- `cargo test --frozen -p splinterd --lib --all-features -- --test-threads=1` (84 passed)
- saturated-write cancellation regression repeated 12/12 successfully
- `cargo clippy --frozen -p splinterm-pty -p splinterd --all-targets --all-features -- -D warnings`
- `python tools/foot-oracle/check-provenance.py --portable`
- `git diff --check`
- independent lifecycle review found one P1 exit-status/CLOEXEC ordering issue; fixed with a fault-injected regression; follow-up verdict: **OK**
- independent integration/scope review: **OK**