### PR TITLE
Allow zero-duration reducer smoke samples

### DIFF
--- a/crates/splinterm/src/wayland.rs
+++ b/crates/splinterm/src/wayland.rs
@@ -10818,7 +10818,7 @@ mod tests {
                 .any(|case| { matches!(case.mode, ReducerBenchMode::InactiveBatch) })
         );
         for case in smoke {
-            assert!(measure_reducer_bench_case(case) > 0);
+            std::hint::black_box(measure_reducer_bench_case(case));
         }
     }
 


### PR DESCRIPTION
## Problem

The pane-reducer smoke contract asserted that every `Instant::elapsed().as_nanos()` sample must be greater than zero. A valid reducer execution can complete within one observable clock tick, especially under VM clock virtualization, causing package checks to fail despite correct reducer behavior.

## Change

Execute and black-box every smoke measurement without treating wall-clock duration as a correctness assertion. The test still verifies bounded case counts/dimensions and coverage of detached, focused, and inactive-batch roles. Actual timing samples remain in the ignored manual timing harness.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --frozen -p splinterm --lib -- -D warnings`
- Focused test stress: 20/20 passed after the fix
- `cargo test --frozen -p splinterm --lib -- --test-threads=1`: 388 passed, 1 ignored
- `git diff --check`
- Independent read-only review: **OK**, no P0/P1/P2 findings.

## Reproduction context

An exact-HEAD Omarchy VM package build observed one zero-duration assertion failure. The unchanged focused test then passed 10/10, confirming timing nondeterminism rather than reducer failure.
