### PR TITLE
Preserve buffered MCP package responses

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,6 +186,7 @@ jobs:
             tools/package/test_installer_safety.py \
             tools/package/test_omarchy_screensaver_integration.py \
             tools/package/test_systemd_unit.py \
+            tools/package/test_validate_mcp_package.py \
             tools/package/test_workload_units.py \
             tools/release/test_ci_attestation.py \
             tools/release/test_prepare_candidate.py \

--- a/packaging/PKGBUILD
+++ b/packaging/PKGBUILD
@@ -32,6 +32,7 @@ check() {
   python -m unittest tools/automation/test_dojo_picker.py
   python -m unittest tools/package/test_installer_safety.py
   python -m unittest tools/package/test_omarchy_screensaver_integration.py
+  python -m unittest tools/package/test_validate_mcp_package.py
   python -m unittest tools/package/test_workload_units.py
 }
 

--- a/tools/package/test_validate_mcp_package.py
+++ b/tools/package/test_validate_mcp_package.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Regression tests for the extracted MCP package validator host."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+
+MODULE_PATH = Path(__file__).with_name("validate-mcp-package.py")
+SPEC = importlib.util.spec_from_file_location("validate_mcp_package", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+validate_mcp_package = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(validate_mcp_package)
+
+
+class McpHostTests(unittest.TestCase):
+    def fake_server(self, payload: bytes) -> Path:
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        script = Path(temporary.name) / "fake-mcp-server"
+        script.write_text(
+            f"#!{sys.executable}\n"
+            "import os\n"
+            "import sys\n"
+            "sys.stdin.buffer.readline()\n"
+            f"os.write(1, {payload!r})\n"
+            "for _ in sys.stdin.buffer:\n"
+            "    pass\n",
+            encoding="utf-8",
+        )
+        script.chmod(0o755)
+        return script
+
+    def test_receive_preserves_a_coalesced_second_frame(self) -> None:
+        payload = (
+            b'{"jsonrpc":"2.0","id":1,"result":{}}\n'
+            b'{"jsonrpc":"2.0","method":"notifications/resources/updated",'
+            b'"params":{"uri":"splinterm://topology"}}\n'
+        )
+        host = validate_mcp_package.McpHost(self.fake_server(payload), os.environ.copy())
+        try:
+            host.send({"jsonrpc": "2.0", "id": 1, "method": "initialize"})
+            self.assertEqual(host.receive(1)["id"], 1)
+            self.assertEqual(
+                host.receive(1)["method"],
+                "notifications/resources/updated",
+            )
+        finally:
+            host.close()
+
+    def test_receive_rejects_an_oversized_buffered_line(self) -> None:
+        host = validate_mcp_package.McpHost(self.fake_server(b""), os.environ.copy())
+        try:
+            with mock.patch.object(
+                validate_mcp_package,
+                "MAXIMUM_MCP_RESPONSE_BYTES",
+                32,
+            ):
+                host.buffer.extend(b"x" * 32 + b"\n")
+                with self.assertRaisesRegex(AssertionError, "line limit"):
+                    host.receive(1)
+        finally:
+            host.close()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/package/validate-mcp-package.py
+++ b/tools/package/validate-mcp-package.py
@@ -15,6 +15,9 @@ import tempfile
 import time
 
 
+MAXIMUM_MCP_RESPONSE_BYTES = 16 * 1024 * 1024
+
+
 class McpHost:
     def __init__(self, executable: Path, environment: dict[str, str]):
         self.process = subprocess.Popen(
@@ -23,25 +26,41 @@ class McpHost:
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
-            text=True,
-            bufsize=1,
+            bufsize=0,
         )
         assert self.process.stdin is not None and self.process.stdout is not None
+        self.buffer = bytearray()
         self.next_id = 1
         self.notifications: list[dict[str, object]] = []
 
     def send(self, document: dict[str, object]) -> None:
         assert self.process.stdin is not None
-        self.process.stdin.write(json.dumps(document, separators=(",", ":")) + "\n")
-        self.process.stdin.flush()
+        payload = (json.dumps(document, separators=(",", ":")) + "\n").encode()
+        assert self.process.stdin.write(payload) == len(payload)
 
     def receive(self, timeout: float = 15) -> dict[str, object]:
         assert self.process.stdout is not None
-        ready, _, _ = select.select([self.process.stdout], [], [], timeout)
-        assert ready, "timed out reading MCP response"
-        line = self.process.stdout.readline()
-        assert line, "MCP server closed stdout"
-        return json.loads(line)
+        deadline = time.monotonic() + timeout
+        while b"\n" not in self.buffer:
+            remaining = deadline - time.monotonic()
+            assert remaining > 0, "timed out reading MCP response"
+            ready, _, _ = select.select([self.process.stdout], [], [], remaining)
+            assert ready, "timed out reading MCP response"
+            chunk = os.read(self.process.stdout.fileno(), 64 * 1024)
+            assert chunk, "MCP server closed stdout"
+            self.buffer.extend(chunk)
+            if b"\n" not in self.buffer:
+                assert (
+                    len(self.buffer) < MAXIMUM_MCP_RESPONSE_BYTES
+                ), "MCP response exceeds line limit"
+        line, _, remainder = self.buffer.partition(b"\n")
+        assert (
+            len(line) + 1 <= MAXIMUM_MCP_RESPONSE_BYTES
+        ), "MCP response exceeds line limit"
+        self.buffer = bytearray(remainder)
+        document = json.loads(line)
+        assert isinstance(document, dict), "MCP response is not an object"
+        return document
 
     def request(self, method: str, params: dict[str, object] | None = None) -> dict[str, object]:
         request_id = self.next_id
@@ -68,20 +87,28 @@ class McpHost:
         })
         assert "error" not in response, response
         self.send({"jsonrpc": "2.0", "method": "notifications/initialized"})
