### PR TITLE
Contain sealed preflight process creation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1212,6 +1212,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "seccompiler"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae55de56877481d112a559bbc12667635fdaf5e005712fd4e2b2fa50ffc884"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1403,8 +1412,10 @@ name = "splinterd"
 version = "0.1.0-beta1"
 dependencies = [
  "anyhow",
+ "libc",
  "nix",
  "rustix",
+ "seccompiler",
  "serde",
  "serde_json",
  "sha2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ freetype-rs = "0.38.0"
 pixman-sys = "0.1.0"
 png = "0.18"
 rmcp = { version = "=2.2.0", default-features = false, features = ["server", "transport-io"] }
+seccompiler = { version = "0.5.0", default-features = false }
 libc = "0.2"
 memmap2 = "0.9.11"
 nix = { version = "0.30.1", default-features = false, features = ["poll", "socket"] }

--- a/THIRD_PARTY.md
+++ b/THIRD_PARTY.md
@@ -71,6 +71,18 @@ not package dependencies. Inspector is MIT licensed. The conformance framework
 is MIT licensed; its server runner currently accepts URL transports only, so it
 cannot execute Splinterm's stdio-only profile and no HTTP transport is added.
 
+## seccompiler
+
+The daemon's sealed offline handoff preflight uses `seccompiler` to install an
+inherited seccomp-BPF rule that denies process and thread creation before an
+untrusted candidate image executes.
+
+- Source: <https://github.com/rust-vmm/seccompiler>
+- Version: 0.5.0
+- License: Apache-2.0 OR BSD-3-Clause
+- Filter policy: allow all other syscalls; return `EPERM` for `fork`, `vfork`,
+  `clone`, and `clone3`
+
 ## rustix
 
 Splinterm uses `rustix` for safe Linux PTY, termios, process, signal, and

--- a/crates/splinterd/Cargo.toml
+++ b/crates/splinterd/Cargo.toml
@@ -12,9 +12,11 @@ integration-test = []
 
 [dependencies]
 anyhow.workspace = true
+libc.workspace = true
 nix = { workspace = true, features = ["fs", "process", "uio"] }
 serde.workspace = true
 serde_json.workspace = true
+seccompiler.workspace = true
 sha2.workspace = true
 splinterm-core = { path = "../splinterm-core" }
 splinterm-filemap = { path = "../splinterm-filemap" }

--- a/crates/splinterd/src/handoff_preflight.rs
+++ b/crates/splinterd/src/handoff_preflight.rs
@@ -24,6 +24,7 @@ use rustix::{
     io::{FdFlags, fcntl_getfd, fcntl_setfd},
     rand::{GetRandomFlags, getrandom},
 };
+use seccompiler::{BpfProgram, SeccompAction, SeccompFilter, TargetArch, apply_filter};
 use sha2::{Digest, Sha256};
 use thiserror::Error;
 
@@ -57,6 +58,9 @@ const TEST_CLEAN_STAGE: &str = "SPLINTERM_PREFLIGHT_TEST_CLEAN_STAGE";
 const TEST_STAGE: &str = "SPLINTERM_PREFLIGHT_TEST_STAGE";
 #[cfg(test)]
 const TEST_ROLE: &str = "SPLINTERM_PREFLIGHT_TEST_ROLE";
+#[cfg(test)]
+const TEST_SECCOMP_NAME: &str =
+    "handoff_preflight::tests::sealed_launcher_denies_descendant_creation";
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[repr(u8)]
@@ -367,6 +371,10 @@ fn launch_sealed_target() -> ! {
     .into_iter()
     .map(|value| CString::new(value).expect("test environment has no NUL"))
     .collect::<Vec<_>>();
+    #[cfg(not(test))]
+    if install_no_descendants_filter().is_err() {
+        std::process::exit(125);
+    }
     let _ = nix::unistd::execveat(
         target.as_fd(),
         &empty_path,
@@ -375,6 +383,41 @@ fn launch_sealed_target() -> ! {
         nix::fcntl::AtFlags::AT_EMPTY_PATH,
     );
     std::process::exit(126)
+}
+
+fn install_no_descendants_filter() -> Result<(), String> {
+    #[cfg(not(any(
+        target_arch = "x86_64",
+        target_arch = "aarch64",
+        target_arch = "riscv64"
+    )))]
+    return Err("unsupported seccomp architecture".to_owned());
+
+    #[cfg(any(
+        target_arch = "x86_64",
+        target_arch = "aarch64",
+        target_arch = "riscv64"
+    ))]
+    {
+        let mut denied = vec![libc::SYS_clone, libc::SYS_clone3];
+        #[cfg(target_arch = "x86_64")]
+        denied.extend([libc::SYS_fork, libc::SYS_vfork]);
+        let architecture =
+            TargetArch::try_from(std::env::consts::ARCH).map_err(|error| error.to_string())?;
+        let filter: BpfProgram = SeccompFilter::new(
+            denied
+                .into_iter()
+                .map(|syscall| (syscall, Vec::new()))
+                .collect(),
+            SeccompAction::Allow,
+            SeccompAction::Errno(libc::EPERM as u32),
+            architecture,
+        )
+        .map_err(|error| error.to_string())?
+        .try_into()
+        .map_err(|error: seccompiler::BackendError| error.to_string())?;
+        apply_filter(&filter).map_err(|error| error.to_string())
+    }
 }
 
 fn run_child(expected_role: PreflightRole) -> Result<(), PreflightError> {
@@ -835,6 +878,30 @@ mod tests {
             reports.rollback.pair_build_version
         );
         assert_eq!(reports.forward.capabilities, reports.rollback.capabilities);
+    }
+
+    #[test]
+    fn sealed_launcher_denies_descendant_creation() {
+        if std::env::var(TEST_STAGE).as_deref() == Ok("seccomp-probe") {
+            install_no_descendants_filter().unwrap();
+            let error = Command::new("/bin/true").status().unwrap_err();
+            assert_eq!(error.raw_os_error(), Some(libc::EPERM));
+            return;
+        }
+        let status = Command::new("python3")
+            .arg("-c")
+            .arg(
+                "import subprocess, sys; raise SystemExit(subprocess.run(sys.argv[1:], close_fds=True).returncode)",
+            )
+            .arg(std::env::current_exe().unwrap())
+            .arg(TEST_SECCOMP_NAME)
+            .arg("--exact")
+            .arg("--nocapture")
+            .arg("--test-threads=1")
+            .env(TEST_STAGE, "seccomp-probe")
+            .status()
+            .unwrap();
+        assert!(status.success());
     }
 
     #[test]

