### PR TITLE
Add pre-exec descriptor discipline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,8 @@ jobs:
         run: |
           set -o pipefail
           {
+            cargo test --frozen -p splinterd \
+              --test handoff_descriptors_exec -- --test-threads=1
             cargo test --frozen -p splinterm-pty \
               --test linux_pty --test pty_adoption_exec -- --test-threads=1
             cargo test --frozen -p splinterm-relay --test stdio -- --test-threads=1

--- a/crates/splinterd/src/handoff_descriptors.rs
+++ b/crates/splinterd/src/handoff_descriptors.rs
@@ -1,0 +1,447 @@
+//! Bounded pre-exec descriptor inheritance for daemon handoff.
+//!
+//! This module prepares descriptors in the old daemon generation. Candidate-side
+//! manifest validation, descriptor claiming, and closure of unclaimed inherited
+//! slots belong to the later handoff ABI boundary.
+
+use std::{
+    collections::BTreeSet,
+    fs, io,
+    os::fd::{AsRawFd, BorrowedFd, RawFd},
+    path::Path,
+};
+
+use rustix::{
+    fs::OFlags,
+    io::{FdFlags, fcntl_getfd, fcntl_setfd},
+};
+use thiserror::Error;
+
+/// Maximum number of descriptors one handoff preparation may expose.
+pub const MAX_HANDOFF_DESCRIPTORS: usize = 1024;
+
+/// Closed set of descriptor roles understood by the pre-exec boundary.
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub enum HandoffDescriptorSlot {
+    PtyMaster(u16),
+    Listener,
+    CheckpointManifest,
+    TerminalCheckpoint(u16),
+    ImageState(u16),
+    ForwardClient,
+    RollbackDaemon,
+    RollbackClient,
+    ClientProcess(u8),
+    Continuation(u8),
+}
+
+/// One borrowed descriptor selected for inheritance.
+#[derive(Clone, Copy, Debug)]
+pub struct HandoffDescriptor<'fd> {
+    slot: HandoffDescriptorSlot,
+    descriptor: BorrowedFd<'fd>,
+}
+
+impl<'fd> HandoffDescriptor<'fd> {
+    #[must_use]
+    pub const fn new(slot: HandoffDescriptorSlot, descriptor: BorrowedFd<'fd>) -> Self {
+        Self { slot, descriptor }
+    }
+
+    #[must_use]
+    pub const fn slot(self) -> HandoffDescriptorSlot {
+        self.slot
+    }
+
+    #[must_use]
+    pub fn descriptor(self) -> BorrowedFd<'fd> {
+        self.descriptor
+    }
+
+    #[must_use]
+    pub fn raw_fd(self) -> RawFd {
+        self.descriptor.as_raw_fd()
+    }
+}
+
+/// Failure to establish or restore the bounded inheritance set.
+#[derive(Debug, Error)]
+pub enum DescriptorHandoffError {
+    #[error("handoff descriptor count exceeds {MAX_HANDOFF_DESCRIPTORS}")]
+    TooManyDescriptors,
+    #[error("standard descriptor {0} cannot be inherited as a handoff slot")]
+    StandardDescriptor(RawFd),
+    #[error("handoff descriptor {0} is listed more than once")]
+    DuplicateDescriptor(RawFd),
+    #[error("handoff descriptor slot {0:?} is listed more than once")]
+    DuplicateSlot(HandoffDescriptorSlot),
+    #[error("handoff descriptor {0} was not close-on-exec before preparation")]
+    AllowlistedDescriptorWasInheritable(RawFd),
+    #[error("unexpected descriptor {0} is not close-on-exec")]
+    UnexpectedInheritableDescriptor(RawFd),
+    #[error("cannot inspect process descriptor table: {0}")]
+    InspectProcessDescriptors(#[source] io::Error),
+    #[error("cannot read flags for handoff descriptor {fd}: {source}")]
+    ReadDescriptorFlags {
+        fd: RawFd,
+        #[source]
+        source: io::Error,
+    },
+    #[error("cannot update flags for handoff descriptor {fd}: {source}")]
+    UpdateDescriptorFlags {
+        fd: RawFd,
+        #[source]
+        source: io::Error,
+    },
+}
+
+/// Prepared old-generation inheritance state.
+///
+/// Successful `execve`/`execveat` never returns. If execution fails or the
+/// operation is cancelled, [`Self::restore`] reports restoration errors and
+/// `Drop` remains a best-effort fallback.
+#[derive(Debug)]
+pub struct PreparedDescriptorInheritance<'fd> {
+    descriptors: Vec<HandoffDescriptor<'fd>>,
+    original_flags: Vec<FdFlags>,
+    restored: bool,
+}
+
+impl<'fd> PreparedDescriptorInheritance<'fd> {
+    /// Audits the process descriptor table and clears `FD_CLOEXEC` only on the
+    /// supplied bounded allowlist.
+    ///
+    /// The caller must hold a process-wide handoff guard from before this call
+    /// until successful exec or restoration. That guard must prevent descriptor
+    /// creation, duplication, closure, and flag mutation, plus child creation
+    /// and exec. `/proc/self/fd` cannot provide a stable audit otherwise, and an
+    /// unrelated exec could inherit an allowlisted descriptor after preparation.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error before mutation for malformed inputs, a violated
+    /// close-on-exec invariant, or an unexpected inheritable descriptor. Flag
+    /// update failures restore every descriptor changed so far before returning.
+    pub fn prepare(
+        descriptors: impl IntoIterator<Item = HandoffDescriptor<'fd>>,
+    ) -> Result<Self, DescriptorHandoffError> {
+        Self::prepare_with_audit(
+            descriptors.into_iter().collect::<Vec<_>>(),
+            audit_process_descriptors,
+        )
+    }
+
+    fn prepare_with_audit(
+        descriptors: Vec<HandoffDescriptor<'fd>>,
+        audit: impl FnOnce(&[HandoffDescriptor<'_>]) -> Result<(), DescriptorHandoffError>,
+    ) -> Result<Self, DescriptorHandoffError> {
+        validate_allowlist(&descriptors)?;
+
+        let mut original_flags = Vec::with_capacity(descriptors.len());
+        for descriptor in &descriptors {
+            let flags = descriptor_flags(*descriptor)?;
+            if !flags.contains(FdFlags::CLOEXEC) {
+                return Err(DescriptorHandoffError::AllowlistedDescriptorWasInheritable(
+                    descriptor.raw_fd(),
+                ));
+            }
+            original_flags.push(flags);
+        }
+
+        audit(&descriptors)?;
+
+        let mut prepared = Self {
+            descriptors,
+            original_flags,
+            restored: false,
+        };
+        for index in 0..prepared.descriptors.len() {
+            let flags = prepared.original_flags[index] - FdFlags::CLOEXEC;
+            if let Err(source) = fcntl_setfd(prepared.descriptors[index].descriptor(), flags) {
+                let error = DescriptorHandoffError::UpdateDescriptorFlags {
+                    fd: prepared.descriptors[index].raw_fd(),
+                    source: io::Error::from_raw_os_error(source.raw_os_error()),
+                };
+                let _ = prepared.restore_all();
+                return Err(error);
+            }
+        }
+        Ok(prepared)
+    }
+
+    #[must_use]
+    pub fn descriptors(&self) -> &[HandoffDescriptor<'fd>] {
+        &self.descriptors
+    }
+
+    /// Restores the exact descriptor flags observed before preparation.
+    ///
+    /// # Errors
+    ///
+    /// Returns the first restoration error after attempting every descriptor.
+    pub fn restore(mut self) -> Result<(), DescriptorHandoffError> {
+        self.restore_all()
+    }
+
+    fn restore_all(&mut self) -> Result<(), DescriptorHandoffError> {
+        let mut first_error = None;
+        for (descriptor, flags) in self.descriptors.iter().zip(&self.original_flags) {
+            if let Err(source) = fcntl_setfd(descriptor.descriptor(), *flags)
+                && first_error.is_none()
+            {
+                first_error = Some(DescriptorHandoffError::UpdateDescriptorFlags {
+                    fd: descriptor.raw_fd(),
+                    source: io::Error::from_raw_os_error(source.raw_os_error()),
+                });
+            }
+        }
+        self.restored = first_error.is_none();
+        first_error.map_or(Ok(()), Err)
+    }
+}
+
+impl Drop for PreparedDescriptorInheritance<'_> {
+    fn drop(&mut self) {
+        if !self.restored
+            && let Err(error) = self.restore_all()
+        {
+            tracing::error!(%error, "failed to restore handoff descriptor flags");
+        }
+    }
+}
+
+fn validate_allowlist(descriptors: &[HandoffDescriptor<'_>]) -> Result<(), DescriptorHandoffError> {
+    if descriptors.len() > MAX_HANDOFF_DESCRIPTORS {
+        return Err(DescriptorHandoffError::TooManyDescriptors);
+    }
+
+    let mut raw_descriptors = BTreeSet::new();
+    let mut slots = BTreeSet::new();
+    for descriptor in descriptors {
+        let raw_fd = descriptor.raw_fd();
+        if raw_fd < 3 {
+            return Err(DescriptorHandoffError::StandardDescriptor(raw_fd));
+        }
+        if !raw_descriptors.insert(raw_fd) {
+            return Err(DescriptorHandoffError::DuplicateDescriptor(raw_fd));
+        }
+        if !slots.insert(descriptor.slot()) {
+            return Err(DescriptorHandoffError::DuplicateSlot(descriptor.slot()));
+        }
+    }
+    Ok(())
+}
+
+fn descriptor_flags(descriptor: HandoffDescriptor<'_>) -> Result<FdFlags, DescriptorHandoffError> {
+    fcntl_getfd(descriptor.descriptor()).map_err(|source| {
+        DescriptorHandoffError::ReadDescriptorFlags {
+            fd: descriptor.raw_fd(),
+            source: io::Error::from_raw_os_error(source.raw_os_error()),
+        }
+    })
+}
+
+fn audit_process_descriptors(
+    allowlist: &[HandoffDescriptor<'_>],
+) -> Result<(), DescriptorHandoffError> {
+    let allowed = allowlist
+        .iter()
+        .map(|descriptor| descriptor.raw_fd())
+        .collect::<BTreeSet<_>>();
+    let directory =
+        fs::read_dir("/proc/self/fd").map_err(DescriptorHandoffError::InspectProcessDescriptors)?;
+    let mut entries = Vec::new();
+    for entry in directory {
+        let entry = entry.map_err(DescriptorHandoffError::InspectProcessDescriptors)?;
+        let file_name = entry.file_name();
+        let raw_name = file_name.to_str().ok_or_else(|| {
+            DescriptorHandoffError::InspectProcessDescriptors(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "descriptor table contains a non-UTF-8 entry",
+            ))
+        })?;
+        let fd = raw_name.parse::<RawFd>().map_err(|error| {
+            DescriptorHandoffError::InspectProcessDescriptors(io::Error::new(
+                io::ErrorKind::InvalidData,
+                error,
+            ))
+        })?;
+        if fd >= 3 && !allowed.contains(&fd) {
+            entries.push(fd);
+        }
+    }
+
+    for fd in entries {
+        match descriptor_is_close_on_exec(fd) {
+            Ok(true) => {}
+            Ok(false) => {
+                return Err(DescriptorHandoffError::UnexpectedInheritableDescriptor(fd));
+            }
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+            Err(error) => return Err(DescriptorHandoffError::InspectProcessDescriptors(error)),
+        }
+    }
+    Ok(())
+}
+
+fn descriptor_is_close_on_exec(fd: RawFd) -> io::Result<bool> {
+    let fdinfo = fs::read_to_string(Path::new("/proc/self/fdinfo").join(fd.to_string()))?;
+    let raw_flags = fdinfo
+        .lines()
+        .find_map(|line| line.strip_prefix("flags:\t"))
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "fdinfo omitted flags"))?;
+    let flags = u64::from_str_radix(raw_flags, 8)
+        .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
+    Ok(flags & u64::from(OFlags::CLOEXEC.bits()) != 0)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{fs::File, os::fd::AsFd};
+
+    use super::*;
+
+    fn null_descriptor() -> File {
+        File::open("/dev/null").expect("open null descriptor")
+    }
+
+    fn prepare_without_process_audit<'fd>(
+        descriptors: impl IntoIterator<Item = HandoffDescriptor<'fd>>,
+    ) -> Result<PreparedDescriptorInheritance<'fd>, DescriptorHandoffError> {
+        PreparedDescriptorInheritance::prepare_with_audit(descriptors.into_iter().collect(), |_| {
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn preparation_records_slots_and_explicit_restore_recovers_exact_flags() {
+        let descriptor = null_descriptor();
+        let original = fcntl_getfd(&descriptor).unwrap();
+        assert!(original.contains(FdFlags::CLOEXEC));
+        let prepared = prepare_without_process_audit([HandoffDescriptor::new(
+            HandoffDescriptorSlot::Listener,
+            descriptor.as_fd(),
+        )])
+        .unwrap();
+
+        assert_eq!(
+            prepared.descriptors()[0].slot(),
+            HandoffDescriptorSlot::Listener
+        );
+        assert_eq!(prepared.descriptors()[0].raw_fd(), descriptor.as_raw_fd());
+        assert!(!fcntl_getfd(&descriptor).unwrap().contains(FdFlags::CLOEXEC));
+
+        prepared.restore().unwrap();
+        assert_eq!(fcntl_getfd(&descriptor).unwrap(), original);
+    }
+
+    #[test]
+    fn malformed_allowlists_fail_before_changing_flags() {
+        let first = null_descriptor();
+        let second = null_descriptor();
+        let first_flags = fcntl_getfd(&first).unwrap();
+        let second_flags = fcntl_getfd(&second).unwrap();
+
+        let duplicate_descriptor = PreparedDescriptorInheritance::prepare([
+            HandoffDescriptor::new(HandoffDescriptorSlot::Listener, first.as_fd()),
+            HandoffDescriptor::new(HandoffDescriptorSlot::CheckpointManifest, first.as_fd()),
+        ]);
+        assert!(matches!(
+            duplicate_descriptor,
+            Err(DescriptorHandoffError::DuplicateDescriptor(_))
+        ));
+
+        let duplicate_slot = PreparedDescriptorInheritance::prepare([
+            HandoffDescriptor::new(HandoffDescriptorSlot::Listener, first.as_fd()),
+            HandoffDescriptor::new(HandoffDescriptorSlot::Listener, second.as_fd()),
+        ]);
+        assert!(matches!(
+            duplicate_slot,
+            Err(DescriptorHandoffError::DuplicateSlot(
+                HandoffDescriptorSlot::Listener
+            ))
+        ));
+        assert_eq!(fcntl_getfd(&first).unwrap(), first_flags);
+        assert_eq!(fcntl_getfd(&second).unwrap(), second_flags);
+    }
+
+    #[test]
+    fn unexpected_inheritable_descriptor_blocks_preparation() {
+        let allowed = null_descriptor();
+        let unexpected = null_descriptor();
+        let unexpected_flags = fcntl_getfd(&unexpected).unwrap();
+        fcntl_setfd(&unexpected, unexpected_flags - FdFlags::CLOEXEC).unwrap();
+
+        let result = PreparedDescriptorInheritance::prepare([HandoffDescriptor::new(
+            HandoffDescriptorSlot::Listener,
+            allowed.as_fd(),
+        )]);
+
+        assert!(matches!(
+            result,
+            Err(DescriptorHandoffError::UnexpectedInheritableDescriptor(fd))
+                if fd == unexpected.as_raw_fd()
+        ));
+        assert!(fcntl_getfd(&allowed).unwrap().contains(FdFlags::CLOEXEC));
+        fcntl_setfd(&unexpected, unexpected_flags).unwrap();
+    }
+
+    #[test]
+    fn allowlisted_descriptor_must_start_close_on_exec() {
+        let descriptor = null_descriptor();
+        let original = fcntl_getfd(&descriptor).unwrap();
+        fcntl_setfd(&descriptor, original - FdFlags::CLOEXEC).unwrap();
+
+        let result = PreparedDescriptorInheritance::prepare([HandoffDescriptor::new(
+            HandoffDescriptorSlot::Listener,
+            descriptor.as_fd(),
+        )]);
+
+        assert!(matches!(
+            result,
+            Err(DescriptorHandoffError::AllowlistedDescriptorWasInheritable(
+                _
+            ))
+        ));
+        fcntl_setfd(&descriptor, original).unwrap();
+    }
+
+    #[test]
+    fn drop_restores_flags_after_cancelled_preparation() {
+        let descriptor = null_descriptor();
+        let original = fcntl_getfd(&descriptor).unwrap();
+        {
+            let _prepared = prepare_without_process_audit([HandoffDescriptor::new(
+                HandoffDescriptorSlot::Listener,
+                descriptor.as_fd(),
+            )])
+            .unwrap();
+            assert!(!fcntl_getfd(&descriptor).unwrap().contains(FdFlags::CLOEXEC));
+        }
+        assert_eq!(fcntl_getfd(&descriptor).unwrap(), original);
+    }
+
+    #[test]
+    fn standard_and_excess_descriptor_sets_are_rejected() {
+        let stdin = std::io::stdin();
+        let standard = PreparedDescriptorInheritance::prepare([HandoffDescriptor::new(
+            HandoffDescriptorSlot::Listener,
+            stdin.as_fd(),
+        )]);
+        assert!(matches!(
+            standard,
+            Err(DescriptorHandoffError::StandardDescriptor(0))
+        ));
+
+        let descriptor = null_descriptor();
+        let entry = HandoffDescriptor::new(HandoffDescriptorSlot::Listener, descriptor.as_fd());
+        let excess = PreparedDescriptorInheritance::prepare(std::iter::repeat_n(
+            entry,
+            MAX_HANDOFF_DESCRIPTORS + 1,
+        ));
+        assert!(matches!(
+            excess,
+            Err(DescriptorHandoffError::TooManyDescriptors)
+        ));
+    }
+}

--- a/crates/splinterd/src/lib.rs
+++ b/crates/splinterd/src/lib.rs
@@ -6,6 +6,7 @@ use anyhow::Result;
 
 pub mod authorization;
 pub mod executable_identity;
+pub mod handoff_descriptors;
 pub mod image_transport;
 mod live;
 pub mod policy;

--- a/crates/splinterd/tests/handoff_descriptors_exec.rs
+++ b/crates/splinterd/tests/handoff_descriptors_exec.rs
@@ -1,0 +1,156 @@
+use std::{
+    env,
+    fs::{self, File},
+    os::fd::{AsFd, AsRawFd},
+    path::{Path, PathBuf},
+    process::Command,
+    sync::atomic::{AtomicU64, Ordering},
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use rustix::io::{FdFlags, fcntl_getfd};
+use splinterd::handoff_descriptors::{
+    HandoffDescriptor, HandoffDescriptorSlot, PreparedDescriptorInheritance,
+};
+
+const CLEAN_STAGE: &str = "SPLINTERD_HANDOFF_DESCRIPTOR_CLEAN_STAGE";
+const STAGE: &str = "SPLINTERD_HANDOFF_DESCRIPTOR_STAGE";
+const ALLOWED_FD: &str = "SPLINTERD_HANDOFF_ALLOWED_FD";
+const ALLOWED_PATH: &str = "SPLINTERD_HANDOFF_ALLOWED_PATH";
+const UNRELATED_PATH: &str = "SPLINTERD_HANDOFF_UNRELATED_PATH";
+const TEST_NAME: &str = "only_the_typed_allowlist_survives_exec";
+static NEXT_DIRECTORY: AtomicU64 = AtomicU64::new(1);
+
+struct TestDirectory(PathBuf);
+
+impl TestDirectory {
+    fn new() -> Self {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock after epoch")
+            .as_nanos();
+        let sequence = NEXT_DIRECTORY.fetch_add(1, Ordering::Relaxed);
+        let path = env::temp_dir().join(format!(
+            "splinterd-handoff-descriptors-{}-{unique}-{sequence}",
+            std::process::id()
+        ));
+        fs::create_dir(&path).expect("create descriptor test directory");
+        Self(path)
+    }
+}
+
+impl Drop for TestDirectory {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.0);
+    }
+}
+
+fn open_fixture(path: &Path) -> File {
+    fs::write(path, path.as_os_str().as_encoded_bytes()).expect("write descriptor fixture");
+    File::open(path).expect("open descriptor fixture")
+}
+
+fn inherited_descriptors() -> Vec<(i32, PathBuf)> {
+    let scan_target = PathBuf::from(format!("/proc/{}/fd", std::process::id()));
+    let directory = fs::read_dir("/proc/self/fd").expect("read descriptor table");
+    let mut inherited = Vec::new();
+    let mut scanner_descriptors = 0;
+    for entry in directory {
+        let entry = entry.expect("read every descriptor table entry");
+        let fd = entry
+            .file_name()
+            .to_str()
+            .expect("numeric descriptor entry")
+            .parse::<i32>()
+            .expect("numeric descriptor entry");
+        if fd < 3 {
+            continue;
+        }
+        match fs::read_link(entry.path()) {
+            Ok(target) if target == scan_target => scanner_descriptors += 1,
+            Ok(target) => inherited.push((fd, target)),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => panic!("cannot inspect inherited descriptor {fd}: {error}"),
+        }
+    }
+    assert_eq!(
+        scanner_descriptors, 1,
+        "exclude only the descriptor opened by this exact table scan"
+    );
+    inherited.sort();
+    inherited
+}
+
+fn clean_test_generation() {
+    let status = Command::new("python3")
+        .arg("-c")
+        .arg(
+            "import subprocess, sys; raise SystemExit(subprocess.run(sys.argv[1:], close_fds=True).returncode)",
+        )
+        .arg(env::current_exe().expect("current test executable"))
+        .arg(TEST_NAME)
+        .arg("--exact")
+        .arg("--nocapture")
+        .arg("--test-threads=1")
+        .env(CLEAN_STAGE, "clean")
+        .status()
+        .expect("launch clean descriptor test generation");
+    assert!(status.success());
+}
+
+fn replacement_generation() {
+    let allowed_fd = env::var(ALLOWED_FD)
+        .expect("allowed descriptor slot")
+        .parse::<i32>()
+        .expect("numeric allowed descriptor slot");
+    let allowed = PathBuf::from(env::var_os(ALLOWED_PATH).expect("allowed fixture path"));
+    let unrelated = PathBuf::from(env::var_os(UNRELATED_PATH).expect("unrelated fixture path"));
+    let inherited = inherited_descriptors();
+    assert_eq!(inherited, vec![(allowed_fd, allowed)]);
+    assert!(!inherited.iter().any(|(_, target)| target == &unrelated));
+}
+
+#[test]
+fn only_the_typed_allowlist_survives_exec() {
+    if env::var_os(STAGE).is_some() {
+        replacement_generation();
+        return;
+    }
+    if env::var_os(CLEAN_STAGE).is_none() {
+        clean_test_generation();
+        return;
+    }
+
+    let directory = TestDirectory::new();
+    let allowed_path = directory.0.join("allowed");
+    let unrelated_path = directory.0.join("unrelated");
+    let allowed = open_fixture(&allowed_path);
+    let unrelated = open_fixture(&unrelated_path);
+    let original_allowed_flags = fcntl_getfd(&allowed).expect("read allowed flags");
+    assert!(original_allowed_flags.contains(FdFlags::CLOEXEC));
+    assert!(fcntl_getfd(&unrelated).unwrap().contains(FdFlags::CLOEXEC));
+
+    let prepared = PreparedDescriptorInheritance::prepare([HandoffDescriptor::new(
+        HandoffDescriptorSlot::Listener,
+        allowed.as_fd(),
+    )])
+    .expect("prepare typed descriptor inheritance");
+    assert!(!fcntl_getfd(&allowed).unwrap().contains(FdFlags::CLOEXEC));
+    assert_eq!(prepared.descriptors()[0].raw_fd(), allowed.as_raw_fd());
+
+    let status = Command::new(env::current_exe().expect("current test executable"))
+        .arg(TEST_NAME)
+        .arg("--exact")
+        .arg("--nocapture")
+        .arg("--test-threads=1")
+        .env(STAGE, "replacement")
+        .env(ALLOWED_FD, allowed.as_raw_fd().to_string())
+        .env(ALLOWED_PATH, &allowed_path)
+        .env(UNRELATED_PATH, &unrelated_path)
+        .status()
+        .expect("execute replacement test generation");
+    assert!(status.success());
+
+    prepared.restore().expect("restore descriptor inheritance");
+    assert_eq!(fcntl_getfd(&allowed).unwrap(), original_allowed_flags);
+}


