### PR TITLE
Add isolated Omarchy VM testbed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,6 +182,7 @@ jobs:
           set -o pipefail
           python -m unittest \
             tools/automation/test_dojo_picker.py \
+            tools/testbed/test_guest_window.py \
             tools/testbed/test_omarchy_vm.py \
             tools/testbed/test_qmp_input.py \
             tools/package/test_release_manifest.py \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Fetch the locked dependency graph
         run: cargo fetch --locked
       - run: cargo fmt --all --check
-      - run: shellcheck install.sh tools/package/build-local-package.sh tools/package/upgrade-local-package.sh
+      - run: shellcheck install.sh tools/package/build-local-package.sh tools/package/upgrade-local-package.sh tools/testbed/omarchy-vm.sh
       - run: cargo clippy --frozen --workspace --all-targets -- -D warnings
 
   workspace-tests:
@@ -182,6 +182,8 @@ jobs:
           set -o pipefail
           python -m unittest \
             tools/automation/test_dojo_picker.py \
+            tools/testbed/test_omarchy_vm.py \
+            tools/testbed/test_qmp_input.py \
             tools/package/test_release_manifest.py \
             tools/package/test_installer_safety.py \
             tools/package/test_omarchy_screensaver_integration.py \

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Validate candidate automation
         run: |
-          shellcheck install.sh tools/package/build-local-package.sh
+          shellcheck install.sh tools/package/build-local-package.sh tools/testbed/omarchy-vm.sh
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
           useradd --create-home validator
           chown -R validator:validator "$GITHUB_WORKSPACE"

--- a/.gitignore
+++ b/.gitignore
@@ -4,10 +4,12 @@ target/
 *.swp
 *.swo
 __pycache__/
+/.splinterm-testbed.env
 *.py[cod]
 .DS_Store
 .env
 /graphify-out/
+/.worktrees/
 /.pi-subagents/
 /.pi/subagents/
 /site/node_modules/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -225,52 +225,65 @@ Do not repeat a failed, expensive command until both of the following have occur
 
 ### 2.6 Graphical Test Matrices
 
-   Request approval once for the complete bounded graphical sequence, identifying
-   the target window, permitted focus/input actions, smoke test, gated matrix, and
-   cleanup plan.
+Request approval once for the complete bounded graphical sequence, identifying
+the guest target Window, permitted focus/input actions, smoke test, gated matrix,
+and cleanup plan. Use the repository Omarchy VM testbed described in Section 3.
 
-   Run one guarded smoke case first. If it succeeds, continue with the approved
-
+Run one guarded guest smoke case first. If it succeeds, continue with the
+approved matrix.
 
 ## 3. Graphical Testing
 
-### 3.1 Allowed Test Targets
+### 3.1 VM-First Graphical Authority
 
-Graphical tests may use either:
+Run every Splinterm graphical smoke, matrix, capture, benchmark, and packaged
+acceptance case in the configured persistent Omarchy VM through
+`tools/testbed/omarchy-vm.sh`. The default target is an isolated guest Window on
+guest workspace 8 / `Virtual-1`; workstation workspace 8 / DP-2 is not the
+default graphical test surface.
 
-* An isolated test window on workspace 8 / DP-2.
-* An existing active user window when the user explicitly approves a bounded
-  sequence and identifies the intended window.
+Host graphical testing is an exception. It requires separate explicit user
+approval for the complete host sequence and must identify either an isolated
+host test Window or the exact existing active user Window. Permission to watch
+the QEMU viewer does not authorize focusing it, moving it, or sending it host
+input; prefer guest-native `input` control and use bounded QMP input only as a
+fallback.
 
-### 3.2 Active-Window Authorization
+### 3.2 Guest-Window Authorization
 
-After explicit approval, the agent may focus, raise, resize, and send bounded
-keyboard or pointer input to the identified active window. Authorization applies
-only to the named test sequence and target window.
+After explicit approval for a bounded graphical sequence, the agent may focus,
+raise, resize, and send bounded keyboard or pointer input only to the identified
+guest test Window. Authorization applies only to the named sequence and target.
 
-Before manipulating an active window:
+Before manipulating a guest Window:
 
-* Record its address, process ID, workspace, monitor, and current focus.
+* Record its address, process ID, workspace, monitor, geometry, current focus,
+  cursor, scale, and transform.
 * State the exact actions and expected cleanup.
-* Target actions by window address whenever possible.
-* Preserve unrelated windows and user processes.
+* Target actions by exact guest Window address whenever possible.
+* Preserve unrelated guest Windows and processes and every workstation Window.
 
-Do not close the window, terminate its shell, restart its daemon, move unrelated
-windows, or enter terminal commands unless those actions were explicitly
-approved.
+Do not close a pre-existing guest Window, terminate its shell/daemon, enter
+commands into it, or manipulate production topology unless that exact action was
+explicitly approved.
 
 ### 3.3 Abort and Cleanup
 
-Abort immediately if input reaches the wrong window, an unrelated window moves,
-or the approved target cannot be identified reliably.
+Abort immediately if input reaches the wrong guest Window, an unrelated Window
+moves, the QEMU viewer receives unintended host input, or the approved target
+cannot be identified reliably.
 
-After testing, restore the original focus, workspace, monitor, size, and position
-when practical, and report anything that could not be restored.
+After every case, close only disposable test Windows, stop private test daemons,
+remove private runtime artifacts, restore the original guest workspace, focus,
+monitor state, cursor, size, and position, and verify the guest test workspace is
+empty. Report anything that could not be restored.
 
-### 3.4 Isolated Testing
+### 3.4 Host Exception
 
-When active-window manipulation was not explicitly approved, retain the existing
-workspace 8 / DP-2 placement and no-focus isolation requirements.
+When the user explicitly approves host graphical testing as an exception, retain
+the existing workspace 8 / DP-2 no-focus isolation requirements unless the user
+names an existing active Window. Apply the same exact-target, abort, and cleanup
+rules, and never treat VM authorization as host authorization.
 
 ## 4. Repository Safety
 
@@ -310,16 +323,23 @@ desktop launcher is installed. The packaged desktop wrapper resolves
 system daemon's trusted-UI inode and exits as unauthorized before mapping a
 window.
 
-For local installation work:
+For packaged graphical acceptance, use the Omarchy VM actions
+`package-build`, `package-status`, `package-install --confirm-guest-install`,
+`package-launch`, and `package-stop`. Do not install or replace a workstation
+package merely to run graphical acceptance.
+
+For installation work:
 
 * First inspect `command -v splinterm`, the desktop-launcher process `PATH`, the
   running daemon executable, and both executable device/inode identities.
-* Remember that `./install.sh` deliberately packages only a clean committed
-  `HEAD`; it cannot install an uncommitted worktree implementation.
-* Ask before replacing the Pacman-owned `/usr/bin/splinterm`. When approved,
-  save a rollback copy, use `pkexec` for the privileged replacement, remove any
-  shadowing user-local client, and disclose that Pacman integrity checks will
-  report the file as altered until reinstall or upgrade.
+* Remember that `./install.sh` and VM `package-build` deliberately package only a
+  clean committed `HEAD`; neither can install an uncommitted implementation.
+* Ask before replacing an existing Pacman-owned `/usr/bin/splinterm`, including
+  inside the guest. The confirmed VM install path saves guest rollback copies
+  and uses passwordless guest `sudo`; a separately approved host exception must
+  save a rollback copy, use `pkexec`, remove any shadowing user-local client, and
+  disclose that Pacman integrity checks will report the host file as altered
+  until reinstall or upgrade.
 * Reopen existing Splinterm windows after replacement. Their running executable
   retains the old inode and no longer matches the newly installed trusted UI.
 * Validate non-graphically with normal human-mode `/usr/bin/splinterm list`,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -239,6 +239,72 @@ Do not claim fuzz coverage for code paths the target does not reach. Diagnose a
 crash or timeout before retrying, minimize retained reproducers without changing
 the failure, and never discard a corpus/finding to make a gate pass.
 
+## Omarchy VM testbed
+
+Maintainers must run Splinterm graphical smokes, matrices, captures, benchmarks,
+and packaged acceptance in the persistent Omarchy VM over SSH by default. Host
+graphical testing is an explicitly approved exception, not a fallback chosen for
+convenience. Copy the example settings, then record the VM's independently
+verified SSH host key in a dedicated known-hosts file:
+
+```bash
+cp tools/testbed/omarchy-vm.env.example .splinterm-testbed.env
+$EDITOR .splinterm-testbed.env
+tools/testbed/omarchy-vm.sh status
+tools/testbed/omarchy-vm.sh bootstrap
+tools/testbed/omarchy-vm.sh check
+```
+
+The settings file is ignored by Git. The runner pins the configured host-key
+file and requires a Bash-login Omarchy guest. Its destructive sync destination
+is restricted to `/home/<user>/Projects/splinterm-testbed[-suffix]`; existing
+symlink destinations are rejected. It mirrors the current worktree there while
+excluding host build artifacts, Git metadata, private Pi state, local environment
+files, and retained benchmark results. `cargo ARGS...` runs a focused Cargo
+command after syncing; `ping`
+checks an isolated development daemon. When a local QMP socket is configured,
+`qmp status`, `qmp type TEXT`, `qmp key QCODE`, `qmp move X Y WIDTH HEIGHT`, and
+`qmp click BUTTON` provide bounded guest-only input without focusing the host
+QEMU Window. The QMP helper caps typed text at 4 KiB and inbound frames at 1 MiB,
+and rejects unsupported text, unterminated frames, and out-of-range pointer
+coordinates rather than guessing. `desktop-exec COMMAND...` runs guest-native
+Wayland tools such as `wtype`, `grim`, and exact-target `hyprctl` commands with
+the active guest compositor identity discovered at execution time. When the
+guest has its owner-only `ydotoold` user service enabled, `input ARGS...` routes
+keyboard and pointer events through the guest's private runtime socket and
+`uinput`; this remains usable while QEMU/SDL lacks host focus and is the preferred
+interactive test path. QMP remains useful for VM status and low-level fallback.
+
+`launch` maps a development Window only on the guest Wayland desktop and writes
+its client log below the guest's private `splinterm-test` runtime directory. It
+still counts as graphical testing: obtain approval for the bounded sequence
+below before using `launch`, capture, or input commands. `stop` tears down the
+isolated guest daemon and its attached test client.
+
+Packaged acceptance uses a separate clean-commit path:
+
+```bash
+tools/testbed/omarchy-vm.sh package-build
+tools/testbed/omarchy-vm.sh package-status
+tools/testbed/omarchy-vm.sh package-install --confirm-guest-install
+# After graphical approval:
+tools/testbed/omarchy-vm.sh package-launch
+tools/testbed/omarchy-vm.sh package-stop
+```
+
+`package-build` refuses tracked or untracked package-input changes, transfers a
+Git bundle for exact `HEAD`, and builds inside an isolated guest package checkout.
+`package-install` requires the explicit confirmation argument, rejects shadowing
+clients, and preserves rollback copies before replacing an existing guest
+package. It never installs on the workstation. `package-launch` runs the exact
+Pacman-owned `/usr/bin/splinterm` and adjacent `/usr/bin/splinterd` with private
+guest socket, state, and config paths; `package-stop` removes only that isolated
+runtime. This is the trusted-UI path for packaged graphical acceptance.
+
+`bootstrap` installs Rust and the guest-only ydotool user service. Development
+launches never install a Splinterm binary or change Omarchy, Hyprland, terminal,
+or default-terminal configuration.
+
 ## Graphical test guardrails
 
 Graphical testing requires separate explicit approval for the complete bounded
@@ -247,22 +313,33 @@ to map, focus, move, resize, capture, or send input to a Window.
 
 Approved tests must:
 
-- use an isolated test Window on workspace 8 / DP-2 unless the user explicitly
-  names an existing active Window;
-- record the target address, PID, workspace, monitor, geometry, original focus,
-  cursor, scale, and transform before input;
-- target the exact fresh address and abort if identity, focus, placement, or
-  cleanup differs;
-- use private daemon/socket/state/config paths and development binaries;
-- run one guarded smoke before any approved matrix;
-- preserve unrelated Windows and user processes; and
-- restore focus, cursor, monitor state, an empty workspace 8, processes, and
-  private paths after every case.
+- use an isolated guest test Window on guest workspace 8 / `Virtual-1` unless
+  the user explicitly approves a host exception or names an existing guest
+  Window for the bounded sequence;
+- record the guest target address, PID, workspace, monitor, geometry, original
+  focus, cursor, scale, and transform before input;
+- target the exact fresh guest address and abort if identity, focus, placement,
+  or cleanup differs;
+- use private guest daemon/socket/state/config paths and development binaries,
+  or the runner's reviewed packaged-acceptance path when installed identity is
+  part of the test;
+- run one guarded guest smoke before any approved matrix;
+- preserve unrelated guest Windows and processes and every workstation Window;
+  and
+- restore guest focus, cursor, monitor state, workspace, processes, and private
+  paths, leaving the guest test workspace empty after every case.
 
-Do not close a user Window, terminate its shell/daemon, enter commands into it,
-or manipulate production topology unless that exact action was separately
-approved. A failed expensive or graphical command must be diagnosed before a
-bounded retry.
+Watching the QEMU viewer does not authorize focusing, moving, resizing, or
+sending host input to that Window. Prefer guest-native `input`; use bounded QMP
+input only as a fallback. Do not close a pre-existing guest Window, terminate its
+shell/daemon, enter commands into it, or manipulate production topology unless
+that exact action was separately approved. A failed expensive or graphical
+command must be diagnosed before a bounded retry.
+
+Host graphical testing requires a separately approved complete exception
+sequence. The request must identify the host target, permitted focus/input,
+smoke, matrix, and cleanup; existing workspace 8 / DP-2 no-focus isolation rules
+remain in force unless the user explicitly names an active host Window.
 
 ## Packaging and installation
 