--- a/tools/foot-oracle/provenance.json
+++ b/tools/foot-oracle/provenance.json
@@ -59,7 +59,7 @@
   "rust": {
     "rustc": "1.91.0",
     "cargo": "1.91.0",
-    "cargo_lock_sha256": "29c4af90faeaeb769317f2c3651a148a0ab6419afe0938cce6af2ec54f7ae83e",
+    "cargo_lock_sha256": "89894631fd6f30802cfa08f93e228354af774cf3d1b9b4baeeb3330089d40711",
     "dependencies": {
       "fontdb": "0.23.0",
       "freetype-rs": "0.38.0",
@@ -112,7 +112,7 @@
     },
     "foreground": "ebebeb",
     "background": "0e1216",
-    "cargo_lock_sha256": "29c4af90faeaeb769317f2c3651a148a0ab6419afe0938cce6af2ec54f7ae83e"
+    "cargo_lock_sha256": "89894631fd6f30802cfa08f93e228354af774cf3d1b9b4baeeb3330089d40711"
   },
   "semantic_fixture_schema": "fixtures/terminal/v1/schema.md",
   "final_buffer_schema": "tools/foot-oracle/final-buffer-schema.md",


### PR DESCRIPTION
## Summary

- deny `fork`, `vfork`, `clone`, and `clone3` in the sealed preflight candidate via an inherited seccomp-BPF filter installed before `execveat`
- fail before candidate execution when containment cannot be installed
- prevent candidate descendants or threads from outliving the directly authenticated and reaped preflight child
- document the safe `seccompiler` dependency and refresh locked Foot provenance

## Context

This is the focused correction for a P1 review comment that arrived immediately after #56 merged. Without containment, a candidate could fork, close the report descriptor in its descendant, let the direct child authenticate and exit, and leave candidate-generation code running. Current `main` has no activated live handoff coordinator, but this correction must land before that later integration.

## Validation

- containment probe, four-snapshot focused preflight suite, and actual `splinterd`/`splinterm` binary entrypoints passed 10 consecutive runs
- process creation under the inherited filter returns `EPERM`
- focused suite passed with pinned Rust 1.88
- package/release Python boundary: 128/128 passed
- provenance/release tests: 8/8 passed
- `cargo clippy --frozen --workspace --all-targets --all-features -- -D warnings`
- `cargo fmt --all --check`
- `python tools/release/release-doctor.py`
- `git diff --check`