### PR DESCRIPTION
## Summary
- add a bounded typed allowlist for descriptors intentionally inherited across a daemon handoff exec
- audit the process descriptor table fail-closed before clearing `FD_CLOEXEC` only on approved descriptors
- restore exact descriptor flags on cancellation or failed exec and prove the complete inherited non-stdio set in a replacement process
- register the new integration target exactly once in the fail-closed CI inventory

## Scope
This is the old-generation descriptor preparation primitive only. The future coordinator must hold the documented process-wide handoff guard across preparation through exec or restoration. Candidate manifest claim/close enforcement remains deferred.

## Validation
- `cargo test --frozen -p splinterd --lib handoff_descriptors -- --test-threads=1` (6 passed)
- descriptor exec integration repeated 10/10
- `cargo test --frozen -p splinterd --all-targets --all-features -- --test-threads=1` (91 lib; 79 binary + 2 environment-only ignored; 20 end-to-end; exec integration passed)
- exact CI workspace unit/binary/example command passed after isolating ambient-descriptor-independent flag restoration fixtures
- `python -m unittest tools/release/test_ci_workflow.py`
- `cargo clippy --frozen -p splinterd --all-targets --all-features -- -D warnings`
- `cargo fmt --all --check`
- `git diff --check`
- fresh read-only review found two P1 contract/test gaps; both fixed; follow-up verdict: **OK**

## Residual risk
The `/proc/self/fd` audit intentionally depends on the documented future coordinator holding a process-wide guard that prevents descriptor and child-process mutation across the preparation window.