--- a/packaging/PKGBUILD
+++ b/packaging/PKGBUILD
@@ -30,6 +30,8 @@ check() {
   export RUSTUP_TOOLCHAIN=stable
   cargo test --frozen --workspace -- --test-threads=1
   python -m unittest tools/automation/test_dojo_picker.py
+  python -m unittest tools/testbed/test_omarchy_vm.py
+  python -m unittest tools/testbed/test_qmp_input.py
   python -m unittest tools/package/test_installer_safety.py
   python -m unittest tools/package/test_omarchy_screensaver_integration.py
   python -m unittest tools/package/test_validate_mcp_package.py

--- a/packaging/PKGBUILD
+++ b/packaging/PKGBUILD
@@ -30,6 +30,7 @@ check() {
   export RUSTUP_TOOLCHAIN=stable
   cargo test --frozen --workspace -- --test-threads=1
   python -m unittest tools/automation/test_dojo_picker.py
+  python -m unittest tools/testbed/test_guest_window.py
   python -m unittest tools/testbed/test_omarchy_vm.py
   python -m unittest tools/testbed/test_qmp_input.py
   python -m unittest tools/package/test_installer_safety.py

--- a/tools/release/test_ci_workflow.py
+++ b/tools/release/test_ci_workflow.py
@@ -96,7 +96,7 @@ class CiWorkflowTests(unittest.TestCase):
         pkgbuild = (ROOT / "packaging/PKGBUILD").read_text(encoding="utf-8")
         check_body = pkgbuild.split("check() {", 1)[1].split("\n}", 1)[0]
         python_targets = re.findall(r"python -m unittest ([^\s]+)", check_body)
-        self.assertEqual(len(python_targets), 7)
+        self.assertEqual(len(python_targets), 8)
         for target in python_targets:
             with self.subTest(target=target):
                 self.assertEqual(workflow.count(target), 1)

--- a/tools/release/test_ci_workflow.py
+++ b/tools/release/test_ci_workflow.py
@@ -96,7 +96,7 @@ class CiWorkflowTests(unittest.TestCase):
         pkgbuild = (ROOT / "packaging/PKGBUILD").read_text(encoding="utf-8")
         check_body = pkgbuild.split("check() {", 1)[1].split("\n}", 1)[0]
         python_targets = re.findall(r"python -m unittest ([^\s]+)", check_body)
-        self.assertEqual(len(python_targets), 5)
+        self.assertEqual(len(python_targets), 7)
         for target in python_targets:
             with self.subTest(target=target):
                 self.assertEqual(workflow.count(target), 1)

--- a/tools/testbed/guest-window.py
+++ b/tools/testbed/guest-window.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python3
+"""Guard one disposable Splinterm window inside the Omarchy test VM."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+import sys
+import time
+from typing import Any, NoReturn
+
+
+APP_ID = "com.oldjobobo.splinterm"
+TARGET_MONITOR = "Virtual-1"
+TARGET_WORKSPACE = 8
+ADDRESS = re.compile(r"^0x[0-9A-Fa-f]+$")
+
+
+def fail(message: str) -> NoReturn:
+    raise RuntimeError(message)
+
+
+def command(*arguments: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        arguments,
+        check=check,
+        text=True,
+        capture_output=True,
+    )
+
+
+def hypr_json(name: str, *arguments: str) -> Any:
+    result = command("hyprctl", "-j", name, *arguments)
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError as error:
+        fail(f"hyprctl {name} returned invalid JSON: {error}")
+
+
+def clients() -> list[dict[str, Any]]:
+    value = hypr_json("clients")
+    if not isinstance(value, list):
+        fail("hyprctl clients did not return a list")
+    return value
+
+
+def monitor_record() -> dict[str, Any]:
+    monitors = hypr_json("monitors", "all")
+    matches = [monitor for monitor in monitors if monitor.get("name") == TARGET_MONITOR]
+    if len(matches) != 1:
+        fail(f"expected exactly one active {TARGET_MONITOR} monitor, found {len(matches)}")
+    monitor = matches[0]
+    if monitor.get("disabled") is True:
+        fail(f"target monitor {TARGET_MONITOR} is disabled")
+    return {
+        "id": monitor.get("id"),
+        "name": monitor.get("name"),
+        "scale": monitor.get("scale"),
+        "transform": monitor.get("transform"),
+    }
+
+
+def workspace_id(client: dict[str, Any]) -> int | None:
+    workspace = client.get("workspace")
+    return workspace.get("id") if isinstance(workspace, dict) else None
+
+
+def require_empty_target_workspace(current_clients: list[dict[str, Any]]) -> None:
+    occupants = [client for client in current_clients if workspace_id(client) == TARGET_WORKSPACE]
+    if occupants:
+        fail(f"guest workspace {TARGET_WORKSPACE} is not empty")
+    workspaces = hypr_json("workspaces")
+    matches = [workspace for workspace in workspaces if workspace.get("id") == TARGET_WORKSPACE]
+    if len(matches) > 1:
+        fail(f"guest workspace {TARGET_WORKSPACE} is ambiguous")
+    if matches and matches[0].get("monitor") != TARGET_MONITOR:
+        fail(
+            f"guest workspace {TARGET_WORKSPACE} belongs to "
+            f"{matches[0].get('monitor')}, not {TARGET_MONITOR}"
+        )
+
+
+def write_state(path: Path, state: dict[str, Any]) -> None:
+    path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".next")
+    temporary.write_text(json.dumps(state, sort_keys=True) + "\n", encoding="utf-8")
+    temporary.chmod(0o600)
+    temporary.replace(path)
+
+
+def read_state(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as error:
+        fail(f"guest window state is missing: {path}")
+    except json.JSONDecodeError as error:
+        fail(f"guest window state is invalid: {error}")
+    if not isinstance(value, dict):
+        fail("guest window state is not an object")
+    return value
+
+
+def prepare(path: Path) -> None:
+    if path.exists():
+        fail(f"guest window state already exists; run stop first: {path}")
+    current_clients = clients()
+    require_empty_target_workspace(current_clients)
+    active_workspace = hypr_json("activeworkspace")
+    active_window = hypr_json("activewindow")
+    cursor = hypr_json("cursorpos")
+    monitor = monitor_record()
+    address = active_window.get("address", "") if isinstance(active_window, dict) else ""
+    if address and not ADDRESS.fullmatch(address):
+        fail(f"active window returned an invalid address: {address}")
+    write_state(
+        path,
+        {
+            "active_window": address,
+            "active_workspace": active_workspace.get("id"),
+            "before_addresses": sorted(
+                client["address"]
+                for client in current_clients
+                if isinstance(client.get("address"), str)
+            ),
+            "cursor": {"x": cursor.get("x"), "y": cursor.get("y")},
+            "monitor": monitor,
+            "target_address": None,
+            "target_initial": None,
+            "target_final": None,
+        },
+    )
+    command(
+        "hyprctl",
+        "dispatch",
+        f'hl.dsp.focus({{ monitor = "{TARGET_MONITOR}" }})',
+    )
+    command(
+        "hyprctl",
+        "dispatch",
+        f'hl.dsp.focus({{ workspace = "{TARGET_WORKSPACE}" }})',
+    )
+    active_target = hypr_json("activeworkspace")
+    if (
+        active_target.get("id") != TARGET_WORKSPACE
+        or active_target.get("monitor") != TARGET_MONITOR
+    ):
+        fail(f"could not activate workspace {TARGET_WORKSPACE} on {TARGET_MONITOR}")
+
+
+def fresh_candidates(state: dict[str, Any]) -> list[dict[str, Any]]:
+    before = set(state.get("before_addresses", []))
+    return [
+        client
+        for client in clients()
+        if client.get("address") not in before
+        and client.get("initialClass") == APP_ID
+        and ADDRESS.fullmatch(str(client.get("address", "")))
+    ]
+
+
+def place(path: Path) -> None:
+    state = read_state(path)
+    candidates: list[dict[str, Any]] = []
+    deadline = time.monotonic() + 10
+    while time.monotonic() < deadline:
+        candidates = fresh_candidates(state)
+        if len(candidates) == 1:
+            break
+        if len(candidates) > 1:
+            fail(f"expected one fresh Splinterm window, found {len(candidates)}")
+        time.sleep(0.05)
+    if len(candidates) != 1:
+        fail("fresh Splinterm window did not map within 10 seconds")
+
+    candidate = candidates[0]
+    address = candidate["address"]
+    state["target_address"] = address
+    state["target_initial"] = {
+        "address": address,
+        "pid": candidate.get("pid"),
+        "workspace": workspace_id(candidate),
+        "monitor": candidate.get("monitor"),
+        "at": candidate.get("at"),
+        "size": candidate.get("size"),
+    }
+    write_state(path, state)
+    selector = f"address:{address}"
+    command(
+        "hyprctl",
+        "dispatch",
+        f'hl.dsp.window.move({{ monitor = "{TARGET_MONITOR}", follow = false, window = "{selector}" }})',
+    )
+    command(
+        "hyprctl",
+        "dispatch",
+        f'hl.dsp.window.move({{ workspace = "{TARGET_WORKSPACE}", follow = false, window = "{selector}" }})',
+    )
+    matches = [client for client in clients() if client.get("address") == address]
+    if len(matches) != 1:
+        fail("fresh Splinterm window disappeared during placement")
+    monitor = monitor_record()
+    if workspace_id(matches[0]) != TARGET_WORKSPACE or matches[0].get("monitor") != monitor["id"]:
+        fail(f"fresh Splinterm window was not isolated on workspace {TARGET_WORKSPACE} / {TARGET_MONITOR}")
+    placed = matches[0]
+    state["target_final"] = {
+        "address": address,
+        "pid": placed.get("pid"),
+        "workspace": workspace_id(placed),
+        "monitor": placed.get("monitor"),
+        "at": placed.get("at"),
+        "size": placed.get("size"),
+    }
+    write_state(path, state)
+    print(
+        f"guest window address={address} pid={placed.get('pid')} "
+        f"workspace={TARGET_WORKSPACE} monitor={TARGET_MONITOR} "
+        f"at={placed.get('at')} size={placed.get('size')}"
+    )
+
+
+def restore(path: Path) -> None:
+    state = read_state(path)
+    target_address = state.get("target_address")
+    deadline = time.monotonic() + 10
+    while target_address and time.monotonic() < deadline:
+        if not any(client.get("address") == target_address for client in clients()):
+            break
+        time.sleep(0.05)
+    current_clients = clients()
+    if target_address and any(client.get("address") == target_address for client in current_clients):
+        fail(f"guest test window is still mapped: {target_address}")
+    require_empty_target_workspace(current_clients)
+
+    recorded_monitor = state.get("monitor")
+    if monitor_record() != recorded_monitor:
+        fail(f"target monitor state changed during the test: {recorded_monitor!r}")
+    workspace = state.get("active_workspace")
+    if not isinstance(workspace, int) or workspace < 1:
+        fail(f"recorded workspace is invalid: {workspace!r}")
+    command("hyprctl", "dispatch", f'hl.dsp.focus({{ workspace = "{workspace}" }})')
+    active_window = state.get("active_window")
+    if active_window:
+        if not ADDRESS.fullmatch(active_window):
+            fail(f"recorded active window address is invalid: {active_window}")
+        if any(client.get("address") == active_window for client in current_clients):
+            command(
+                "hyprctl",
+                "dispatch",
+                f'hl.dsp.focus({{ window = "address:{active_window}" }})',
+            )
+    cursor = state.get("cursor", {})
+    x, y = cursor.get("x"), cursor.get("y")
+    if not isinstance(x, (int, float)) or not isinstance(y, (int, float)):
+        fail(f"recorded cursor is invalid: {cursor!r}")
+    ydotool_socket = Path(os.environ.get("YDOTOOL_SOCKET", ""))
+    if not ydotool_socket.is_socket():
+        fail(f"ydotool socket is unavailable: {ydotool_socket}")
+    command("ydotool", "mousemove", "--absolute", "-x", str(round(x)), "-y", str(round(y)))
+    path.unlink()
+    print(f"guest workspace {TARGET_WORKSPACE} is empty; prior focus and cursor restored")
+
+
+def parser() -> argparse.ArgumentParser:
+    result = argparse.ArgumentParser(description=__doc__)
+    result.add_argument("action", choices=("prepare", "place", "restore"))
+    result.add_argument("--state", required=True, type=Path)
+    return result
+
+
+def main() -> int:
+    arguments = parser().parse_args()
+    try:
+        {"prepare": prepare, "place": place, "restore": restore}[arguments.action](arguments.state)
+    except (RuntimeError, subprocess.CalledProcessError) as error:
+        if isinstance(error, subprocess.CalledProcessError) and error.stderr:
+            print(error.stderr.rstrip(), file=sys.stderr)
+        print(f"guest-window: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/testbed/guest-window.py
+++ b/tools/testbed/guest-window.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import os
 from pathlib import Path
 import re
 import subprocess
@@ -256,10 +255,11 @@ def restore(path: Path) -> None:
     x, y = cursor.get("x"), cursor.get("y")
     if not isinstance(x, (int, float)) or not isinstance(y, (int, float)):
         fail(f"recorded cursor is invalid: {cursor!r}")
-    ydotool_socket = Path(os.environ.get("YDOTOOL_SOCKET", ""))
-    if not ydotool_socket.is_socket():
-        fail(f"ydotool socket is unavailable: {ydotool_socket}")
-    command("ydotool", "mousemove", "--absolute", "-x", str(round(x)), "-y", str(round(y)))
+    command(
+        "hyprctl",
+        "dispatch",
+        f"hl.dsp.cursor.move({{ x = {round(x)}, y = {round(y)} }})",
+    )
     path.unlink()
     print(f"guest workspace {TARGET_WORKSPACE} is empty; prior focus and cursor restored")
 

--- a/tools/testbed/guest-window.py
+++ b/tools/testbed/guest-window.py
@@ -17,6 +17,7 @@ APP_ID = "com.oldjobobo.splinterm"
 TARGET_MONITOR = "Virtual-1"
 TARGET_WORKSPACE = 8
 ADDRESS = re.compile(r"^0x[0-9A-Fa-f]+$")
+LAUNCH_TOKEN = re.compile(r"^[0-9a-f]{32}$")
 
 
 def fail(message: str) -> NoReturn:
@@ -150,7 +151,20 @@ def prepare(path: Path) -> None:
         fail(f"could not activate workspace {TARGET_WORKSPACE} on {TARGET_MONITOR}")
 
 
-def fresh_candidates(state: dict[str, Any]) -> list[dict[str, Any]]:
+def process_has_launch_token(pid: int, token: str) -> bool:
+    if pid < 1 or not LAUNCH_TOKEN.fullmatch(token):
+        return False
+    try:
+        environment = Path(f"/proc/{pid}/environ").read_bytes()
+    except (FileNotFoundError, PermissionError, ProcessLookupError):
+        return False
+    expected = f"SPLINTERM_TEST_WINDOW_TOKEN={token}".encode()
+    return expected in environment.split(b"\0")
+
+
+def fresh_candidates(
+    state: dict[str, Any], client_token: str
+) -> list[dict[str, Any]]:
     before = set(state.get("before_addresses", []))
     return [
         client
@@ -158,15 +172,19 @@ def fresh_candidates(state: dict[str, Any]) -> list[dict[str, Any]]:
         if client.get("address") not in before
         and client.get("initialClass") == APP_ID
         and ADDRESS.fullmatch(str(client.get("address", "")))
+        and isinstance(client.get("pid"), int)
+        and process_has_launch_token(client["pid"], client_token)
     ]
 
 
-def place(path: Path) -> None:
+def place(path: Path, client_pid: int, client_token: str) -> None:
     state = read_state(path)
+    state["launch_pid"] = client_pid
+    write_state(path, state)
     candidates: list[dict[str, Any]] = []
     deadline = time.monotonic() + 10
     while time.monotonic() < deadline:
-        candidates = fresh_candidates(state)
+        candidates = fresh_candidates(state, client_token)
         if len(candidates) == 1:
             break
         if len(candidates) > 1:
@@ -268,13 +286,24 @@ def parser() -> argparse.ArgumentParser:
     result = argparse.ArgumentParser(description=__doc__)
     result.add_argument("action", choices=("prepare", "place", "restore"))
     result.add_argument("--state", required=True, type=Path)
+    result.add_argument("--client-pid", type=int)
+    result.add_argument("--client-token")
     return result
 
 
 def main() -> int:
     arguments = parser().parse_args()
     try:
-        {"prepare": prepare, "place": place, "restore": restore}[arguments.action](arguments.state)
+        if arguments.action == "place":
+            if arguments.client_pid is None or arguments.client_pid < 1:
+                fail("place requires a positive --client-pid")
+            if arguments.client_token is None or not LAUNCH_TOKEN.fullmatch(
+                arguments.client_token
+            ):
+                fail("place requires a 32-character lowercase hexadecimal --client-token")
+            place(arguments.state, arguments.client_pid, arguments.client_token)
+        else:
+            {"prepare": prepare, "restore": restore}[arguments.action](arguments.state)
     except (RuntimeError, subprocess.CalledProcessError) as error:
         if isinstance(error, subprocess.CalledProcessError) and error.stderr:
             print(error.stderr.rstrip(), file=sys.stderr)

--- a/tools/testbed/omarchy-vm.env.example
+++ b/tools/testbed/omarchy-vm.env.example
@@ -1,0 +1,9 @@
+# Copy this file to the repository root as .splinterm-testbed.env.
+# Keep private keys and machine-specific paths out of Git.
+SPLINTERM_TESTBED_HOST=127.0.0.1
+SPLINTERM_TESTBED_PORT=2222
+SPLINTERM_TESTBED_USER=omarchy
+SPLINTERM_TESTBED_IDENTITY=/absolute/path/to/id_ed25519
+SPLINTERM_TESTBED_KNOWN_HOSTS=/absolute/path/to/known_hosts
+SPLINTERM_TESTBED_REMOTE_ROOT=/home/omarchy/Projects/splinterm-testbed
+SPLINTERM_TESTBED_QMP_SOCKET=/absolute/path/to/qmp.sock

--- a/tools/testbed/omarchy-vm.sh
+++ b/tools/testbed/omarchy-vm.sh
@@ -359,7 +359,32 @@ command -v splinterm | grep -Fx /usr/bin/splinterm
 pacman -Qo /usr/bin/splinterm /usr/bin/splinterd
 stat -Lc 'identity: %d:%i %n' /usr/bin/splinterm /usr/bin/splinterd
 desktop-file-validate /usr/share/applications/com.oldjobobo.splinterm.desktop
-/usr/bin/splinterm list >/dev/null
+runtime="/run/user/$(id -u)/splinterm-package-install-check"
+socket="$runtime/splinterd.sock"
+state="$package_root/install-check-state"
+rm -rf "$runtime" "$state"
+mkdir -m 700 "$runtime" "$state"
+SPLINTERM_SOCKET="$socket" XDG_STATE_HOME="$state" \
+  /usr/bin/splinterd >"$runtime/daemon.log" 2>&1 </dev/null &
+daemon_pid=$!
+cleanup_install_check() {
+  kill "$daemon_pid" 2>/dev/null || true
+  wait "$daemon_pid" 2>/dev/null || true
+  rm -rf "$runtime" "$state"
+}
+trap cleanup_install_check EXIT
+for _ in $(seq 1 100); do
+  if SPLINTERM_SOCKET="$socket" /usr/bin/splinterm ping >/dev/null 2>&1; then break; fi
+  kill -0 "$daemon_pid" 2>/dev/null || {
+    cat "$runtime/daemon.log" >&2
+    exit 1
+  }
+  sleep 0.05
+done
+SPLINTERM_SOCKET="$socket" /usr/bin/splinterm ping >/dev/null
+SPLINTERM_SOCKET="$socket" /usr/bin/splinterm list >/dev/null
+cleanup_install_check
+trap - EXIT
 REMOTE
     ;;
   package-launch)

--- a/tools/testbed/omarchy-vm.sh
+++ b/tools/testbed/omarchy-vm.sh
@@ -108,7 +108,7 @@ desktop_command() {
   local command
   command=$(quote_command "$@")
   ssh "${ssh_options[@]}" "$target" \
-    "set -euo pipefail; instance=\$(hyprctl instances -j | jq -er '.[0]'); runtime=/run/user/\$(id -u); export XDG_RUNTIME_DIR=\$runtime WAYLAND_DISPLAY=\$(jq -r .wl_socket <<<\"\$instance\") HYPRLAND_INSTANCE_SIGNATURE=\$(jq -r .instance <<<\"\$instance\") DBUS_SESSION_BUS_ADDRESS=unix:path=\$runtime/bus; cd $(printf '%q' "$remote_root"); exec $command"
+    "set -euo pipefail; instance=\$(hyprctl instances -j | jq -er 'if length == 1 then .[0] else error(\"expected exactly one Hyprland instance\") end'); runtime=/run/user/\$(id -u); export XDG_RUNTIME_DIR=\$runtime WAYLAND_DISPLAY=\$(jq -r .wl_socket <<<\"\$instance\") HYPRLAND_INSTANCE_SIGNATURE=\$(jq -r .instance <<<\"\$instance\") DBUS_SESSION_BUS_ADDRESS=unix:path=\$runtime/bus; cd $(printf '%q' "$remote_root"); exec $command"
 }
 
 input_command() {
@@ -307,10 +307,13 @@ cleanup_failed_launch() {
 }
 trap cleanup_failed_launch ERR
 python tools/testbed/guest-window.py prepare --state "$window_state"
+client_token=$(python -c 'import secrets; print(secrets.token_hex(16))')
+SPLINTERM_TEST_WINDOW_TOKEN="$client_token" \
 SPLINTERM_REPO="$SPLINTERM_TESTBED_ROOT" \
   nohup ./splinterm-test launch >"$log_dir/client.log" 2>&1 </dev/null &
 client_pid=$!
-python tools/testbed/guest-window.py place --state "$window_state"
+python tools/testbed/guest-window.py place --state "$window_state" \
+  --client-pid "$client_pid" --client-token "$client_token"
 printf 'guest client pid=%s log=%s\n' "$client_pid" "$log_dir/client.log"
 trap - ERR
 REMOTE
@@ -495,11 +498,14 @@ for _ in $(seq 1 100); do
   sleep 0.05
 done
 SPLINTERM_SOCKET="$socket" /usr/bin/splinterm ping >/dev/null
+client_token=$(python -c 'import secrets; print(secrets.token_hex(16))')
+SPLINTERM_TEST_WINDOW_TOKEN="$client_token" \
 SPLINTERM_SOCKET="$socket" XDG_STATE_HOME="$state" XDG_CONFIG_HOME="$config" \
   nohup /usr/bin/splinterm launch --working-directory "$SPLINTERM_TESTBED_ROOT" \
     >"$runtime/client.log" 2>&1 </dev/null &
 client_pid=$!
-python "$package_root/source/tools/testbed/guest-window.py" place --state "$window_state"
+python "$package_root/source/tools/testbed/guest-window.py" place --state "$window_state" \
+  --client-pid "$client_pid" --client-token "$client_token"
 printf 'guest packaged client pid=%s daemon=%s log=%s\n' \
   "$client_pid" "$daemon_pid" "$runtime/client.log"
 trap - ERR

--- a/tools/testbed/omarchy-vm.sh
+++ b/tools/testbed/omarchy-vm.sh
@@ -452,7 +452,8 @@ stop_matching() {
   local expected=$1 process executable
   for process in /proc/[0-9]*; do
     [[ -r $process/environ ]] || continue
-    tr '\0' '\n' <"$process/environ" 2>/dev/null | grep -Fqx "SPLINTERM_SOCKET=$socket" || continue
+    cat "$process/environ" 2>/dev/null | tr '\0' '\n' \
+      | grep -Fqx "SPLINTERM_SOCKET=$socket" || continue
     executable=$(readlink -f "$process/exe" 2>/dev/null || true)
     [[ $executable == "$expected" ]] && kill "${process##*/}" 2>/dev/null || true
   done
@@ -463,7 +464,8 @@ for _ in $(seq 1 100); do
   alive=false
   for process in /proc/[0-9]*; do
     [[ -r $process/environ ]] || continue
-    if tr '\0' '\n' <"$process/environ" 2>/dev/null | grep -Fqx "SPLINTERM_SOCKET=$socket"; then
+    if cat "$process/environ" 2>/dev/null | tr '\0' '\n' \
+      | grep -Fqx "SPLINTERM_SOCKET=$socket"; then
       executable=$(readlink -f "$process/exe" 2>/dev/null || true)
       case $executable in /usr/bin/splinterm|/usr/bin/splinterd) alive=true ;; esac
     fi

--- a/tools/testbed/omarchy-vm.sh
+++ b/tools/testbed/omarchy-vm.sh
@@ -279,24 +279,63 @@ REMOTE
     ssh "${ssh_options[@]}" "$target" \
       "SPLINTERM_TESTBED_ROOT=$(printf '%q' "$remote_root") bash -s" <<'REMOTE'
 set -euo pipefail
-instance=$(hyprctl instances -j | jq -er '.[0]')
-wayland_display=$(jq -r '.wl_socket' <<<"$instance")
-hyprland_signature=$(jq -r '.instance' <<<"$instance")
+instance=$(hyprctl instances -j | jq -er \
+  'if length == 1 then .[0] else error("expected exactly one Hyprland instance") end')
 runtime_dir="/run/user/$(id -u)"
 log_dir="$runtime_dir/splinterm-test"
-mkdir -p "$log_dir"
+window_state="$log_dir/guest-window.json"
+mkdir -m 700 -p "$log_dir"
+export XDG_RUNTIME_DIR="$runtime_dir"
+export WAYLAND_DISPLAY
+WAYLAND_DISPLAY=$(jq -r '.wl_socket' <<<"$instance")
+export HYPRLAND_INSTANCE_SIGNATURE
+HYPRLAND_INSTANCE_SIGNATURE=$(jq -r '.instance' <<<"$instance")
+export DBUS_SESSION_BUS_ADDRESS="unix:path=$runtime_dir/bus"
+export YDOTOOL_SOCKET="$runtime_dir/.ydotool_socket"
 cd "$SPLINTERM_TESTBED_ROOT"
-XDG_RUNTIME_DIR="$runtime_dir" \
-WAYLAND_DISPLAY="$wayland_display" \
-HYPRLAND_INSTANCE_SIGNATURE="$hyprland_signature" \
-DBUS_SESSION_BUS_ADDRESS="unix:path=$runtime_dir/bus" \
+[[ ! -e $window_state ]] || {
+  printf 'development guest window state exists; run stop first\n' >&2
+  exit 1
+}
+client_pid=
+cleanup_failed_launch() {
+  [[ -z $client_pid ]] || kill "$client_pid" 2>/dev/null || true
+  SPLINTERM_REPO="$SPLINTERM_TESTBED_ROOT" ./splinterm-test stop || true
+  [[ -z $client_pid ]] || wait "$client_pid" 2>/dev/null || true
+  [[ ! -e $window_state ]] \
+    || python tools/testbed/guest-window.py restore --state "$window_state" || true
+}
+trap cleanup_failed_launch ERR
+python tools/testbed/guest-window.py prepare --state "$window_state"
 SPLINTERM_REPO="$SPLINTERM_TESTBED_ROOT" \
   nohup ./splinterm-test launch >"$log_dir/client.log" 2>&1 </dev/null &
-printf 'guest client pid=%s log=%s\n' "$!" "$log_dir/client.log"
+client_pid=$!
+python tools/testbed/guest-window.py place --state "$window_state"
+printf 'guest client pid=%s log=%s\n' "$client_pid" "$log_dir/client.log"
+trap - ERR
 REMOTE
     ;;
   stop)
-    remote_command ./splinterm-test stop
+    ssh "${ssh_options[@]}" "$target" \
+      "SPLINTERM_TESTBED_ROOT=$(printf '%q' "$remote_root") bash -s" <<'REMOTE'
+set -euo pipefail
+instance=$(hyprctl instances -j | jq -er \
+  'if length == 1 then .[0] else error("expected exactly one Hyprland instance") end')
+runtime_dir="/run/user/$(id -u)"
+window_state="$runtime_dir/splinterm-test/guest-window.json"
+export XDG_RUNTIME_DIR="$runtime_dir"
+export WAYLAND_DISPLAY
+WAYLAND_DISPLAY=$(jq -r '.wl_socket' <<<"$instance")
+export HYPRLAND_INSTANCE_SIGNATURE
+HYPRLAND_INSTANCE_SIGNATURE=$(jq -r '.instance' <<<"$instance")
+export DBUS_SESSION_BUS_ADDRESS="unix:path=$runtime_dir/bus"
+export YDOTOOL_SOCKET="$runtime_dir/.ydotool_socket"
+cd "$SPLINTERM_TESTBED_ROOT"
+./splinterm-test stop
+if [[ -e $window_state ]]; then
+  python tools/testbed/guest-window.py restore --state "$window_state"
+fi
+REMOTE
     ;;
   package-build)
     (($# == 0)) || fail 'package-build takes no arguments'
@@ -397,27 +436,56 @@ resolved=$(command -v splinterm 2>/dev/null || true)
 [[ $resolved == /usr/bin/splinterm ]]
 pacman -Qo /usr/bin/splinterm /usr/bin/splinterd >/dev/null
 package_root=$SPLINTERM_TESTBED_PACKAGE_ROOT
-test -d "$package_root"
+test -d "$package_root/source/.git"
 test ! -L "$package_root"
 runtime="/run/user/$(id -u)/splinterm-package-test"
 socket="$runtime/splinterd.sock"
+window_state="$runtime/guest-window.json"
 state="$package_root/acceptance-state"
 config="$package_root/acceptance-config"
+for process in /proc/[0-9]*; do
+  [[ -r $process/environ ]] || continue
+  cat "$process/environ" 2>/dev/null | tr '\0' '\n' \
+    | grep -Fqx "SPLINTERM_SOCKET=$socket" || continue
+  executable=$(readlink -f "$process/exe" 2>/dev/null || true)
+  case $executable in
+    /usr/bin/splinterm|/usr/bin/splinterd)
+      printf 'packaged test is already active; run package-stop first\n' >&2
+      exit 1
+      ;;
+  esac
+done
+[[ ! -e $window_state ]] || {
+  printf 'packaged guest window state exists; run package-stop first\n' >&2
+  exit 1
+}
 rm -rf "$runtime" "$state" "$config"
 mkdir -m 700 "$runtime" "$state" "$config"
-instance=$(hyprctl instances -j | jq -er '.[0]')
-wayland_display=$(jq -r '.wl_socket' <<<"$instance")
-hyprland_signature=$(jq -r '.instance' <<<"$instance")
+instance=$(hyprctl instances -j | jq -er \
+  'if length == 1 then .[0] else error("expected exactly one Hyprland instance") end')
 export XDG_RUNTIME_DIR="/run/user/$(id -u)"
+export WAYLAND_DISPLAY
+WAYLAND_DISPLAY=$(jq -r '.wl_socket' <<<"$instance")
+export HYPRLAND_INSTANCE_SIGNATURE
+HYPRLAND_INSTANCE_SIGNATURE=$(jq -r '.instance' <<<"$instance")
 export DBUS_SESSION_BUS_ADDRESS="unix:path=$XDG_RUNTIME_DIR/bus"
+export YDOTOOL_SOCKET="$XDG_RUNTIME_DIR/.ydotool_socket"
+daemon_pid=
+client_pid=
+cleanup_failed_launch() {
+  [[ -z $client_pid ]] || kill "$client_pid" 2>/dev/null || true
+  [[ -z $daemon_pid ]] || kill "$daemon_pid" 2>/dev/null || true
+  [[ -z $client_pid ]] || wait "$client_pid" 2>/dev/null || true
+  [[ -z $daemon_pid ]] || wait "$daemon_pid" 2>/dev/null || true
+  [[ ! -e $window_state ]] \
+    || python "$package_root/source/tools/testbed/guest-window.py" restore \
+      --state "$window_state" || true
+}
+trap cleanup_failed_launch ERR
+python "$package_root/source/tools/testbed/guest-window.py" prepare --state "$window_state"
 SPLINTERM_SOCKET="$socket" XDG_STATE_HOME="$state" XDG_CONFIG_HOME="$config" \
   nohup /usr/bin/splinterd >"$runtime/daemon.log" 2>&1 </dev/null &
 daemon_pid=$!
-cleanup_failed_launch() {
-  kill "$daemon_pid" 2>/dev/null || true
-  wait "$daemon_pid" 2>/dev/null || true
-}
-trap cleanup_failed_launch ERR
 for _ in $(seq 1 100); do
   if SPLINTERM_SOCKET="$socket" /usr/bin/splinterm ping >/dev/null 2>&1; then break; fi
   kill -0 "$daemon_pid" 2>/dev/null || {
@@ -427,16 +495,13 @@ for _ in $(seq 1 100); do
   sleep 0.05
 done
 SPLINTERM_SOCKET="$socket" /usr/bin/splinterm ping >/dev/null
-XDG_RUNTIME_DIR="$XDG_RUNTIME_DIR" \
-WAYLAND_DISPLAY="$wayland_display" \
-HYPRLAND_INSTANCE_SIGNATURE="$hyprland_signature" \
-DBUS_SESSION_BUS_ADDRESS="$DBUS_SESSION_BUS_ADDRESS" \
-SPLINTERM_SOCKET="$socket" \
-XDG_STATE_HOME="$state" \
-XDG_CONFIG_HOME="$config" \
+SPLINTERM_SOCKET="$socket" XDG_STATE_HOME="$state" XDG_CONFIG_HOME="$config" \
   nohup /usr/bin/splinterm launch --working-directory "$SPLINTERM_TESTBED_ROOT" \
     >"$runtime/client.log" 2>&1 </dev/null &
-printf 'guest packaged client pid=%s daemon=%s log=%s\n' "$!" "$daemon_pid" "$runtime/client.log"
+client_pid=$!
+python "$package_root/source/tools/testbed/guest-window.py" place --state "$window_state"
+printf 'guest packaged client pid=%s daemon=%s log=%s\n' \
+  "$client_pid" "$daemon_pid" "$runtime/client.log"
 trap - ERR
 REMOTE
     ;;
@@ -448,6 +513,7 @@ REMOTE
 set -euo pipefail
 runtime="/run/user/$(id -u)/splinterm-package-test"
 socket="$runtime/splinterd.sock"
+window_state="$runtime/guest-window.json"
 stop_matching() {
   local expected=$1 process executable
   for process in /proc/[0-9]*; do
@@ -474,6 +540,19 @@ for _ in $(seq 1 100); do
   sleep 0.05
 done
 [[ $alive == false ]]
+if [[ -e $window_state ]]; then
+  instance=$(hyprctl instances -j | jq -er \
+    'if length == 1 then .[0] else error("expected exactly one Hyprland instance") end')
+  export XDG_RUNTIME_DIR="/run/user/$(id -u)"
+  export WAYLAND_DISPLAY
+  WAYLAND_DISPLAY=$(jq -r '.wl_socket' <<<"$instance")
+  export HYPRLAND_INSTANCE_SIGNATURE
+  HYPRLAND_INSTANCE_SIGNATURE=$(jq -r '.instance' <<<"$instance")
+  export DBUS_SESSION_BUS_ADDRESS="unix:path=$XDG_RUNTIME_DIR/bus"
+  export YDOTOOL_SOCKET="$XDG_RUNTIME_DIR/.ydotool_socket"
+  python "$SPLINTERM_TESTBED_PACKAGE_ROOT/source/tools/testbed/guest-window.py" restore \
+    --state "$window_state"
+fi
 rm -rf "$runtime" "$SPLINTERM_TESTBED_PACKAGE_ROOT/acceptance-state" \
   "$SPLINTERM_TESTBED_PACKAGE_ROOT/acceptance-config"
 REMOTE

--- a/tools/testbed/omarchy-vm.sh
+++ b/tools/testbed/omarchy-vm.sh
@@ -1,0 +1,470 @@
+#!/usr/bin/env bash
+# Remote paths and commands are deliberately quoted and expanded on the client.
+# shellcheck disable=SC2029
+set -euo pipefail
+
+repo_root=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)
+config_file=${SPLINTERM_TESTBED_CONFIG:-"$repo_root/.splinterm-testbed.env"}
+
+if [[ -r $config_file ]]; then
+  # This is an explicitly selected, maintainer-owned shell configuration file.
+  # shellcheck source=/dev/null
+  source "$config_file"
+fi
+
+host=${SPLINTERM_TESTBED_HOST:-127.0.0.1}
+port=${SPLINTERM_TESTBED_PORT:-2222}
+user=${SPLINTERM_TESTBED_USER:-omarchy}
+identity=${SPLINTERM_TESTBED_IDENTITY:-}
+known_hosts=${SPLINTERM_TESTBED_KNOWN_HOSTS:-}
+remote_root=${SPLINTERM_TESTBED_REMOTE_ROOT:-"/home/$user/Projects/splinterm-testbed"}
+qmp_socket=${SPLINTERM_TESTBED_QMP_SOCKET:-}
+action=${1:-status}
+if (($# > 0)); then
+  shift
+fi
+
+usage() {
+  cat <<'USAGE'
+Splinterm Omarchy VM testbed runner
+
+Usage: tools/testbed/omarchy-vm.sh ACTION [ARGS...]
+
+Actions:
+  status             Inspect VM, compositor, toolchain, and checkout state
+  bootstrap          Install Rust plus the guest-native input control service
+  sync               Mirror the current worktree into the isolated guest checkout
+  check              Sync and run the normal non-graphical validation boundary
+  cargo ARGS...      Sync and run a focused Cargo command in the guest
+  ping               Sync and verify the isolated development daemon
+  qmp ARGS...         Query or control guest input through the pinned QMP socket
+  input ARGS...       Send guest-native ydotool keyboard or pointer input
+  launch             Sync and launch development Splinterm on guest Wayland
+  stop               Stop the isolated development daemon and test client
+  package-build      Build packages from clean committed HEAD inside the guest
+  package-status     Inspect guest package and trusted sibling identities
+  package-install --confirm-guest-install
+                     Install the built guest package, preserving rollback copies
+  package-launch     Launch installed /usr/bin siblings with private guest state
+  package-stop       Stop installed-package test processes and remove private state
+  exec COMMAND...    Run a command from the guest checkout without syncing
+  desktop-exec CMD... Run a command in the guest Wayland session
+  shell              Open an interactive shell in the guest checkout
+USAGE
+}
+
+fail() {
+  printf 'omarchy-vm: %s\n' "$*" >&2
+  exit 1
+}
+
+case "$action" in
+  -h|--help|help)
+    usage
+    exit 0
+    ;;
+esac
+
+[[ $port =~ ^[0-9]+$ ]] || fail 'SPLINTERM_TESTBED_PORT must be numeric'
+[[ $user =~ ^[a-z_][a-z0-9_-]*$ ]] || fail 'SPLINTERM_TESTBED_USER is invalid'
+remote_parent="/home/$user/Projects"
+remote_leaf=${remote_root##*/}
+[[ $remote_root == "$remote_parent/$remote_leaf" \
+  && $remote_leaf =~ ^splinterm-testbed(-[A-Za-z0-9._]+)?$ ]] \
+  || fail "SPLINTERM_TESTBED_REMOTE_ROOT must be $remote_parent/splinterm-testbed[-suffix]"
+[[ -n $identity ]] || fail "set SPLINTERM_TESTBED_IDENTITY in $config_file"
+[[ -r $identity ]] || fail "identity file is not readable: $identity"
+[[ -n $known_hosts ]] || fail "set SPLINTERM_TESTBED_KNOWN_HOSTS in $config_file"
+[[ -r $known_hosts ]] || fail "known-hosts file is not readable: $known_hosts"
+
+ssh_options=(
+  -i "$identity"
+  -p "$port"
+  -o BatchMode=yes
+  -o IdentitiesOnly=yes
+  -o StrictHostKeyChecking=yes
+  -o "UserKnownHostsFile=$known_hosts"
+  -o ConnectTimeout=10
+)
+target="$user@$host"
+
+quote_command() {
+  local quoted=() argument
+  for argument in "$@"; do
+    printf -v argument '%q' "$argument"
+    quoted+=("$argument")
+  done
+  printf '%s' "${quoted[*]}"
+}
+
+remote_command() {
+  local command
+  command=$(quote_command "$@")
+  ssh "${ssh_options[@]}" "$target" \
+    "cd $(printf '%q' "$remote_root") && exec $command"
+}
+
+desktop_command() {
+  local command
+  command=$(quote_command "$@")
+  ssh "${ssh_options[@]}" "$target" \
+    "set -euo pipefail; instance=\$(hyprctl instances -j | jq -er '.[0]'); runtime=/run/user/\$(id -u); export XDG_RUNTIME_DIR=\$runtime WAYLAND_DISPLAY=\$(jq -r .wl_socket <<<\"\$instance\") HYPRLAND_INSTANCE_SIGNATURE=\$(jq -r .instance <<<\"\$instance\") DBUS_SESSION_BUS_ADDRESS=unix:path=\$runtime/bus; cd $(printf '%q' "$remote_root"); exec $command"
+}
+
+input_command() {
+  local command
+  command=$(quote_command ydotool "$@")
+  ssh "${ssh_options[@]}" "$target" \
+    "set -euo pipefail; socket=/run/user/\$(id -u)/.ydotool_socket; test -S \"\$socket\"; export YDOTOOL_SOCKET=\$socket; exec $command"
+}
+
+sync_checkout() {
+  local rsync_rsh
+  local rsync_output=()
+  printf 'Syncing current worktree to %s:%s…\n' "$target" "$remote_root"
+  printf -v rsync_rsh '%q ' ssh "${ssh_options[@]}"
+  if [[ ${SPLINTERM_TESTBED_VERBOSE:-0} == 1 ]]; then
+    rsync_output=(--human-readable --itemize-changes)
+  fi
+  ssh "${ssh_options[@]}" "$target" \
+    "set -eu; parent=$(printf '%q' "$remote_parent"); root=$(printf '%q' "$remote_root"); mkdir -p \"\$parent\"; test ! -L \"\$parent\"; if test -e \"\$root\" || test -L \"\$root\"; then test -d \"\$root\" && test ! -L \"\$root\"; else mkdir \"\$root\"; fi"
+  rsync --archive --delete "${rsync_output[@]}" \
+    --exclude=/.env \
+    --exclude=/.splinterm-testbed.env \
+    --exclude=/.git/ \
+    --exclude=/.pi/ \
+    --exclude=/.testbed-package/ \
+    --exclude=/.worktrees/ \
+    --exclude=/benchmark-results/ \
+    --exclude=/graphify-out/ \
+    --exclude=/packaging/pkg/ \
+    --exclude=/packaging/src/ \
+    --exclude=/site/node_modules/ \
+    --exclude=/site/dist/ \
+    --exclude=/target/ \
+    --exclude='**/__pycache__/' \
+    -e "$rsync_rsh" \
+    "$repo_root/" "$target:$remote_root/"
+  printf 'Sync complete.\n'
+}
+
+prepare_package_checkout() {
+  local dirty bundle commit rsync_rsh package_root
+  dirty=$(git -C "$repo_root" status --porcelain --untracked-files=normal -- . \
+    ':(exclude)AGENTS.md' ':(exclude).splinterm-testbed.env')
+  [[ -z $dirty ]] || fail 'package-build requires a clean committed checkout'
+  commit=$(git -C "$repo_root" rev-parse --verify HEAD)
+  bundle=$(mktemp "${TMPDIR:-/tmp}/splinterm-testbed.XXXXXX.bundle")
+  trap 'rm -f "$bundle"' RETURN
+  git -C "$repo_root" bundle create "$bundle" HEAD
+  package_root="$remote_root/.testbed-package"
+  ssh "${ssh_options[@]}" "$target" \
+    "set -eu; root=$(printf '%q' "$remote_root"); package=$(printf '%q' "$package_root"); test -d \"\$root\"; test ! -L \"\$root\"; if test -e \"\$package\" || test -L \"\$package\"; then test -d \"\$package\" && test ! -L \"\$package\"; else mkdir \"\$package\"; fi"
+  printf -v rsync_rsh '%q ' ssh "${ssh_options[@]}"
+  rsync --archive -e "$rsync_rsh" "$bundle" "$target:$package_root/HEAD.bundle"
+  ssh "${ssh_options[@]}" "$target" \
+    "SPLINTERM_TESTBED_PACKAGE_ROOT=$(printf '%q' "$package_root") SPLINTERM_TESTBED_COMMIT=$(printf '%q' "$commit") bash -s" <<'REMOTE'
+set -euo pipefail
+cd "$SPLINTERM_TESTBED_PACKAGE_ROOT"
+test ! -L HEAD.bundle
+rm -rf source.next
+trap 'rm -rf source.next' EXIT
+git clone --quiet --no-checkout HEAD.bundle source.next
+git -C source.next checkout --quiet --detach "$SPLINTERM_TESTBED_COMMIT"
+test -z "$(git -C source.next status --porcelain --untracked-files=all)"
+rm -rf source
+mv source.next source
+trap - EXIT
+printf 'guest package source: %s (%s)\n' "$SPLINTERM_TESTBED_PACKAGE_ROOT/source" "$SPLINTERM_TESTBED_COMMIT"
+REMOTE
+  rm -f "$bundle"
+  trap - RETURN
+}
+
+case "$action" in
+  status)
+    ssh "${ssh_options[@]}" "$target" \
+      "SPLINTERM_TESTBED_ROOT=$(printf '%q' "$remote_root") bash -s" <<'REMOTE'
+set -euo pipefail
+runtime=/run/user/$(id -u)
+export XDG_RUNTIME_DIR="$runtime" DBUS_SESSION_BUS_ADDRESS="unix:path=$runtime/bus"
+printf 'host: %s\n' "$(hostname)"
+printf 'os: '
+sed -n 's/^PRETTY_NAME=//p' /etc/os-release | tr -d '"'
+printf 'session: '
+loginctl show-session "$(loginctl list-sessions --no-legend | awk '$3 == ENVIRON["USER"] && $4 == "seat0" { print $1; exit }')" \
+  -p Active -p Desktop -p Type --value | paste -sd / -
+printf 'hyprland: '
+hyprctl instances -j | jq -r 'if length == 0 then "not running" else .[0] | "pid=\(.pid) socket=\(.wl_socket) instance=\(.instance)" end'
+printf 'rust: '
+if command -v rustc >/dev/null; then rustc --version; else printf 'not installed\n'; fi
+printf 'cargo: '
+if command -v cargo >/dev/null; then cargo --version; else printf 'not installed\n'; fi
+printf 'input: '
+if command -v ydotool >/dev/null && systemctl --user is-active --quiet ydotool.service \
+  && [[ -S $runtime/.ydotool_socket ]]; then
+  printf 'ydotool active\n'
+else
+  printf 'unavailable\n'
+fi
+printf 'checkout: '
+if [[ -f $SPLINTERM_TESTBED_ROOT/Cargo.toml ]]; then
+  printf '%s\n' "$SPLINTERM_TESTBED_ROOT"
+else
+  printf 'not synced (%s)\n' "$SPLINTERM_TESTBED_ROOT"
+fi
+printf 'space: '
+df -h --output=avail "$HOME" | tail -1 | xargs
+REMOTE
+    ;;
+  bootstrap)
+    ssh "${ssh_options[@]}" "$target" 'bash -s' <<'REMOTE'
+set -euo pipefail
+omarchy pkg add rustup ydotool
+if ! id -nG | tr ' ' '\n' | grep -Fqx input; then
+  printf 'omarchy-vm: guest user must belong to the input group\n' >&2
+  exit 1
+fi
+if [[ -e /dev/uinput && ! -w /dev/uinput ]]; then
+  sudo -n chgrp input /dev/uinput
+  sudo -n chmod 0660 /dev/uinput
+fi
+runtime=/run/user/$(id -u)
+export XDG_RUNTIME_DIR="$runtime" DBUS_SESSION_BUS_ADDRESS="unix:path=$runtime/bus"
+systemctl --user enable --now ydotool.service
+for _ in $(seq 1 30); do
+  [[ -S $runtime/.ydotool_socket ]] && break
+  sleep 0.1
+done
+[[ -S $runtime/.ydotool_socket ]]
+rustup toolchain install 1.88.0 --profile minimal --component clippy,rustfmt
+rustup default 1.88.0
+rustc --version
+cargo --version
+REMOTE
+    ;;
+  sync)
+    sync_checkout
+    ;;
+  check)
+    sync_checkout
+    printf '\n[1/3] Formatting\n'
+    remote_command cargo fmt --all --check
+    printf '\n[2/3] Clippy\n'
+    remote_command cargo clippy --workspace --all-targets -- -D warnings
+    printf '\n[3/3] Workspace tests\n'
+    remote_command cargo test --workspace -- --test-threads=1
+    printf '\nVM validation complete.\n'
+    ;;
+  cargo)
+    (($# > 0)) || fail 'cargo requires arguments'
+    sync_checkout
+    remote_command cargo "$@"
+    ;;
+  ping)
+    sync_checkout
+    remote_command env "SPLINTERM_REPO=$remote_root" ./splinterm-test ping
+    ;;
+  qmp)
+    [[ -n $qmp_socket ]] || fail "set SPLINTERM_TESTBED_QMP_SOCKET in $config_file"
+    (($# > 0)) || fail 'qmp requires a qmp-input.py action'
+    "$repo_root/tools/testbed/qmp-input.py" --socket "$qmp_socket" "$@"
+    ;;
+  input)
+    (($# > 0)) || fail 'input requires ydotool arguments'
+    input_command "$@"
+    ;;
+  launch)
+    sync_checkout
+    ssh "${ssh_options[@]}" "$target" \
+      "SPLINTERM_TESTBED_ROOT=$(printf '%q' "$remote_root") bash -s" <<'REMOTE'
+set -euo pipefail
+instance=$(hyprctl instances -j | jq -er '.[0]')
+wayland_display=$(jq -r '.wl_socket' <<<"$instance")
+hyprland_signature=$(jq -r '.instance' <<<"$instance")
+runtime_dir="/run/user/$(id -u)"
+log_dir="$runtime_dir/splinterm-test"
+mkdir -p "$log_dir"
+cd "$SPLINTERM_TESTBED_ROOT"
+XDG_RUNTIME_DIR="$runtime_dir" \
+WAYLAND_DISPLAY="$wayland_display" \
+HYPRLAND_INSTANCE_SIGNATURE="$hyprland_signature" \
+DBUS_SESSION_BUS_ADDRESS="unix:path=$runtime_dir/bus" \
+SPLINTERM_REPO="$SPLINTERM_TESTBED_ROOT" \
+  nohup ./splinterm-test launch >"$log_dir/client.log" 2>&1 </dev/null &
+printf 'guest client pid=%s log=%s\n' "$!" "$log_dir/client.log"
+REMOTE
+    ;;
+  stop)
+    remote_command ./splinterm-test stop
+    ;;
+  package-build)
+    (($# == 0)) || fail 'package-build takes no arguments'
+    prepare_package_checkout
+    package_root="$remote_root/.testbed-package"
+    ssh "${ssh_options[@]}" "$target" \
+      "cd $(printf '%q' "$package_root/source") && exec ./tools/package/build-local-package.sh"
+    ;;
+  package-status)
+    (($# == 0)) || fail 'package-status takes no arguments'
+    ssh "${ssh_options[@]}" "$target" 'bash -s' <<'REMOTE'
+set -euo pipefail
+printf 'command: %s\n' "$(command -v splinterm 2>/dev/null || printf 'not installed')"
+printf 'package: '
+pacman -Q splinterm 2>/dev/null || printf 'not installed\n'
+printf 'daemon: '
+pid=$(pgrep -xo splinterd || true)
+if [[ -n $pid ]]; then
+  executable=$(readlink -f "/proc/$pid/exe")
+  printf 'pid=%s executable=%s\n' "$pid" "$executable"
+else
+  printf 'not running\n'
+fi
+if [[ -e /usr/bin/splinterm || -L /usr/bin/splinterm ]]; then
+  test -f /usr/bin/splinterm
+  test -f /usr/bin/splinterd
+  pacman -Qo /usr/bin/splinterm /usr/bin/splinterd
+  stat -Lc 'identity: %d:%i %n' /usr/bin/splinterm /usr/bin/splinterd
+  desktop-file-validate /usr/share/applications/com.oldjobobo.splinterm.desktop
+fi
+REMOTE
+    ;;
+  package-install)
+    [[ ${1:-} == --confirm-guest-install && $# == 1 ]] \
+      || fail 'package-install requires --confirm-guest-install'
+    package_root="$remote_root/.testbed-package"
+    ssh "${ssh_options[@]}" "$target" \
+      "SPLINTERM_TESTBED_PACKAGE_ROOT=$(printf '%q' "$package_root") bash -s" <<'REMOTE'
+set -euo pipefail
+package_root=$SPLINTERM_TESTBED_PACKAGE_ROOT
+source_root="$package_root/source"
+test -d "$source_root/.git"
+test ! -L "$package_root"
+resolved=$(command -v splinterm 2>/dev/null || true)
+[[ -z $resolved || $resolved == /usr/bin/splinterm ]] || {
+  printf 'shadowing client would break trusted UI identity: %s\n' "$resolved" >&2
+  exit 1
+}
+if pacman -Q splinterm >/dev/null 2>&1; then
+  rollback="$package_root/rollback/$(date -u +%Y%m%dT%H%M%SZ)"
+  mkdir -p "$rollback"
+  pacman -Q splinterm >"$rollback/package.txt"
+  cp --preserve=all /usr/bin/splinterm /usr/bin/splinterd "$rollback/"
+  sha256sum /usr/bin/splinterm /usr/bin/splinterd >"$rollback/sha256sums"
+  printf 'rollback copies: %s\n' "$rollback"
+fi
+cd "$source_root"
+./tools/package/upgrade-local-package.sh --yes
+command -v splinterm | grep -Fx /usr/bin/splinterm
+pacman -Qo /usr/bin/splinterm /usr/bin/splinterd
+stat -Lc 'identity: %d:%i %n' /usr/bin/splinterm /usr/bin/splinterd
+desktop-file-validate /usr/share/applications/com.oldjobobo.splinterm.desktop
+/usr/bin/splinterm list >/dev/null
+REMOTE
+    ;;
+  package-launch)
+    (($# == 0)) || fail 'package-launch takes no arguments'
+    package_root="$remote_root/.testbed-package"
+    ssh "${ssh_options[@]}" "$target" \
+      "SPLINTERM_TESTBED_ROOT=$(printf '%q' "$remote_root") SPLINTERM_TESTBED_PACKAGE_ROOT=$(printf '%q' "$package_root") bash -s" <<'REMOTE'
+set -euo pipefail
+resolved=$(command -v splinterm 2>/dev/null || true)
+[[ $resolved == /usr/bin/splinterm ]]
+pacman -Qo /usr/bin/splinterm /usr/bin/splinterd >/dev/null
+package_root=$SPLINTERM_TESTBED_PACKAGE_ROOT
+test -d "$package_root"
+test ! -L "$package_root"
+runtime="/run/user/$(id -u)/splinterm-package-test"
+socket="$runtime/splinterd.sock"
+state="$package_root/acceptance-state"
+config="$package_root/acceptance-config"
+rm -rf "$runtime" "$state" "$config"
+mkdir -m 700 "$runtime" "$state" "$config"
+instance=$(hyprctl instances -j | jq -er '.[0]')
+wayland_display=$(jq -r '.wl_socket' <<<"$instance")
+hyprland_signature=$(jq -r '.instance' <<<"$instance")
+export XDG_RUNTIME_DIR="/run/user/$(id -u)"
+export DBUS_SESSION_BUS_ADDRESS="unix:path=$XDG_RUNTIME_DIR/bus"
+SPLINTERM_SOCKET="$socket" XDG_STATE_HOME="$state" XDG_CONFIG_HOME="$config" \
+  nohup /usr/bin/splinterd >"$runtime/daemon.log" 2>&1 </dev/null &
+daemon_pid=$!
+cleanup_failed_launch() {
+  kill "$daemon_pid" 2>/dev/null || true
+  wait "$daemon_pid" 2>/dev/null || true
+}
+trap cleanup_failed_launch ERR
+for _ in $(seq 1 100); do
+  if SPLINTERM_SOCKET="$socket" /usr/bin/splinterm ping >/dev/null 2>&1; then break; fi
+  kill -0 "$daemon_pid" 2>/dev/null || {
+    cat "$runtime/daemon.log" >&2
+    exit 1
+  }
+  sleep 0.05
+done
+SPLINTERM_SOCKET="$socket" /usr/bin/splinterm ping >/dev/null
+XDG_RUNTIME_DIR="$XDG_RUNTIME_DIR" \
+WAYLAND_DISPLAY="$wayland_display" \
+HYPRLAND_INSTANCE_SIGNATURE="$hyprland_signature" \
+DBUS_SESSION_BUS_ADDRESS="$DBUS_SESSION_BUS_ADDRESS" \
+SPLINTERM_SOCKET="$socket" \
+XDG_STATE_HOME="$state" \
+XDG_CONFIG_HOME="$config" \
+  nohup /usr/bin/splinterm launch --working-directory "$SPLINTERM_TESTBED_ROOT" \
+    >"$runtime/client.log" 2>&1 </dev/null &
+printf 'guest packaged client pid=%s daemon=%s log=%s\n' "$!" "$daemon_pid" "$runtime/client.log"
+trap - ERR
+REMOTE
+    ;;
+  package-stop)
+    (($# == 0)) || fail 'package-stop takes no arguments'
+    package_root="$remote_root/.testbed-package"
+    ssh "${ssh_options[@]}" "$target" \
+      "SPLINTERM_TESTBED_PACKAGE_ROOT=$(printf '%q' "$package_root") bash -s" <<'REMOTE'
+set -euo pipefail
+runtime="/run/user/$(id -u)/splinterm-package-test"
+socket="$runtime/splinterd.sock"
+stop_matching() {
+  local expected=$1 process executable
+  for process in /proc/[0-9]*; do
+    [[ -r $process/environ ]] || continue
+    tr '\0' '\n' <"$process/environ" 2>/dev/null | grep -Fqx "SPLINTERM_SOCKET=$socket" || continue
+    executable=$(readlink -f "$process/exe" 2>/dev/null || true)
+    [[ $executable == "$expected" ]] && kill "${process##*/}" 2>/dev/null || true
+  done
+}
+stop_matching /usr/bin/splinterm
+stop_matching /usr/bin/splinterd
+for _ in $(seq 1 100); do
+  alive=false
+  for process in /proc/[0-9]*; do
+    [[ -r $process/environ ]] || continue
+    if tr '\0' '\n' <"$process/environ" 2>/dev/null | grep -Fqx "SPLINTERM_SOCKET=$socket"; then
+      executable=$(readlink -f "$process/exe" 2>/dev/null || true)
+      case $executable in /usr/bin/splinterm|/usr/bin/splinterd) alive=true ;; esac
+    fi
+  done
+  [[ $alive == false ]] && break
+  sleep 0.05
+done
+[[ $alive == false ]]
+rm -rf "$runtime" "$SPLINTERM_TESTBED_PACKAGE_ROOT/acceptance-state" \
+  "$SPLINTERM_TESTBED_PACKAGE_ROOT/acceptance-config"
+REMOTE
+    ;;
+  exec)
+    (($# > 0)) || fail 'exec requires a command'
+    remote_command "$@"
+    ;;
+  desktop-exec)
+    (($# > 0)) || fail 'desktop-exec requires a command'
+    desktop_command "$@"
+    ;;
+  shell)
+    ssh -t "${ssh_options[@]}" "$target" \
+      "cd $(printf '%q' "$remote_root") && exec \${SHELL:-/bin/bash} -l"
+    ;;
+  *)
+    usage >&2
+    fail "unknown action: $action"
+    ;;
+esac

--- a/tools/testbed/qmp-input.py
+++ b/tools/testbed/qmp-input.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+"""Bounded QMP keyboard and pointer control for an isolated test VM."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import socket
+from typing import Any, Iterable
+
+
+MAX_TYPED_TEXT_BYTES = 4096
+MAX_QMP_LINE_BYTES = 1024 * 1024
+
+SHIFTED = {
+    "_": "minus",
+    "+": "equal",
+    "{": "bracket_left",
+    "}": "bracket_right",
+    ":": "semicolon",
+    '"': "apostrophe",
+    "~": "grave_accent",
+    "|": "backslash",
+    "<": "comma",
+    ">": "dot",
+    "?": "slash",
+    "!": "1",
+    "@": "2",
+    "#": "3",
+    "$": "4",
+    "%": "5",
+    "^": "6",
+    "&": "7",
+    "*": "8",
+    "(": "9",
+    ")": "0",
+}
+UNSHIFTED = {
+    "-": "minus",
+    "=": "equal",
+    "[": "bracket_left",
+    "]": "bracket_right",
+    ";": "semicolon",
+    "'": "apostrophe",
+    "`": "grave_accent",
+    "\\": "backslash",
+    ",": "comma",
+    ".": "dot",
+    "/": "slash",
+    " ": "spc",
+    "\t": "tab",
+    "\n": "ret",
+}
+
+
+def key_event(qcode: str, down: bool) -> dict[str, Any]:
+    return {
+        "type": "key",
+        "data": {
+            "down": down,
+            "key": {"type": "qcode", "data": qcode},
+        },
+    }
+
+
+def tap_events(qcode: str, shifted: bool = False) -> list[dict[str, Any]]:
+    events: list[dict[str, Any]] = []
+    if shifted:
+        events.append(key_event("shift", True))
+    events.extend((key_event(qcode, True), key_event(qcode, False)))
+    if shifted:
+        events.append(key_event("shift", False))
+    return events
+
+
+def ascii_events(text: str) -> Iterable[list[dict[str, Any]]]:
+    """Encode supported printable ASCII as one bounded key chord per command."""
+    if len(text.encode("utf-8")) > MAX_TYPED_TEXT_BYTES:
+        raise ValueError(
+            f"typed text exceeds {MAX_TYPED_TEXT_BYTES} encoded bytes"
+        )
+    for character in text:
+        if "a" <= character <= "z" or "0" <= character <= "9":
+            yield tap_events(character)
+        elif "A" <= character <= "Z":
+            yield tap_events(character.lower(), shifted=True)
+        elif character in UNSHIFTED:
+            yield tap_events(UNSHIFTED[character])
+        elif character in SHIFTED:
+            yield tap_events(SHIFTED[character], shifted=True)
+        else:
+            raise ValueError(f"unsupported input character: U+{ord(character):04X}")
+
+
+class QmpClient:
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self.socket: socket.socket | None = None
+        self.stream: Any = None
+
+    def __enter__(self) -> "QmpClient":
+        self.socket = socket.socket(socket.AF_UNIX)
+        self.socket.settimeout(5)
+        self.socket.connect(str(self.path))
+        self.stream = self.socket.makefile("rwb", buffering=0)
+        greeting = self._read_message()
+        if "QMP" not in greeting:
+            raise RuntimeError("QMP greeting is missing")
+        self.execute("qmp_capabilities")
+        return self
+
+    def __exit__(self, *_: object) -> None:
+        if self.stream is not None:
+            self.stream.close()
+        if self.socket is not None:
+            self.socket.close()
+
+    def _read_message(self) -> dict[str, Any]:
+        line = self.stream.readline(MAX_QMP_LINE_BYTES + 1)
+        if not line:
+            raise RuntimeError("QMP connection closed")
+        if len(line) > MAX_QMP_LINE_BYTES:
+            raise RuntimeError(
+                f"QMP frame exceeds {MAX_QMP_LINE_BYTES} bytes"
+            )
+        if not line.endswith(b"\n"):
+            raise RuntimeError("QMP frame is unterminated")
+        return json.loads(line)
+
+    def execute(self, command: str, arguments: dict[str, Any] | None = None) -> Any:
+        request: dict[str, Any] = {"execute": command}
+        if arguments is not None:
+            request["arguments"] = arguments
+        self.stream.write((json.dumps(request, separators=(",", ":")) + "\n").encode())
+        while True:
+            reply = self._read_message()
+            if "error" in reply:
+                description = reply["error"].get("desc", "unknown QMP error")
+                raise RuntimeError(f"{command}: {description}")
+            if "return" in reply:
+                return reply["return"]
+
+    def send_events(self, events: list[dict[str, Any]]) -> None:
+        self.execute("input-send-event", {"events": events})
+
+
+def absolute_value(position: int, extent: int) -> int:
+    if extent <= 1:
+        raise ValueError("display extent must be greater than one pixel")
+    if position < 0 or position >= extent:
+        raise ValueError(f"position {position} is outside 0..{extent - 1}")
+    return round(position * 32767 / (extent - 1))
+
+
+def parser() -> argparse.ArgumentParser:
+    result = argparse.ArgumentParser(description=__doc__)
+    result.add_argument("--socket", required=True, type=Path, help="QMP Unix socket")
+    commands = result.add_subparsers(dest="action", required=True)
+    commands.add_parser("status", help="report QEMU run state and active pointer device")
+    type_parser = commands.add_parser("type", help="type bounded printable ASCII")
+    type_parser.add_argument("text")
+    type_parser.add_argument("--enter", action="store_true")
+    key_parser = commands.add_parser("key", help="tap one QEMU qcode")
+    key_parser.add_argument("qcode")
+    move_parser = commands.add_parser("move", help="move the absolute guest pointer")
+    move_parser.add_argument("x", type=int)
+    move_parser.add_argument("y", type=int)
+    move_parser.add_argument("width", type=int)
+    move_parser.add_argument("height", type=int)
+    click_parser = commands.add_parser("click", help="click a guest pointer button")
+    click_parser.add_argument("button", choices=("left", "middle", "right"))
+    return result
+
+
+def main() -> int:
+    arguments = parser().parse_args()
+    typed_events: list[list[dict[str, Any]]] | None = None
+    if arguments.action == "type":
+        text = arguments.text + ("\n" if arguments.enter else "")
+        try:
+            typed_events = list(ascii_events(text))
+        except ValueError as error:
+            raise SystemExit(f"qmp-input: {error}") from error
+    if not arguments.socket.is_socket():
+        raise SystemExit(f"QMP socket is unavailable: {arguments.socket}")
+
+    with QmpClient(arguments.socket) as client:
+        if arguments.action == "status":
+            status = client.execute("query-status")
+            mice = client.execute("query-mice")
+            current = next((mouse for mouse in mice if mouse.get("current")), None)
+            print(f"vm: {status['status']}")
+            if current is None:
+                print("pointer: unavailable")
+            else:
+                print(
+                    f"pointer: {current['name']} "
+                    f"({'absolute' if current['absolute'] else 'relative'})"
+                )
+        elif arguments.action == "type":
+            assert typed_events is not None
+            for events in typed_events:
+                client.send_events(events)
+        elif arguments.action == "key":
+            client.send_events(tap_events(arguments.qcode))
+        elif arguments.action == "move":
+            client.send_events(
+                [
+                    {
+                        "type": "abs",
+                        "data": {
+                            "axis": "x",
+                            "value": absolute_value(arguments.x, arguments.width),
+                        },
+                    },
+                    {
+                        "type": "abs",
+                        "data": {
+                            "axis": "y",
+                            "value": absolute_value(arguments.y, arguments.height),
+                        },
+                    },
+                ]
+            )
+        elif arguments.action == "click":
+            client.send_events(
+                [
+                    {"type": "btn", "data": {"button": arguments.button, "down": True}},
+                    {"type": "btn", "data": {"button": arguments.button, "down": False}},
+                ]
+            )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/testbed/test_guest_window.py
+++ b/tools/testbed/test_guest_window.py
@@ -172,9 +172,7 @@ class GuestWindowTests(unittest.TestCase):
             mock.patch.object(guest_window, "clients", return_value=remaining),
             mock.patch.object(guest_window, "hypr_json", return_value=[]),
             mock.patch.object(guest_window, "monitor_record", return_value=monitor),
-            mock.patch.object(Path, "is_socket", return_value=True),
             mock.patch.object(guest_window, "command") as command,
-            mock.patch.dict(guest_window.os.environ, {"YDOTOOL_SOCKET": "/run/socket"}),
         ):
             guest_window.restore(path)
 
@@ -184,7 +182,11 @@ class GuestWindowTests(unittest.TestCase):
         self.assertIn("address:0xabc", calls[1][2])
         self.assertEqual(
             calls[2],
-            ("ydotool", "mousemove", "--absolute", "-x", "12", "-y", "34"),
+            (
+                "hyprctl",
+                "dispatch",
+                "hl.dsp.cursor.move({ x = 12, y = 34 })",
+            ),
         )
 
 

--- a/tools/testbed/test_guest_window.py
+++ b/tools/testbed/test_guest_window.py
@@ -80,6 +80,41 @@ class GuestWindowTests(unittest.TestCase):
                 [{"address": "0xabc", "workspace": {"id": 8}}]
             )
 
