### PR TITLE
Update nanoid to patched release

### DIFF
--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -5745,9 +5745,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## Summary

- update the site lockfile from `nanoid` 3.3.17 to 3.3.18
- resolve high-severity advisory `GHSA-2v37-7h3g-55p8`
- leave the direct dependency manifest and all other resolved packages unchanged

## Validation

- `npm ls nanoid --all`
- `npm audit --audit-level=high`
- `(cd site && npm run validate)`
- `python tools/release/release-doctor.py`
- `cargo fmt --all --check`
- `cargo clippy --frozen --workspace --all-targets -- -D warnings`
- complete non-graphical Rust CI test boundaries, including serialized daemon and MCP integration tests
- package/release Python unittest boundary
- Foot oracle and benchmark fixture tests
- ShellCheck, desktop-file, and AppStream validation
- `git diff --check`
- independent read-only review: approved with no findings

## Residual risk

Minimal: this is a lockfile-only transitive patch update. Graphical testing was not run because the change does not affect graphical behavior.
