### PR TITLE
Harden runtime shutdown and backpressure

### DIFF
--- a/crates/splinterd/src/live.rs
+++ b/crates/splinterd/src/live.rs
@@ -2418,8 +2418,6 @@ pub enum LiveError {
     InvalidSubscriberCapacity,
     #[error("terminal publication memory limit exceeded")]
     PublicationMemoryFull,
-    #[error("PTY reply queue limit exceeded")]
-    ReplyQueueFull,
     #[error("child process has already exited")]
     ProcessExited,
     #[error("image content does not exist on the active screen")]
@@ -2526,6 +2524,8 @@ pub struct LiveRuntimeMetrics {
     pub command_queue_high_water: usize,
     pub user_write_queue_high_water_bytes: usize,
     pub reply_write_queue_high_water_bytes: usize,
+    /// Terminal-generated PTY reply bytes dropped after the bounded reply queue fills.
+    pub reply_write_queue_dropped_bytes: u64,
     /// Maximum active subscribers observed while publication attribution was enabled.
     pub subscriber_count_high_water: usize,
     /// Compact events whose ownership was admitted by a reserved queue permit
@@ -2607,6 +2607,7 @@ struct RuntimeMetrics {
     command_queue_high_water: AtomicUsize,
     user_write_queue_high_water_bytes: AtomicUsize,
     reply_write_queue_high_water_bytes: AtomicUsize,
+    reply_write_queue_dropped_bytes: AtomicU64,
     subscriber_count_high_water: AtomicUsize,
     subscriber_queue_events_current: AtomicUsize,
     subscriber_queue_events_high_water: AtomicUsize,
@@ -2815,6 +2816,9 @@ impl RuntimeMetrics {
                 .load(Ordering::Relaxed),
             reply_write_queue_high_water_bytes: self
                 .reply_write_queue_high_water_bytes
+                .load(Ordering::Relaxed),
+            reply_write_queue_dropped_bytes: self
+                .reply_write_queue_dropped_bytes
                 .load(Ordering::Relaxed),
             subscriber_count_high_water: self.subscriber_count_high_water.load(Ordering::Relaxed),
             subscriber_queue_events_current: self
@@ -3829,7 +3833,7 @@ async fn run_actor_body(
                                 &mut publication,
                                 metrics,
                                 config.reply_byte_limit,
-                            )?;
+                            );
                             metrics.output_parse_batches.fetch_add(
                                 output.parse_batches,
                                 Ordering::Relaxed,
@@ -4481,7 +4485,7 @@ fn process_output(
     publication: &mut SynchronizedPublication,
     runtime_metrics: &Arc<RuntimeMetrics>,
     reply_limit: usize,
-) -> Result<ProcessOutputMetrics, LiveError> {
+) -> ProcessOutputMetrics {
     let _compact_batch = CompactProducerBatch::begin(subscribers);
     let mut metrics = ProcessOutputMetrics::default();
     let trace_enabled = perf_trace_enabled();
@@ -4553,9 +4557,13 @@ fn process_output(
         }
         for event in terminal.drain_events() {
             if let TerminalEvent::PtyWrite(bytes) = event {
-                reply_writes
-                    .push(bytes, reply_limit)
-                    .map_err(|_| LiveError::ReplyQueueFull)?;
+                let dropped_bytes = u64::try_from(bytes.len()).unwrap_or(u64::MAX);
+                if reply_writes.push(bytes, reply_limit).is_err() {
+                    RuntimeMetrics::add_saturating(
+                        &runtime_metrics.reply_write_queue_dropped_bytes,
+                        dropped_bytes,
+                    );
+                }
             }
         }
     }
@@ -4588,7 +4596,7 @@ fn process_output(
             },
         );
     }
-    Ok(metrics)
+    metrics
 }
 
 #[allow(
@@ -5232,8 +5240,7 @@ mod tests {
             &mut publication,
             &attribution,
             1024,
-        )
-        .unwrap();
+        );
         assert!(publication.active && !publication.timed_out);
         assert_eq!(metrics.terminal_updates, 0);
         assert!(matches!(
@@ -5256,8 +5263,7 @@ mod tests {
             &mut publication,
             &attribution,
             1024,
-        )
-        .unwrap();
+        );
         assert!(!publication.active);
         let LiveEvent::Update {
             updates, snapshot, ..
@@ -5281,6 +5287,39 @@ mod tests {
     }
 
     #[test]
+    fn reply_queue_saturation_drops_excess_replies_without_stopping_output() {
+        let incarnation = ProcessIncarnation::allocate();
+        let mut terminal = Terminal::new(8, 2, TerminalConfig::default());
+        let mut subscribers = Vec::new();
+        let mut publication = SynchronizedPublication::new(terminal.revision());
+        let mut replies = WriteQueue::default();
+        let metrics = Arc::new(RuntimeMetrics::default());
+
+        process_output(
+            b"\x1b[5n\x1b[5nZ",
+            SplintId::new(),
+            incarnation,
+            None,
+            &mut terminal,
+            &mut replies,
+            &mut subscribers,
+            &mut publication,
+            &metrics,
+            4,
+        );
+
+        assert_eq!(replies.bytes, 4);
+        assert_eq!(metrics.snapshot().reply_write_queue_dropped_bytes, 4);
+        let snapshot = terminal.snapshot(SnapshotRequest::default());
+        let first_cell = snapshot
+            .visible_rows()
+            .next()
+            .and_then(|row| row.cells().next())
+            .expect("terminal has a first visible cell");
+        assert_eq!(first_cell.content(), CellSnapshotContent::Scalar('Z'));
+    }
+
+    #[test]
     fn completed_cava_frame_publishes_when_batch_begins_next_frame() {
         let incarnation = ProcessIncarnation::allocate();
         let mut terminal = Terminal::new(8, 2, TerminalConfig::default());
@@ -5301,8 +5340,7 @@ mod tests {
             &mut publication,
             &attribution,
             1024,
-        )
-        .unwrap();
+        );
 
         assert!(terminal.synchronized_updates());
         assert!(publication.active && !publication.timed_out);
@@ -5347,8 +5385,7 @@ mod tests {
             &mut publication,
             &attribution,
             1024,
-        )
-        .unwrap();
+        );
         process_output(
             b"\x1b\\",
             SplintId::new(),
@@ -5360,8 +5397,7 @@ mod tests {
             &mut publication,
             &attribution,
             1024,
-        )
-        .unwrap();
+        );
         assert!(matches!(
             receiver.try_recv(),
             Err(mpsc::error::TryRecvError::Empty)
@@ -5377,8 +5413,7 @@ mod tests {
             &mut publication,
             &attribution,
             1024,
-        )
-        .unwrap();
+        );
 
         assert_eq!(metrics.terminal_updates, 2);
         let LiveEvent::Update {
@@ -6172,8 +6207,7 @@ mod tests {
             &mut publication,
             &attribution,
             1024,
-        )
-        .unwrap();
+        );
         assert_eq!(terminal.revision(), initial_revision);
         let deadline = publication.deadline.unwrap();
         publication.observe(true, started + Duration::from_millis(900));

--- a/crates/splinterd/src/live.rs
+++ b/crates/splinterd/src/live.rs
@@ -2402,6 +2402,13 @@ impl Default for LiveSplintConfig {
     }
 }
 
+impl LiveSplintConfig {
+    #[must_use]
+    pub fn maximum_input_message_bytes(&self) -> usize {
+        self.input_byte_limit / self.command_capacity.max(1)
+    }
+}
+
 #[derive(Debug, Error)]
 pub enum LiveError {
     #[error(transparent)]
@@ -3378,7 +3385,7 @@ impl LiveSplintRuntime {
             commands: sender,
             default_snapshot_rows: config.max_scrollback_snapshot_rows,
             default_subscriber_capacity: config.subscriber_capacity,
-            max_input_message_bytes: config.input_byte_limit / config.command_capacity.max(1),
+            max_input_message_bytes: config.maximum_input_message_bytes(),
             metrics: Arc::clone(&metrics),
             exit,
         };

--- a/crates/splinterd/src/main.rs
+++ b/crates/splinterd/src/main.rs
@@ -1710,7 +1710,7 @@ async fn serve_authenticated(
         control,
         ServerFrame::Hello {
             version: PROTOCOL_VERSION,
-            limits: ServerLimits::default(),
+            limits: server_limits(),
             development_terminal_access: state.development_terminal_access,
         },
     )
@@ -7805,6 +7805,12 @@ fn encode_search_cursor(offset: usize) -> String {
 fn internal() -> ProtocolError {
     ProtocolError::new(ErrorCode::Internal, "operation failed")
 }
+fn server_limits() -> ServerLimits {
+    ServerLimits {
+        maximum_input_bytes: LiveSplintConfig::default().maximum_input_message_bytes(),
+        ..ServerLimits::default()
+    }
+}
 fn input_error(error: &LiveError) -> ProtocolError {
     match error {
         LiveError::InputQueueFull => {
@@ -8351,6 +8357,19 @@ mod tests {
         assert_eq!(error.message, "input queue limit exceeded");
 
         assert_eq!(input_error(&LiveError::Closed).code, ErrorCode::Internal);
+    }
+
+    #[test]
+    fn advertised_input_limit_matches_live_actor_admission() {
+        let config = LiveSplintConfig::default();
+        let limits = server_limits();
+
+        assert_eq!(limits.maximum_input_bytes, 16 * 1024);
+        assert_eq!(
+            limits.maximum_input_bytes,
+            config.maximum_input_message_bytes()
+        );
+        limits.validate_terminal_transport().unwrap();
     }
 
     #[test]

--- a/crates/splinterd/src/main.rs
+++ b/crates/splinterd/src/main.rs
@@ -962,6 +962,8 @@ async fn main() -> Result<()> {
     info!(socket = %socket.display(), image_socket = %image_socket.display(), development_terminal_access = state.development_terminal_access, "splinterd ready");
     let shutdown_signal = signal::ctrl_c();
     tokio::pin!(shutdown_signal);
+    let mut terminate_signal = signal::unix::signal(signal::unix::SignalKind::terminate())
+        .context("failed to listen for termination signal")?;
     let mut reload_signal = signal::unix::signal(signal::unix::SignalKind::hangup())
         .context("failed to listen for policy reload signal")?;
     let image_transfer_expiry =
@@ -973,6 +975,12 @@ async fn main() -> Result<()> {
             biased;
             result = &mut shutdown_signal => {
                 result.context("failed to listen for shutdown signal")?;
+                break;
+            }
+            received = terminate_signal.recv() => {
+                if received.is_none() {
+                    bail!("termination signal stream closed");
+                }
                 break;
             }
             () = &mut image_transfer_expiry => {
@@ -6575,7 +6583,10 @@ async fn handle_authorized_request(
             let handle =
                 controlled_handle(state, connection_id, controller_id, splint_id, incarnation)
                     .await?;
-            handle.input(bytes).await.map_err(|_| internal())?;
+            handle
+                .input(bytes)
+                .await
+                .map_err(|error| input_error(&error))?;
             terminal_action_acknowledgement(state, &handle).await?
         }
         Request::Resize {
@@ -7794,6 +7805,14 @@ fn encode_search_cursor(offset: usize) -> String {
 fn internal() -> ProtocolError {
     ProtocolError::new(ErrorCode::Internal, "operation failed")
 }
+fn input_error(error: &LiveError) -> ProtocolError {
+    match error {
+        LiveError::InputQueueFull => {
+            ProtocolError::new(ErrorCode::ResourceLimit, "input queue limit exceeded")
+        }
+        _ => internal(),
+    }
+}
 fn not_found() -> ProtocolError {
     ProtocolError::new(ErrorCode::NotFound, "resource not found")
 }
@@ -8323,6 +8342,15 @@ mod tests {
             assert_eq!(debug_test_shutdown_grace(Some(invalid.into())), None);
         }
         assert_eq!(debug_test_shutdown_grace(None), None);
+    }
+
+    #[test]
+    fn input_queue_saturation_is_a_recoverable_resource_limit() {
+        let error = input_error(&LiveError::InputQueueFull);
+        assert_eq!(error.code, ErrorCode::ResourceLimit);
+        assert_eq!(error.message, "input queue limit exceeded");
+
+        assert_eq!(input_error(&LiveError::Closed).code, ErrorCode::Internal);
     }
 
     #[test]

--- a/crates/splinterd/src/main.rs
+++ b/crates/splinterd/src/main.rs
@@ -832,6 +832,13 @@ async fn main() -> Result<()> {
         .with_env_filter(EnvFilter::from_default_env())
         .init();
 
+    let mut interrupt_signal = signal::unix::signal(signal::unix::SignalKind::interrupt())
+        .context("failed to listen for interrupt signal")?;
+    let mut terminate_signal = signal::unix::signal(signal::unix::SignalKind::terminate())
+        .context("failed to listen for termination signal")?;
+    let mut reload_signal = signal::unix::signal(signal::unix::SignalKind::hangup())
+        .context("failed to listen for policy reload signal")?;
+
     let metadata = MetadataStore::discover()?;
     let loaded = tokio::task::spawn_blocking({
         let metadata = metadata.clone();
@@ -960,12 +967,6 @@ async fn main() -> Result<()> {
     let image_connections = Arc::new(Semaphore::new(IMAGE_CONTENT_CONNECTION_LIMIT));
     let mut connection_tasks = tokio::task::JoinSet::new();
     info!(socket = %socket.display(), image_socket = %image_socket.display(), development_terminal_access = state.development_terminal_access, "splinterd ready");
-    let shutdown_signal = signal::ctrl_c();
-    tokio::pin!(shutdown_signal);
-    let mut terminate_signal = signal::unix::signal(signal::unix::SignalKind::terminate())
-        .context("failed to listen for termination signal")?;
-    let mut reload_signal = signal::unix::signal(signal::unix::SignalKind::hangup())
-        .context("failed to listen for policy reload signal")?;
     let image_transfer_expiry =
         time::sleep_until(image_transfer_expiry_deadline(&state, false).await);
     tokio::pin!(image_transfer_expiry);
@@ -973,8 +974,10 @@ async fn main() -> Result<()> {
     loop {
         tokio::select! {
             biased;
-            result = &mut shutdown_signal => {
-                result.context("failed to listen for shutdown signal")?;
+            received = interrupt_signal.recv() => {
+                if received.is_none() {
+                    bail!("interrupt signal stream closed");
+                }
                 break;
             }
             received = terminate_signal.recv() => {

--- a/crates/splinterd/tests/end_to_end.rs
+++ b/crates/splinterd/tests/end_to_end.rs
@@ -182,9 +182,13 @@ impl Daemon {
         rustix::process::kill_process(pid, rustix::process::Signal::HUP).unwrap();
     }
 
-    fn shutdown(mut self) {
+    fn shutdown(self) {
+        self.shutdown_with_signal(rustix::process::Signal::INT);
+    }
+
+    fn shutdown_with_signal(mut self, signal: rustix::process::Signal) {
         let pid = rustix::process::Pid::from_raw(i32::try_from(self.child.id()).unwrap()).unwrap();
-        rustix::process::kill_process(pid, rustix::process::Signal::INT).unwrap();
+        rustix::process::kill_process(pid, signal).unwrap();
         let status = self.child.wait().unwrap();
         self.assert_success(status);
         assert!(!self.socket.exists());
@@ -2443,6 +2447,21 @@ async fn parent_policy_snapshot_excludes_new_splint_until_reload() {
     })
     .await
     .expect("parent policy snapshot integration timed out");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn sigterm_shutdown_removes_daemon_socket() {
+    let daemon = Daemon::start().await;
+    let socket = daemon.socket.clone();
+    let connection = daemon.connect().await;
+    drop(connection);
+
+    tokio::task::spawn_blocking(move || {
+        daemon.shutdown_with_signal(rustix::process::Signal::TERM);
+    })
+    .await
+    .unwrap();
+    assert!(!socket.exists());
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]

--- a/crates/splinterd/tests/end_to_end.rs
+++ b/crates/splinterd/tests/end_to_end.rs
@@ -2453,8 +2453,6 @@ async fn parent_policy_snapshot_excludes_new_splint_until_reload() {
 async fn sigterm_shutdown_removes_daemon_socket() {
     let daemon = Daemon::start().await;
     let socket = daemon.socket.clone();
-    let connection = daemon.connect().await;
-    drop(connection);
 
     tokio::task::spawn_blocking(move || {
         daemon.shutdown_with_signal(rustix::process::Signal::TERM);

--- a/crates/splinterm-protocol/src/lib.rs
+++ b/crates/splinterm-protocol/src/lib.rs
@@ -251,13 +251,19 @@ impl ServerLimits {
     /// uses any advertised dimensions or frame budget.
     ///
     /// # Errors
-    /// Returns `InvalidArgument` when the fixed frame limit or endpoint-local
-    /// grid bounds are outside the protocol's absolute envelope.
+    /// Returns `InvalidArgument` when the fixed frame limit, input limit, or
+    /// endpoint-local grid bounds are outside the protocol's absolute envelope.
     pub fn validate_terminal_transport(self) -> Result<(), ProtocolError> {
         if self.maximum_frame_bytes != MAX_FRAME_BYTES {
             return Err(ProtocolError::new(
                 ErrorCode::InvalidArgument,
                 "server frame limit does not match the protocol version",
+            ));
+        }
+        if !(1..=MAX_INPUT_BYTES).contains(&self.maximum_input_bytes) {
+            return Err(ProtocolError::new(
+                ErrorCode::InvalidArgument,
+                "server input limit is outside the protocol envelope",
             ));
         }
         if !(2..=MAX_COLUMNS).contains(&self.maximum_columns)
@@ -3655,6 +3661,14 @@ mod tests {
             },
             ServerLimits {
                 maximum_frame_bytes: MAX_FRAME_BYTES + 1,
+                ..limits
+            },
+            ServerLimits {
+                maximum_input_bytes: 0,
+                ..limits
+            },
+            ServerLimits {
+                maximum_input_bytes: MAX_INPUT_BYTES + 1,
                 ..limits
             },
             ServerLimits {

--- a/crates/splinterm/src/app/pane_bridge.rs
+++ b/crates/splinterm/src/app/pane_bridge.rs
@@ -378,9 +378,11 @@ fn input_requests(
     incarnation: u64,
     bytes: &[u8],
     maximum_input_bytes: usize,
-) -> Vec<Request> {
-    debug_assert!(maximum_input_bytes > 0);
-    bytes
+) -> Result<Vec<Request>> {
+    if maximum_input_bytes == 0 {
+        bail!("splinterd advertised a zero terminal input limit");
+    }
+    Ok(bytes
         .chunks(maximum_input_bytes)
         .map(|chunk| Request::Input {
             controller_id,
@@ -388,7 +390,7 @@ fn input_requests(
             incarnation,
             bytes: chunk.to_vec(),
         })
-        .collect()
+        .collect())
 }
 
 fn recoverable_input_error(error: &anyhow::Error) -> bool {
@@ -748,7 +750,7 @@ pub(in crate::app) async fn run_controller(
                         incarnation,
                         &bytes,
                         maximum_input_bytes,
-                    ) {
+                    )? {
                         match control.request(request).await {
                             Ok(response)
                                 if terminal_action_matches(&response, splint_id, incarnation) => {}
@@ -1418,7 +1420,7 @@ mod tests {
     fn terminal_input_is_chunked_to_the_negotiated_server_limit() {
         let splint_id = SplintId::new();
         let bytes = vec![7; 17];
-        let requests = input_requests(3, splint_id, 9, &bytes, 8);
+        let requests = input_requests(3, splint_id, 9, &bytes, 8).unwrap();
 
         assert_eq!(requests.len(), 3);
         let chunks = requests
@@ -1440,6 +1442,7 @@ mod tests {
             .collect::<Vec<_>>();
         assert_eq!(chunks.iter().map(Vec::len).collect::<Vec<_>>(), [8, 8, 1]);
         assert_eq!(chunks.concat(), bytes);
+        assert!(input_requests(3, splint_id, 9, &bytes, 0).is_err());
     }
 
     #[test]

--- a/crates/splinterm/src/app/pane_bridge.rs
+++ b/crates/splinterm/src/app/pane_bridge.rs
@@ -3,6 +3,8 @@
 use std::time::{Duration, Instant};
 
 use anyhow::{Result, bail};
+#[cfg(test)]
+use splinterm::automation::response_protocol_error;
 use splinterm::automation::{
     Connection, ImageContentLeaseSet, SharedImageContentCache, protocol_error,
 };
@@ -370,6 +372,29 @@ pub(in crate::app) async fn wait_for_resize_deadline(deadline: Option<tokio::tim
     }
 }
 
+fn input_requests(
+    controller_id: u64,
+    splint_id: SplintId,
+    incarnation: u64,
+    bytes: &[u8],
+    maximum_input_bytes: usize,
+) -> Vec<Request> {
+    debug_assert!(maximum_input_bytes > 0);
+    bytes
+        .chunks(maximum_input_bytes)
+        .map(|chunk| Request::Input {
+            controller_id,
+            splint_id,
+            incarnation,
+            bytes: chunk.to_vec(),
+        })
+        .collect()
+}
+
+fn recoverable_input_error(error: &anyhow::Error) -> bool {
+    protocol_error(error).is_some_and(|error| error.code == ErrorCode::ResourceLimit)
+}
+
 pub(in crate::app) fn terminal_action_matches(
     response: &Response,
     splint_id: SplintId,
@@ -716,12 +741,30 @@ pub(in crate::app) async fn run_controller(
                     else {
                         continue;
                     };
-                    Request::Input {
+                    let maximum_input_bytes = control.limits().maximum_input_bytes;
+                    for request in input_requests(
                         controller_id,
                         splint_id,
                         incarnation,
-                        bytes,
+                        &bytes,
+                        maximum_input_bytes,
+                    ) {
+                        match control.request(request).await {
+                            Ok(response)
+                                if terminal_action_matches(&response, splint_id, incarnation) => {}
+                            Ok(_) => {
+                                bail!("splinterd did not acknowledge a window input command");
+                            }
+                            Err(error) if recoverable_input_error(&error) => {
+                                eprintln!(
+                                    "splinterm input queue saturated; dropping remaining terminal input"
+                                );
+                                break;
+                            }
+                            Err(error) => return Err(error),
+                        }
                     }
+                    continue;
                 }
                 WindowCommand::Resynchronize => {
                     if outputs.resyncs.send(()).await.is_err() {
@@ -1369,6 +1412,49 @@ mod tests {
         });
         assert_eq!(limits.maximum_columns, 120);
         assert_eq!(limits.maximum_rows, 64);
+    }
+
+    #[test]
+    fn terminal_input_is_chunked_to_the_negotiated_server_limit() {
+        let splint_id = SplintId::new();
+        let bytes = vec![7; 17];
+        let requests = input_requests(3, splint_id, 9, &bytes, 8);
+
+        assert_eq!(requests.len(), 3);
+        let chunks = requests
+            .into_iter()
+            .map(|request| match request {
+                Request::Input {
+                    controller_id,
+                    splint_id: request_splint_id,
+                    incarnation,
+                    bytes,
+                } => {
+                    assert_eq!(controller_id, 3);
+                    assert_eq!(request_splint_id, splint_id);
+                    assert_eq!(incarnation, 9);
+                    bytes
+                }
+                _ => panic!("expected an input request"),
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(chunks.iter().map(Vec::len).collect::<Vec<_>>(), [8, 8, 1]);
+        assert_eq!(chunks.concat(), bytes);
+    }
+
+    #[test]
+    fn input_resource_saturation_is_recoverable() {
+        let error = response_protocol_error(splinterm_protocol::ProtocolError::new(
+            ErrorCode::ResourceLimit,
+            "input queue limit exceeded",
+        ));
+        assert!(recoverable_input_error(&error));
+
+        let error = response_protocol_error(splinterm_protocol::ProtocolError::new(
+            ErrorCode::Internal,
+            "operation failed",
+        ));
+        assert!(!recoverable_input_error(&error));
     }
 
     #[test]

--- a/crates/splinterm/src/wayland.rs
+++ b/crates/splinterm/src/wayland.rs
@@ -237,7 +237,8 @@ const SCALE_DENOMINATOR: u32 = 120;
 const MIN_SCALE_120: u32 = 120;
 const MAX_SCALE_120: u32 = 960;
 const MAX_PREEDIT_BYTES: usize = 4 * 1024;
-const MAX_PENDING_TERMINAL_INPUT_BYTES: usize = splinterm_protocol::MAX_INPUT_BYTES;
+const MAX_PENDING_TERMINAL_INPUT_BYTES: usize =
+    clipboard::MAX_CLIPBOARD_BYTES + clipboard::BRACKETED_PASTE_OVERHEAD;
 const PENDING_INPUT_RETRY_INTERVAL: Duration = Duration::from_millis(5);
 const SIGNOFF_TICK_INTERVAL: Duration = Duration::from_millis(50);
 const CURSOR_BLINK_INTERVAL: Duration = Duration::from_millis(500);

--- a/crates/splinterm/src/wayland/clipboard.rs
+++ b/crates/splinterm/src/wayland/clipboard.rs
@@ -20,7 +20,8 @@ use super::{
 };
 
 pub(super) const TEXT_MIMES: [&str; 3] = ["text/plain;charset=utf-8", "text/plain", "UTF8_STRING"];
-const MAX_CLIPBOARD_BYTES: usize = 1024 * 1024;
+pub(super) const MAX_CLIPBOARD_BYTES: usize = 1024 * 1024;
+pub(super) const BRACKETED_PASTE_OVERHEAD: usize = 12;
 const MAX_CLIPBOARD_WORKERS: usize = 4;
 pub(super) const CLIPBOARD_IO_TIMEOUT: Duration = Duration::from_secs(2);
 pub(super) static ACTIVE_CLIPBOARD_WORKERS: AtomicUsize = AtomicUsize::new(0);
@@ -66,7 +67,7 @@ pub fn encode_bracketed_paste(bytes: &[u8], enabled: bool) -> Vec<u8> {
     if !enabled {
         return bytes.to_vec();
     }
-    let mut encoded = Vec::with_capacity(bytes.len() + 12);
+    let mut encoded = Vec::with_capacity(bytes.len() + BRACKETED_PASTE_OVERHEAD);
     encoded.extend_from_slice(b"\x1b[200~");
     encoded.extend_from_slice(bytes);
     encoded.extend_from_slice(b"\x1b[201~");


### PR DESCRIPTION
## Summary

- route SIGTERM through the daemon's orderly shutdown and cleanup path
- keep PTY reply queue saturation bounded and nonfatal, with dropped-byte accounting
- chunk graphical input to the negotiated daemon limit and keep input saturation recoverable
- expand the bounded pending-input allowance to include bracketed-paste framing

Closes #2.
Closes #4.
Closes #6.

## Validation

- `cargo build -p splinterm-pty --bin splinterm-pty-child`
- `cargo test -p splinterd --lib`
- `cargo test -p splinterd --bin splinterd`
- `cargo test -p splinterm --lib`
- `cargo test -p splinterm --bin splinterm`
- `cargo test -p splinterd --test end_to_end sigterm_shutdown_removes_daemon_socket -- --exact`
- `cargo clippy -p splinterd -p splinterm --all-targets -- -D warnings`
- `cargo fmt --all --check`
- `git diff --check`

## Review

Independent read-only review approved the change with no blockers.

## Residual risk

- PTY actor survival and graphical controller retention under saturation are covered through focused unit seams and source inspection rather than a live graphical saturation test.
- The SIGTERM integration test verifies successful daemon exit and socket cleanup; live-runtime draining follows the shared shutdown path already exercised by existing shutdown coverage.