+    def test_process_token_survives_reparenting_and_requires_exact_value(self) -> None:
+        token = "a" * 32
+        environment = f"PATH=/usr/bin\0SPLINTERM_TEST_WINDOW_TOKEN={token}\0".encode()
+        with mock.patch.object(Path, "read_bytes", return_value=environment):
+            self.assertTrue(guest_window.process_has_launch_token(300, token))
+            self.assertFalse(guest_window.process_has_launch_token(300, "b" * 32))
+            self.assertFalse(guest_window.process_has_launch_token(300, "invalid"))
+
+    def test_fresh_candidates_reject_an_unrelated_splinterm_window(self) -> None:
+        current = [
+            {
+                "address": "0xaaa",
+                "initialClass": guest_window.APP_ID,
+                "pid": 100,
+            },
+            {
+                "address": "0xbbb",
+                "initialClass": guest_window.APP_ID,
+                "pid": 200,
+            },
+        ]
+        with (
+            mock.patch.object(guest_window, "clients", return_value=current),
+            mock.patch.object(
+                guest_window,
+                "process_has_launch_token",
+                side_effect=lambda pid, token: pid == 200 and token == "a" * 32,
+            ),
+        ):
+            candidates = guest_window.fresh_candidates(
+                {"before_addresses": []},
+                client_token="a" * 32,
+            )
+        self.assertEqual([candidate["address"] for candidate in candidates], ["0xbbb"])
+
     def test_place_targets_one_fresh_window_by_exact_address(self) -> None:
         path = self.state_path()
         guest_window.write_state(
@@ -113,7 +148,7 @@ class GuestWindowTests(unittest.TestCase):
             ),
             mock.patch.object(guest_window, "command") as command,
         ):