-        return response["result"]
+        result = response["result"]
+        assert isinstance(result, dict), "MCP initialize result is not an object"
+        return result
 
     def tool(self, name: str, arguments: dict[str, object]) -> dict[str, object]:
         response = self.request("tools/call", {"name": name, "arguments": arguments})
         assert "error" not in response, response
-        return response["result"]
+        result = response["result"]
+        assert isinstance(result, dict), "MCP tool result is not an object"
+        return result
 
     def close(self) -> None:
         if self.process.stdin is not None and not self.process.stdin.closed:
             self.process.stdin.close()
         self.process.wait(timeout=15)
+        stderr = self.process.stderr.read() if self.process.stderr else b""
+        if self.process.stdout is not None:
+            self.process.stdout.close()
+        if self.process.stderr is not None:
+            self.process.stderr.close()
         assert self.process.returncode == 0
-        stderr = self.process.stderr.read() if self.process.stderr else ""
-        assert not stderr, stderr
+        assert not stderr, stderr.decode(errors="replace")
 
 
 def write_policy(path: Path, executable: Path, scopes: list[str], resources: list[dict[str, object]]) -> None:

--- a/tools/release/test_ci_workflow.py
+++ b/tools/release/test_ci_workflow.py
@@ -96,7 +96,7 @@ class CiWorkflowTests(unittest.TestCase):
         pkgbuild = (ROOT / "packaging/PKGBUILD").read_text(encoding="utf-8")
         check_body = pkgbuild.split("check() {", 1)[1].split("\n}", 1)[0]
         python_targets = re.findall(r"python -m unittest ([^\s]+)", check_body)
-        self.assertEqual(len(python_targets), 4)
+        self.assertEqual(len(python_targets), 5)
         for target in python_targets:
             with self.subTest(target=target):
                 self.assertEqual(workflow.count(target), 1)


### PR DESCRIPTION
## Problem

The extracted MCP package validator mixed `select()` on the child stdout file descriptor with buffered text `readline()`. When an MCP response and `notifications/resources/updated` arrived in one pipe write, `readline()` could prefetch both lines; the second remained in Python's buffer while the next `select()` waited until timeout.

This deterministically blocked exact-HEAD packaged VM acceptance after the package build and complete workspace checks succeeded.

## Change

- Use unbuffered binary subprocess pipes and an owned newline-delimited byte buffer.
- Consume already-buffered frames before waiting on the file descriptor.
- Preserve coalesced remainder bytes across receives.
- Bound one validator response line to 16 MiB and reject non-object JSON.
- Close captured process streams on cleanup.
- Add regressions for two frames delivered in one write and an oversized buffered line.
- Include the regression in CI and PKGBUILD checks.

## Validation

- `python -W error::ResourceWarning -m unittest tools/package/test_validate_mcp_package.py tools/release/test_ci_workflow.py`
- 103 package/release Python tests
- `python -m py_compile tools/package/validate-mcp-package.py tools/package/test_validate_mcp_package.py`
- `python tools/release/release-doctor.py`
- `git diff --check`
- Real Omarchy VM `validate-package.py` against retained exact packages:
  - base package validation passed
  - extracted MCP runtime validation passed
  - combined package validation passed
- Independent read-only review: **OK**, no P0/P1/P2 findings.