-            guest_window.place(path)
+            guest_window.place(path, client_pid=1234, client_token="a" * 32)
 
         calls = [call.args for call in command.call_args_list]
         self.assertEqual(len(calls), 2)
@@ -121,6 +156,7 @@ class GuestWindowTests(unittest.TestCase):
         self.assertIn('monitor = "Virtual-1"', calls[0][2])
         self.assertIn('workspace = "8"', calls[1][2])
         state = json.loads(path.read_text(encoding="utf-8"))
+        self.assertEqual(state["launch_pid"], 1234)
         self.assertEqual(state["target_address"], "0xdef")
         self.assertEqual(
             state["target_initial"],
@@ -146,7 +182,7 @@ class GuestWindowTests(unittest.TestCase):
             ),
             self.assertRaisesRegex(RuntimeError, "expected one fresh"),
         ):
-            guest_window.place(path)
+            guest_window.place(path, client_pid=1234, client_token="a" * 32)
 
     def test_restore_verifies_cleanup_and_restores_workspace_focus_and_cursor(self) -> None:
         path = self.state_path()

--- a/tools/testbed/test_guest_window.py
+++ b/tools/testbed/test_guest_window.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""Unit tests for the guarded guest-window lifecycle."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import tempfile
+import unittest
+from unittest import mock
+
+
+MODULE_PATH = Path(__file__).with_name("guest-window.py")
+SPEC = importlib.util.spec_from_file_location("guest_window", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+guest_window = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(guest_window)
+
+
+class GuestWindowTests(unittest.TestCase):
+    def state_path(self) -> Path:
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        return Path(temporary.name) / "guest-window.json"
+
+    def test_prepare_records_exact_environment_and_requires_empty_workspace(self) -> None:
+        path = self.state_path()
+        initial_clients = [
+            {"address": "0xabc", "workspace": {"id": 2}, "initialClass": "other"}
+        ]
+
+        active_workspaces = iter(
+            (
+                {"id": 2, "monitor": "Virtual-1"},
+                {"id": 8, "monitor": "Virtual-1"},
+            )
+        )
+
+        def hypr_json(name: str, *_: str) -> object:
+            if name == "activeworkspace":
+                return next(active_workspaces)
+            return {
+                "activewindow": {"address": "0xabc"},
+                "cursorpos": {"x": 12, "y": 34},
+                "workspaces": [{"id": 8, "monitor": "Virtual-1"}],
+            }[name]
+
+        with (
+            mock.patch.object(guest_window, "clients", return_value=initial_clients),
+            mock.patch.object(guest_window, "hypr_json", side_effect=hypr_json),
+            mock.patch.object(
+                guest_window,
+                "monitor_record",
+                return_value={
+                    "id": 0,
+                    "name": "Virtual-1",
+                    "scale": 1.0,
+                    "transform": 0,
+                },
+            ),
+            mock.patch.object(guest_window, "command") as command,
+        ):
+            guest_window.prepare(path)
+
+        calls = [call.args for call in command.call_args_list]
+        self.assertIn('monitor = "Virtual-1"', calls[0][2])
+        self.assertIn('workspace = "8"', calls[1][2])
+
+        state = json.loads(path.read_text(encoding="utf-8"))
+        self.assertEqual(state["active_window"], "0xabc")
+        self.assertEqual(state["active_workspace"], 2)
+        self.assertEqual(state["before_addresses"], ["0xabc"])
+        self.assertEqual(state["cursor"], {"x": 12, "y": 34})
+        self.assertIsNone(state["target_address"])
+
+    def test_prepare_rejects_an_occupied_target_workspace(self) -> None:
+        with self.assertRaisesRegex(RuntimeError, "workspace 8 is not empty"):
+            guest_window.require_empty_target_workspace(
+                [{"address": "0xabc", "workspace": {"id": 8}}]
+            )
+
+    def test_place_targets_one_fresh_window_by_exact_address(self) -> None:
+        path = self.state_path()
+        guest_window.write_state(
+            path,
+            {
+                "before_addresses": ["0xabc"],
+                "target_address": None,
+            },
+        )
+        candidate = {
+            "address": "0xdef",
+            "initialClass": guest_window.APP_ID,
+            "pid": 1234,
+            "monitor": 0,
+            "workspace": {"id": 8},
+            "at": [10, 20],
+            "size": [800, 600],
+        }
+        with (
+            mock.patch.object(guest_window, "fresh_candidates", return_value=[candidate]),
+            mock.patch.object(guest_window, "clients", return_value=[candidate]),
+            mock.patch.object(
+                guest_window,
+                "monitor_record",
+                return_value={
+                    "id": 0,
+                    "name": "Virtual-1",
+                    "scale": 1.0,
+                    "transform": 0,
+                },
+            ),
+            mock.patch.object(guest_window, "command") as command,
+        ):
+            guest_window.place(path)
+
+        calls = [call.args for call in command.call_args_list]
+        self.assertEqual(len(calls), 2)
+        self.assertTrue(all("address:0xdef" in call[2] for call in calls))
+        self.assertIn('monitor = "Virtual-1"', calls[0][2])
+        self.assertIn('workspace = "8"', calls[1][2])
+        state = json.loads(path.read_text(encoding="utf-8"))
+        self.assertEqual(state["target_address"], "0xdef")
+        self.assertEqual(
+            state["target_initial"],
+            {
+                "address": "0xdef",
+                "pid": 1234,
+                "workspace": 8,
+                "monitor": 0,
+                "at": [10, 20],
+                "size": [800, 600],
+            },
+        )
+        self.assertEqual(state["target_final"], state["target_initial"])
+
+    def test_place_rejects_multiple_fresh_splinterm_windows(self) -> None:
+        path = self.state_path()
+        guest_window.write_state(path, {"before_addresses": [], "target_address": None})
+        with (
+            mock.patch.object(
+                guest_window,
+                "fresh_candidates",
+                return_value=[{"address": "0x1"}, {"address": "0x2"}],
+            ),
+            self.assertRaisesRegex(RuntimeError, "expected one fresh"),
+        ):
+            guest_window.place(path)
+
+    def test_restore_verifies_cleanup_and_restores_workspace_focus_and_cursor(self) -> None:
+        path = self.state_path()
+        monitor = {
+            "id": 0,
+            "name": "Virtual-1",
+            "scale": 1.0,
+            "transform": 0,
+        }
+        guest_window.write_state(
+            path,
+            {
+                "active_window": "0xabc",
+                "active_workspace": 2,
+                "before_addresses": ["0xabc"],
+                "cursor": {"x": 12, "y": 34},
+                "monitor": monitor,
+                "target_address": "0xdef",
+            },
+        )
+        remaining = [{"address": "0xabc", "workspace": {"id": 2}}]
+        with (
+            mock.patch.object(guest_window, "clients", return_value=remaining),
+            mock.patch.object(guest_window, "hypr_json", return_value=[]),
+            mock.patch.object(guest_window, "monitor_record", return_value=monitor),
+            mock.patch.object(Path, "is_socket", return_value=True),
+            mock.patch.object(guest_window, "command") as command,
+            mock.patch.dict(guest_window.os.environ, {"YDOTOOL_SOCKET": "/run/socket"}),
+        ):
+            guest_window.restore(path)
+
+        self.assertFalse(path.exists())
+        calls = [call.args for call in command.call_args_list]
+        self.assertIn('workspace = "2"', calls[0][2])
+        self.assertIn("address:0xabc", calls[1][2])
+        self.assertEqual(
+            calls[2],
+            ("ydotool", "mousemove", "--absolute", "-x", "12", "-y", "34"),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/testbed/test_omarchy_vm.py
+++ b/tools/testbed/test_omarchy_vm.py
@@ -107,6 +107,31 @@ class OmarchyVmRunnerTests(unittest.TestCase):
             'SPLINTERM_SOCKET="$socket" /usr/bin/splinterm list', runner
         )
         self.assertIn("--exclude=/.testbed-package/", runner)
+        active_guard = "packaged test is already active; run package-stop first"
+        self.assertIn(active_guard, runner)
+        package_launch = runner.split("  package-launch)", 1)[1].split(
+            "  package-stop)", 1
+        )[0]
+        self.assertLess(
+            package_launch.index(active_guard),
+            package_launch.index('rm -rf "$runtime"'),
+        )
+
+    def test_graphical_launches_use_guarded_guest_window_lifecycle(self) -> None:
+        runner = RUNNER.read_text(encoding="utf-8")
+        self.assertEqual(runner.count("guest-window.py prepare"), 1)
+        self.assertEqual(runner.count("guest-window.py place"), 1)
+        self.assertGreaterEqual(runner.count("guest-window.py restore"), 2)
+        self.assertIn('"$package_root/source/tools/testbed/guest-window.py" prepare', runner)
+        self.assertIn('"$package_root/source/tools/testbed/guest-window.py" place', runner)
+        self.assertIn(
+            '"$SPLINTERM_TESTBED_PACKAGE_ROOT/source/tools/testbed/guest-window.py" restore',
+            runner,
+        )
+        self.assertIn("expected exactly one Hyprland instance", runner)
+        development_launch = runner.split("  launch)", 1)[1].split("  stop)", 1)[0]
+        self.assertIn('kill "$client_pid"', development_launch)
+        self.assertIn('wait "$client_pid"', development_launch)
 
     def test_status_uses_pinned_noninteractive_ssh(self) -> None:
         result, log = self.run_runner("status")

--- a/tools/testbed/test_omarchy_vm.py
+++ b/tools/testbed/test_omarchy_vm.py
@@ -129,6 +129,9 @@ class OmarchyVmRunnerTests(unittest.TestCase):
             runner,
         )
         self.assertIn("expected exactly one Hyprland instance", runner)
+        self.assertEqual(runner.count('--client-pid "$client_pid"'), 2)
+        self.assertEqual(runner.count('--client-token "$client_token"'), 2)
+        self.assertEqual(runner.count('SPLINTERM_TEST_WINDOW_TOKEN="$client_token"'), 2)
         development_launch = runner.split("  launch)", 1)[1].split("  stop)", 1)[0]
         self.assertIn('kill "$client_pid"', development_launch)
         self.assertIn('wait "$client_pid"', development_launch)
@@ -155,6 +158,8 @@ class OmarchyVmRunnerTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
         call = log.read_text()
         self.assertIn("hyprctl instances -j", call)
+        self.assertIn("if length == 1 then .[0]", call)
+        self.assertIn("expected exactly one Hyprland instance", call)
         self.assertIn("XDG_RUNTIME_DIR=", call)
         self.assertIn("WAYLAND_DISPLAY=", call)
         self.assertIn("HYPRLAND_INSTANCE_SIGNATURE=", call)

--- a/tools/testbed/test_omarchy_vm.py
+++ b/tools/testbed/test_omarchy_vm.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""Contract tests for the maintainer Omarchy VM runner."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+RUNNER = ROOT / "tools/testbed/omarchy-vm.sh"
+
+
+class OmarchyVmRunnerTests(unittest.TestCase):
+    def run_runner(
+        self,
+        *args: str,
+        configured: bool = True,
+        remote_root: str = "/home/omarchy/Projects/splinterm-testbed-review",
+    ) -> tuple[subprocess.CompletedProcess[str], Path]:
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        base = Path(temporary.name)
+        fake_bin = base / "bin"
+        fake_bin.mkdir()
+        log = base / "calls.log"
+        identity = base / "id_ed25519"
+        known_hosts = base / "known_hosts"
+        identity.touch()
+        known_hosts.write_text("[127.0.0.1]:2222 ssh-ed25519 test-key\n")
+
+        fake = "#!/bin/sh\nprintf '%s\\n' \"--- $0\" \"$@\" >>\"$CALL_LOG\"\n"
+        for command in ("ssh", "rsync"):
+            path = fake_bin / command
+            path.write_text(fake)
+            path.chmod(0o755)
+
+        config = base / "testbed.env"
+        if configured:
+            config.write_text(
+                "\n".join(
+                    (
+                        "SPLINTERM_TESTBED_HOST=127.0.0.1",
+                        "SPLINTERM_TESTBED_PORT=2222",
+                        "SPLINTERM_TESTBED_USER=omarchy",
+                        f"SPLINTERM_TESTBED_IDENTITY={identity}",
+                        f"SPLINTERM_TESTBED_KNOWN_HOSTS={known_hosts}",
+                        f"SPLINTERM_TESTBED_REMOTE_ROOT='{remote_root}'",
+                    )
+                )
+                + "\n"
+            )
+
+        environment = os.environ.copy()
+        environment.update(
+            {
+                "CALL_LOG": str(log),
+                "PATH": f"{fake_bin}:{environment['PATH']}",
+                "SPLINTERM_TESTBED_CONFIG": str(config),
+            }
+        )
+        result = subprocess.run(
+            [str(RUNNER), *args],
+            cwd=ROOT,
+            env=environment,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        return result, log
+
+    def test_help_does_not_require_private_configuration(self) -> None:
+        result, _ = self.run_runner("--help", configured=False)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("Omarchy VM", result.stdout)
+
+    def test_repository_policy_is_vm_first_for_graphical_testing(self) -> None:
+        agents = (ROOT / "AGENTS.md").read_text(encoding="utf-8")
+        contributing = (ROOT / "CONTRIBUTING.md").read_text(encoding="utf-8")
+        self.assertIn("Run every Splinterm graphical smoke", agents)
+        self.assertIn("guest workspace 8 / `Virtual-1`", agents)
+        self.assertIn("Host graphical testing is an exception", agents)
+        self.assertIn("must run Splinterm graphical smokes", contributing)
+        self.assertIn("Watching the QEMU viewer does not authorize", contributing)
+        self.assertIn("package-install --confirm-guest-install", agents)
+        self.assertIn("This is the trusted-UI path", contributing)
+
+    def test_package_install_requires_explicit_guest_confirmation(self) -> None:
+        result, log = self.run_runner("package-install")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("--confirm-guest-install", result.stderr)
+        self.assertFalse(log.exists())
+
+    def test_packaged_acceptance_uses_clean_head_and_private_guest_state(self) -> None:
+        runner = RUNNER.read_text(encoding="utf-8")
+        self.assertIn('git -C "$repo_root" bundle create "$bundle" HEAD', runner)
+        self.assertIn("package-build requires a clean committed checkout", runner)
+        self.assertIn("./tools/package/upgrade-local-package.sh --yes", runner)
+        self.assertIn("/usr/bin/splinterm launch", runner)
+        self.assertIn('XDG_STATE_HOME="$state"', runner)
+        self.assertIn('XDG_CONFIG_HOME="$config"', runner)
+        self.assertIn("--exclude=/.testbed-package/", runner)
+
+    def test_status_uses_pinned_noninteractive_ssh(self) -> None:
+        result, log = self.run_runner("status")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        call = log.read_text()
+        self.assertIn("BatchMode=yes", call)
+        self.assertIn("IdentitiesOnly=yes", call)
+        self.assertIn("StrictHostKeyChecking=yes", call)
+        self.assertIn("UserKnownHostsFile=", call)
+        self.assertNotIn("StrictHostKeyChecking=no", call)
+
+    def test_exec_quotes_remote_checkout_and_arguments(self) -> None:
+        result, log = self.run_runner("exec", "printf", "%s", "two words")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        call = log.read_text()
+        self.assertIn("cd /home/omarchy/Projects/splinterm-testbed-review", call)
+        self.assertIn("exec printf %s two\\ words", call)
+
+    def test_desktop_exec_discovers_guest_wayland_environment(self) -> None:
+        result, log = self.run_runner("desktop-exec", "wtype", "--", "two words")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        call = log.read_text()
+        self.assertIn("hyprctl instances -j", call)
+        self.assertIn("XDG_RUNTIME_DIR=", call)
+        self.assertIn("WAYLAND_DISPLAY=", call)
+        self.assertIn("HYPRLAND_INSTANCE_SIGNATURE=", call)
+        self.assertIn("exec wtype -- two\\ words", call)
+
+    def test_input_uses_private_guest_runtime_socket(self) -> None:
+        result, log = self.run_runner("input", "type", "two words")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        call = log.read_text()
+        self.assertIn("/run/user/$(id -u)/.ydotool_socket", call)
+        self.assertIn("YDOTOOL_SOCKET=", call)
+        self.assertIn("exec ydotool type two\\ words", call)
+
+    def test_ping_and_launch_use_the_synced_checkout_as_repo(self) -> None:
+        result, log = self.run_runner("ping")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn(
+            "SPLINTERM_REPO=/home/omarchy/Projects/splinterm-testbed-review",
+            log.read_text(),
+        )
+        self.assertIn(
+            'SPLINTERM_REPO="$SPLINTERM_TESTBED_ROOT"',
+            RUNNER.read_text(encoding="utf-8"),
+        )
+
+    def test_sync_deletes_only_inside_dedicated_remote_root(self) -> None:
+        result, log = self.run_runner("sync")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        call = log.read_text()
+        self.assertIn("parent=/home/omarchy/Projects", call)
+        self.assertIn("root=/home/omarchy/Projects/splinterm-testbed-review", call)
+        self.assertIn('test ! -L "$parent"', call)
+        self.assertIn('test ! -L "$root"', call)
+        self.assertIn("--delete", call)
+        self.assertIn("--exclude=/target/", call)
+        self.assertIn("--exclude=/.git/", call)
+        self.assertIn("--exclude=/.env", call)
+        self.assertIn("--exclude=/.splinterm-testbed.env", call)
+        self.assertIn(
+            "omarchy@127.0.0.1:/home/omarchy/Projects/splinterm-testbed-review/",
+            call,
+        )
+
+    def test_unsafe_sync_roots_fail_before_remote_commands(self) -> None:
+        unsafe_roots = (
+            "/",
+            "/home/omarchy",
+            "/home/omarchy/Projects",
+            "/home/omarchy/Projects/ordinary-project",
+            "/home/omarchy/Projects/splinterm-testbed/..",
+        )
+        for remote_root in unsafe_roots:
+            with self.subTest(remote_root=remote_root):
+                result, log = self.run_runner("sync", remote_root=remote_root)
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn("must be", result.stderr)
+                self.assertFalse(log.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/testbed/test_omarchy_vm.py
+++ b/tools/testbed/test_omarchy_vm.py
@@ -102,6 +102,10 @@ class OmarchyVmRunnerTests(unittest.TestCase):
         self.assertIn("/usr/bin/splinterm launch", runner)
         self.assertIn('XDG_STATE_HOME="$state"', runner)
         self.assertIn('XDG_CONFIG_HOME="$config"', runner)
+        self.assertIn("splinterm-package-install-check", runner)
+        self.assertIn(
+            'SPLINTERM_SOCKET="$socket" /usr/bin/splinterm list', runner
+        )
         self.assertIn("--exclude=/.testbed-package/", runner)
 
     def test_status_uses_pinned_noninteractive_ssh(self) -> None:

--- a/tools/testbed/test_qmp_input.py
+++ b/tools/testbed/test_qmp_input.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Unit tests for bounded QMP input encoding."""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+from pathlib import Path
+import unittest
+
+
+MODULE_PATH = Path(__file__).with_name("qmp-input.py")
+SPEC = importlib.util.spec_from_file_location("qmp_input", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+qmp_input = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(qmp_input)
+
+
+class QmpInputTests(unittest.TestCase):
+    def test_ascii_encoder_releases_shift_and_keys(self) -> None:
+        encoded = list(qmp_input.ascii_events("A-1\n"))
+        self.assertEqual(
+            [event["data"]["key"]["data"] for event in encoded[0]],
+            ["shift", "a", "a", "shift"],
+        )
+        self.assertEqual(
+            [event["data"]["down"] for event in encoded[0]],
+            [True, True, False, False],
+        )
+        self.assertEqual(encoded[1], qmp_input.tap_events("minus"))
+        self.assertEqual(encoded[2], qmp_input.tap_events("1"))
+        self.assertEqual(encoded[3], qmp_input.tap_events("ret"))
+
+    def test_ascii_encoder_rejects_unbounded_unicode(self) -> None:
+        with self.assertRaisesRegex(ValueError, "U\\+2603"):
+            list(qmp_input.ascii_events("snowman ☃"))
+
+    def test_ascii_encoder_enforces_exact_byte_limit(self) -> None:
+        accepted = "a" * qmp_input.MAX_TYPED_TEXT_BYTES
+        self.assertEqual(len(list(qmp_input.ascii_events(accepted))), len(accepted))
+        with self.assertRaisesRegex(ValueError, "exceeds"):
+            list(qmp_input.ascii_events(accepted + "a"))
+
+    def test_qmp_reader_bounds_and_requires_newline(self) -> None:
+        client = qmp_input.QmpClient(Path("/unused"))
+        client.stream = io.BytesIO(b'{"return": {}}\n')
+        self.assertEqual(client._read_message(), {"return": {}})
+
+        client.stream = io.BytesIO(b"x" * (qmp_input.MAX_QMP_LINE_BYTES + 1))
+        with self.assertRaisesRegex(RuntimeError, "exceeds"):
+            client._read_message()
+
+        client.stream = io.BytesIO(b'{"return": {}}')
+        with self.assertRaisesRegex(RuntimeError, "unterminated"):
+            client._read_message()
+
+    def test_absolute_pointer_coordinates_cover_qmp_range(self) -> None:
+        self.assertEqual(qmp_input.absolute_value(0, 1920), 0)
+        self.assertEqual(qmp_input.absolute_value(1919, 1920), 32767)
+        self.assertEqual(qmp_input.absolute_value(959, 1920), 16375)
+
+    def test_absolute_pointer_coordinates_reject_out_of_bounds(self) -> None:
+        with self.assertRaises(ValueError):
+            qmp_input.absolute_value(-1, 1080)
+        with self.assertRaises(ValueError):
+            qmp_input.absolute_value(1080, 1080)
+        with self.assertRaises(ValueError):
+            qmp_input.absolute_value(0, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

Splinterm graphical validation previously depended on manipulating workstation windows. Maintainers needed an isolated, persistent Omarchy VM path for development smokes, bounded guest input, exact clean-commit package builds, trusted-sibling installation checks, and packaged graphical acceptance.

## Change

- Add the pinned SSH/rsync Omarchy VM runner and machine-local configuration example.
- Restrict destructive sync to `/home/<user>/Projects/splinterm-testbed[-suffix]` and reject symlink destinations.
- Add bounded QMP keyboard/pointer fallback and guest-native ydotool input routing.
- Add exact clean-HEAD Git-bundle package builds, explicit confirmed guest installation, rollback copies, package identity/status, and private packaged launch/stop actions.
- Enforce guest workspace 8 / `Virtual-1` graphical isolation with exact fresh-window identity, PID, geometry, monitor, workspace, focus, cursor, scale, and transform records.
- Restore focus and cursor through compositor-native dispatch, verify the test window is gone and workspace 8 is empty, and reject active/stale launch namespaces.
- Make VM-first graphical policy explicit in contributor and agent guardrails.
- Add shell/Python contract tests and CI/PKGBUILD integration.

## Validation

### Local and CI-aligned

- 124 package/release tests passed before prerequisite integration.
- Combined focused boundary after final rebase: 33 tests passed.
- ShellCheck, `bash -n`, `py_compile`, release doctor, and `git diff --check` passed.
- Independent VM-testbed review confirmed the original branch findings resolved; bounded follow-up cleanup findings were fixed.

### Development graphical smoke

- Fresh exact window mapped at workspace 8 / `Virtual-1`.
- Address/PID/geometry/monitor/focus verified.
- No guest text input or host-QEMU input sent.
- Stop removed the window and private state, left workspace 8 empty, and restored workspace 1, monitor state, and cursor exactly.

### Exact package build and installation

- Exact clean rebased HEAD built inside the guest from a Git bundle.
- Full workspace/package checks passed.
- Base and extracted MCP package runtime validation passed.
- Guest install required `--confirm-guest-install` and retained rollback copies at:
  `/home/omarchy/Projects/splinterm-testbed/.testbed-package/rollback/20260825T200735Z`
- Pacman owns both `/usr/bin/splinterm` and adjacent `/usr/bin/splinterd`.
- Installed identities after replacement:
  - `/usr/bin/splinterm`: device/inode `31:269867`
  - `/usr/bin/splinterd`: device/inode `31:269866`
- Human-mode private ping/list installation checks passed.

### Packaged graphical smoke

- Exact Pacman-owned client `/usr/bin/splinterm` and daemon `/usr/bin/splinterd` launched with private socket/state/config.
- One exact window mapped on workspace 8 / `Virtual-1`; address, PID, executable identity, geometry, focus, and private socket were verified.
- `package-stop` removed the client, daemon, private runtime, and lifecycle state.
- Workspace 8 was empty afterward; workspace 1, cursor `(441, 822)`, scale, transform, and monitor state were restored exactly.

## Prerequisites integrated separately

- #46 exact subscriber-pressure delivery
- #47 buffered MCP package responses
- #48 zero-duration reducer smoke samples

All three prerequisites passed mandatory CI and were squash-merged into `main` before this branch's final rebase and package acceptance.

## Safety boundary

No workstation package was installed or replaced. The host QEMU window was not focused, moved, resized, or sent input. The guest package remains installed for further acceptance; rollback copies are retained.
