### PR TITLE
Prepare Beta 3 UI and workload-limit fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1400,7 +1400,7 @@ dependencies = [
 
 [[package]]
 name = "splinterd"
-version = "0.1.0-beta2"
+version = "0.1.0-beta3"
 dependencies = [
  "anyhow",
  "nix",
@@ -1424,7 +1424,7 @@ dependencies = [
 
 [[package]]
 name = "splinterm"
-version = "0.1.0-beta2"
+version = "0.1.0-beta3"
 dependencies = [
  "anyhow",
  "clap",
@@ -1454,7 +1454,7 @@ dependencies = [
 
 [[package]]
 name = "splinterm-automation-client"
-version = "0.1.0-beta2"
+version = "0.1.0-beta3"
 dependencies = [
  "anyhow",
  "rustix",
@@ -1470,7 +1470,7 @@ dependencies = [
 
 [[package]]
 name = "splinterm-core"
-version = "0.1.0-beta2"
+version = "0.1.0-beta3"
 dependencies = [
  "serde",
  "serde_json",
@@ -1480,7 +1480,7 @@ dependencies = [
 
 [[package]]
 name = "splinterm-filemap"
-version = "0.1.0-beta2"
+version = "0.1.0-beta3"
 dependencies = [
  "memmap2",
  "rustix",
@@ -1488,7 +1488,7 @@ dependencies = [
 
 [[package]]
 name = "splinterm-freetype"
-version = "0.1.0-beta2"
+version = "0.1.0-beta3"
 dependencies = [
  "freetype-rs",
  "splinterm-pixman",
@@ -1497,7 +1497,7 @@ dependencies = [
 
 [[package]]
 name = "splinterm-graphical-relay"
-version = "0.1.0-beta2"
+version = "0.1.0-beta3"
 dependencies = [
  "anyhow",
  "tokio",
@@ -1506,7 +1506,7 @@ dependencies = [
 
 [[package]]
 name = "splinterm-mcp"
-version = "0.1.0-beta2"
+version = "0.1.0-beta3"
 dependencies = [
  "anyhow",
  "rmcp",
@@ -1521,7 +1521,7 @@ dependencies = [
 
 [[package]]
 name = "splinterm-pixman"
-version = "0.1.0-beta2"
+version = "0.1.0-beta3"
 dependencies = [
  "libc",
  "pixman-sys",
@@ -1530,7 +1530,7 @@ dependencies = [
 
 [[package]]
 name = "splinterm-protocol"
-version = "0.1.0-beta2"
+version = "0.1.0-beta3"
 dependencies = [
  "base64",
  "rustix",
@@ -1543,7 +1543,7 @@ dependencies = [
 
 [[package]]
 name = "splinterm-pty"
-version = "0.1.0-beta2"
+version = "0.1.0-beta3"
 dependencies = [
  "rustix",
  "thiserror",
@@ -1552,7 +1552,7 @@ dependencies = [
 
 [[package]]
 name = "splinterm-relay"
-version = "0.1.0-beta2"
+version = "0.1.0-beta3"
 dependencies = [
  "anyhow",
  "nix",
@@ -1564,7 +1564,7 @@ dependencies = [
 
 [[package]]
 name = "splinterm-terminal"
-version = "0.1.0-beta2"
+version = "0.1.0-beta3"
 dependencies = [
  "base64",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.1.0-beta2"
+version = "0.1.0-beta3"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT"

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -46,7 +46,7 @@ divider. The active tab retains its exact theme-provided body, contrasting
 foreground, and accent underline.
 
 Older persisted unnamed Lairs may still carry historical generated identities
-such as `terminal-324324573264238-4132`. Reopening one from the Dojo picker now
+such as `terminal-1787899189-4132`. Reopening one from the Dojo picker now
 presents its initial tab as `Dojo 1`. This is a presentation-only compatibility
 rule: explicit Dojo names remain unchanged and daemon-owned topology is not
 renamed.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,143 +1,72 @@
-# Splinterm 0.1.0 Beta 2 — Persistence With an Exit
+# Splinterm 0.1.0 Beta 3 — Room to Work
 
-Splinterm remains persistent by default. Beta 2 adds a deliberate alternative:
-an ordinary unnamed graphical terminal can belong to its Window and disappear
-when that Window closes. The moment you organize that terminal into a named or
-multi-tab workspace, Splinterm can make the complete Lair durable automatically.
+Beta 3 removes task ceilings that were too small for ordinary applications,
+polishes the Dojo tab strip, and gives legacy unnamed Dojos a stable readable
+label.
 
-Beta 2 also includes the startup font-family correction for newly opened
-Windows. Selecting CaskaydiaMono, another Omarchy terminal family, or an
-explicit Fontconfig family no longer leaves bold and italic resolution tied to
-JetBrains Mono.
+## Workloads inherit the user manager's task policy
 
-This release also separates terminal workloads from the daemon's resource
-failure boundary. Packaged Splints now run inside nested systemd user units:
-the aggregate Splinterm workload slice contains one slice per Dojo and one scope
-per Splint. The daemon keeps its own independent task and memory-pressure guard.
+Beta 2 introduced the correct nested systemd hierarchy but shipped provisional
+fixed ceilings of 512 tasks per Splint, 1024 per Dojo, and 2048 across all
+terminal workloads. Because Linux counts both processes and threads, ordinary
+Chromium, Node, editor, build, and coding-agent workloads can reach those limits.
+Rejected task creation may then appear as an application failure even though the
+workload is not runaway.
 
-## Configurable terminal lifetime
+Beta 3 keeps the containment hierarchy and exact pre-exec PTY placement:
 
-The new settings are:
-
-```ini
-[multiplexer]
-persistent-by-default=yes
-persist-on-tab-organization=yes
+```text
+splinterd.service
+app-splinterm.slice
+└── app-splinterm-dojo<ID>.slice
+    └── splinterm-splint<ID>-<incarnation>.scope
 ```
 
-Both default to `yes`, preserving Beta 1 behavior for existing configurations.
+The corrected policy is:
 
-Set `persistent-by-default=no` when normal terminals should behave like
-Window-owned terminals rather than detached multiplexer sessions. It applies to:
+- `splinterd.service` retains `TasksMax=2048` for the small control plane;
+- the aggregate workload slice does not set `TasksMax`;
+- transient Dojo slices do not set `TasksMax`; and
+- transient Splint scopes do not set `TasksMax`.
 
-- the commandless desktop/XDG launch used by Omarchy's terminal icon and
-  `SUPER+ENTER`;
-- bare `splinterm launch`;
-- **New** in the Recent Dojos picker; and
-- in-Window **New Terminal**.
+Terminal workloads therefore inherit the systemd user manager's
+`DefaultTasksMax`, subject to any stricter administrator or ancestor policy.
+`EffectiveTasksMax` is the authoritative runtime value. The existing
+`MemoryHigh` pressure boundaries remain 75% aggregate, 50% per Dojo, and 25%
+per Splint; Beta 3 still sets no `MemoryMax`.
 
-Closing the owning Window terminates the processes and removes the complete
-unpromoted Lair. It is not saved, restored, placed in Recent Dojos, or selected
-by `reopen`.
+## Clearer Dojo tabs
 
-Explicit durable intent still wins. Named Lairs, `splinterm new NAME`,
-`splinterm launch --name NAME`, native command-bearing launches, presets,
-restore/relaunch, remote creation, automation, and MCP creation remain
-persistent. Generated collision-resistant Lair names and the initial `Dojo 1`
-label are implementation identities, not explicit naming.
+The New Dojo `+` control now sits immediately after the final visible tab instead
+of being pinned to the far-right edge of the Window. When the strip is full, the
+existing bounded active-tab visibility and hit targets remain unchanged.
 
-## Organize first, keep it afterward
+Inactive tabs now use the theme's semantic pane-border color for a narrow exact
+divider. The active tab retains its exact theme-provided body, contrasting
+foreground, and accent underline.
 
-With `persist-on-tab-organization=yes`, either of these actions atomically
-promotes a Window-owned Lair to persistent:
+Older persisted unnamed Lairs may still carry historical generated identities
+such as `terminal-324324573264238-4132`. Reopening one from the Dojo picker now
+presents its initial tab as `Dojo 1`. This is a presentation-only compatibility
+rule: explicit Dojo names remain unchanged and daemon-owned topology is not
+renamed.
 
-- creating another Dojo tab; or
-- explicitly naming or renaming a Dojo tab.
+## Upgrade boundary
 
-Promotion includes every Dojo, Splint, and running process in the Lair. It is
-permanent for that Lair. Once promoted, closing the Window detaches normally and
-the Lair can appear in Recent Dojos.
+The corrected task policy applies when the daemon and transient workload
+hierarchy are recreated. Existing Beta 2 scopes retain their old explicit limits
+until then.
 
-Set the option to `no` when even organized or multi-tab terminals should remain
-Window-owned. In that mode, all tabs in the transient Lair are removed together
-when its Window closes.
+Splinterm 0.1 does not support live daemon upgrade handoff. Upgrading Beta 2 to
+Beta 3 therefore ends active Dojos. Perform the upgrade from Foot or another
+terminal not owned by `splinterd`, then reopen Splinterm Windows after package
+replacement. Package installation does not silently restart the user service.
 
-Promotion is an owner-only topology transaction. Lifetime, tab creation or
-rename, persistence, lease removal, revision advancement, and publication
-commit together. A stale revision, wrong owner, invalid name, runtime admission
-failure, or persistence failure leaves the original transient Lair unchanged.
+## Compatibility
 
-Command-bearing `splinterm-xdg-terminal-exec -- COMMAND...` retains its existing
-client-bound contract regardless of these settings.
-
-## Startup font-family correction
-
-New clients now resolve regular, bold, italic, and bold-italic from the family
-selected by the configured regular Fontconfig pattern. The application default
-is now:
-
-```ini
-[main]
-font=monospace:style=Regular
-```
-
-That follows the active Omarchy Fontconfig terminal-family selection. An
-explicit `main.font` remains authoritative.
-
-A styled face is accepted only when it belongs to the selected regular family,
-represents the requested weight and slant, and has compatible terminal-cell
-metrics. When no compatible style exists, Splinterm warns and deliberately
-reuses the regular face instead of refusing to open a Window.
-
-New clients also resolve Fontconfig's ordered outline fallback set once during
-renderer initialization. Symbols missing from the primary, CJK, and emoji faces
-now use the first installed fallback face that covers the complete cell instead
-of immediately rendering the replacement character. Fallback files are lazily
-mapped through a 24-entry evictable cache alongside the existing bounded glyph
-and raster-face caches.
-
-This corrects startup for families such as CaskaydiaMono and for regular-only
-families. Already-open Windows still retain immutable renderer resources; live
-font-family replacement remains planned for the 0.2 line.
-
-## Workload isolation and daemon protection
-
-The packaged daemon starts only after it proves that the user systemd manager
-can create, verify, and remove the transient units required for workload
-placement. Each terminal command remains blocked in the PTY helper until its
-process has been moved into and verified inside the exact Splint scope.
-Placement failure prevents the target command from executing.
-
-The packaged boundaries are:
-
-- `splinterd.service`: `TasksMax=2048`, `MemoryHigh=75%`;
-- aggregate `app-splinterm.slice`: `TasksMax=2048`, `MemoryHigh=75%`;
-- each Dojo slice: `TasksMax=1024`, `MemoryHigh=50%`; and
-- each Splint scope: `TasksMax=512`, `MemoryHigh=25%`.
-
-`MemoryHigh` applies reclaim pressure rather than terminating the unit at a hard
-byte ceiling. Beta 2 deliberately sets no `MemoryMax`; a hard-memory limit
-requires measured follow-up evidence. These boundaries limit a runaway terminal
-workload's impact on the daemon and neighboring Dojos, but they do not claim to
-fix unrelated client-side panics.
-
-Upgrading from Beta 1 still restarts the 0.1 daemon and ends its active Dojos.
-Perform the upgrade from Foot or another terminal not owned by `splinterd`, then
-reopen Splinterm windows after the package replacement.
-
-## Compatibility and boundaries
-
-- Existing configuration omission remains persistent.
-- Persistent topology, restore, history, remote, automation, MCP, and preset
-  contracts are unchanged.
-- Transient authority is restricted to the trusted local graphical owner.
-- Terminal output cannot select lifetime, trigger promotion, or retain a Lair.
-- Beta 1 tags and packages remain immutable.
-- Beta 2 still targets x86_64 Omarchy/Arch Linux with native Wayland.
-
-## Validation boundary
-
-The Beta 2 implementation passed serialized workspace, package,
-release-tooling, portable Foot-provenance, documentation, independent review,
-real-systemd workload-placement, local installation, and guarded staged-package
-graphical boundaries before publication.
+- Persistent topology, restore, history, remote, automation, MCP, preset, and
+  terminal protocol contracts are unchanged.
+- Exact cgroup placement and workload cleanup remain mandatory in packaged mode.
+- Explicit Dojo names remain authoritative.
+- Beta 2 tags and packages remain immutable.
+- Beta 3 continues to target x86_64 Omarchy/Arch Linux with native Wayland.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -58,15 +58,25 @@ hierarchy are recreated. Existing Beta 2 scopes retain their old explicit limits
 until then.
 
 Splinterm 0.1 does not support live daemon upgrade handoff. Upgrading Beta 2 to
-Beta 3 therefore ends active Dojos. Perform the upgrade from Foot or another
-terminal not owned by `splinterd`, then reopen Splinterm Windows after package
-replacement. Package installation does not silently restart the user service.
+Beta 3 therefore ends active Dojos. From Foot or another terminal not owned by
+`splinterd`, use this lifecycle around the package upgrade:
+
+```bash
+systemctl --user stop splinterd.service
+# upgrade the splinterm package here
+systemctl --user daemon-reload
+systemctl --user start splinterd.service
+```
+
+Then reopen Splinterm Windows. Package installation does not silently reload or
+restart the user service.
 
 ## Compatibility
 
 - Persistent topology, restore, history, remote, automation, MCP, preset, and
   terminal protocol contracts are unchanged.
 - Exact cgroup placement and workload cleanup remain mandatory in packaged mode.
-- Explicit Dojo names remain authoritative.
+- Explicit Dojo names remain authoritative; only the strict historical
+  `terminal-<timestamp>[-<pid>]` compatibility shape is presented as unnamed.
 - Beta 2 tags and packages remain immutable.
 - Beta 3 continues to target x86_64 Omarchy/Arch Linux with native Wayland.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -76,7 +76,8 @@ restart the user service.
 - Persistent topology, restore, history, remote, automation, MCP, preset, and
   terminal protocol contracts are unchanged.
 - Exact cgroup placement and workload cleanup remain mandatory in packaged mode.
-- Explicit Dojo names remain authoritative; only the strict historical
-  `terminal-<timestamp>[-<pid>]` compatibility shape is presented as unnamed.
+- Explicit Dojo names remain authoritative; only the strict historical pair of
+  initial Dojo `terminal` under Lair `terminal-<epoch-seconds>-<pid>` is
+  presented as unnamed.
 - Beta 2 tags and packages remain immutable.
 - Beta 3 continues to target x86_64 Omarchy/Arch Linux with native Wayland.

--- a/crates/splinterd/src/cgroup.rs
+++ b/crates/splinterd/src/cgroup.rs
@@ -18,7 +18,6 @@ use zbus::{
     zvariant::{OwnedObjectPath, OwnedValue, Str, Value},
 };
 
-const AGGREGATE_TASKS_MAX: u64 = 2_048;
 const AGGREGATE_MEMORY_HIGH_PERCENT: u32 = 75;
 const METHOD_TIMEOUT: Duration = Duration::from_millis(500);
 const VERIFY_TIMEOUT: Duration = Duration::from_secs(2);
@@ -26,30 +25,23 @@ const VERIFY_INTERVAL: Duration = Duration::from_millis(25);
 static NEXT_PROBE_ID: AtomicU64 = AtomicU64::new(1);
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(crate) struct WorkloadResourcePolicy {
-    pub(crate) dojo_tasks_max: u64,
-    pub(crate) splint_tasks_max: u64,
+pub(crate) struct WorkloadMemoryPolicy {
     pub(crate) dojo_memory_high_percent: u32,
     pub(crate) splint_memory_high_percent: u32,
 }
 
-impl Default for WorkloadResourcePolicy {
+impl Default for WorkloadMemoryPolicy {
     fn default() -> Self {
         Self {
-            dojo_tasks_max: 1_024,
-            splint_tasks_max: 512,
             dojo_memory_high_percent: 50,
             splint_memory_high_percent: 25,
         }
     }
 }
 
-impl WorkloadResourcePolicy {
+impl WorkloadMemoryPolicy {
     fn validate(self) -> Result<Self, WorkloadUnitError> {
-        if self.splint_tasks_max == 0
-            || self.splint_tasks_max >= self.dojo_tasks_max
-            || self.dojo_tasks_max >= AGGREGATE_TASKS_MAX
-            || self.splint_memory_high_percent == 0
+        if self.splint_memory_high_percent == 0
             || self.splint_memory_high_percent >= self.dojo_memory_high_percent
             || self.dojo_memory_high_percent >= AGGREGATE_MEMORY_HIGH_PERCENT
         {
@@ -91,7 +83,7 @@ fn percent_scale(percent: u32) -> u32 {
 
 #[derive(Debug, Error)]
 pub(crate) enum WorkloadUnitError {
-    #[error("workload resource policy is invalid")]
+    #[error("workload memory policy is invalid")]
     InvalidPolicy,
     #[error("systemd user-manager connection failed")]
     Connection(#[source] zbus::Error),
@@ -113,14 +105,14 @@ trait SystemdUnitAdapter: Send + Sync {
     fn start_dojo_slice(
         &self,
         name: &str,
-        policy: WorkloadResourcePolicy,
+        policy: WorkloadMemoryPolicy,
     ) -> Result<(), WorkloadUnitError>;
 
     fn start_splint_scope(
         &self,
         names: &WorkloadUnitNames,
         child_pid: u32,
-        policy: WorkloadResourcePolicy,
+        policy: WorkloadMemoryPolicy,
     ) -> Result<(), WorkloadUnitError>;
 
     fn stop_unit(&self, name: &str) -> Result<(), WorkloadUnitError>;
@@ -176,15 +168,7 @@ impl SystemdUnitAdapter for SystemdUserManager {
     fn probe(&self) -> Result<(), WorkloadUnitError> {
         let probe_id = NEXT_PROBE_ID.fetch_add(1, Ordering::Relaxed);
         let name = format!("app-splinterm-probe{}i{probe_id}.slice", std::process::id());
-        let mut properties = vec![
-            string_property("Description", "Splinterm workload capability probe"),
-            u64_property("TasksMax", 1),
-            u32_property("MemoryHighScale", percent_scale(1)),
-            string_property("CollectMode", "inactive-or-failed"),
-        ];
-        if let Some(owner_unit) = &self.owner_unit {
-            properties.push(vec_string_property("PartOf", vec![owner_unit.clone()])?);
-        }
+        let properties = capability_probe_properties(self.owner_unit.as_deref())?;
         if let Err(error) = self.start_transient_unit(&name, properties) {
             if !is_unit_exists(&error) {
                 let _ = self.stop_unit(&name);
@@ -197,42 +181,23 @@ impl SystemdUnitAdapter for SystemdUserManager {
     fn start_dojo_slice(
         &self,
         name: &str,
-        policy: WorkloadResourcePolicy,
+        policy: WorkloadMemoryPolicy,
     ) -> Result<(), WorkloadUnitError> {
-        let mut properties = vec![
-            string_property("Description", "Splinterm Dojo workload"),
-            u64_property("TasksMax", policy.dojo_tasks_max),
-            u32_property(
-                "MemoryHighScale",
-                percent_scale(policy.dojo_memory_high_percent),
-            ),
-            string_property("CollectMode", "inactive-or-failed"),
-        ];
-        if let Some(owner_unit) = &self.owner_unit {
-            properties.push(vec_string_property("PartOf", vec![owner_unit.clone()])?);
-        }
-        self.start_transient_unit(name, properties)
+        self.start_transient_unit(
+            name,
+            dojo_slice_properties(self.owner_unit.as_deref(), policy)?,
+        )
     }
 
     fn start_splint_scope(
         &self,
         names: &WorkloadUnitNames,
         child_pid: u32,
-        policy: WorkloadResourcePolicy,
+        policy: WorkloadMemoryPolicy,
     ) -> Result<(), WorkloadUnitError> {
         let result = self.start_transient_unit(
             &names.splint_scope,
-            vec![
-                string_property("Description", "Splinterm Splint workload"),
-                string_property("Slice", &names.dojo_slice),
-                vec_u32_property("PIDs", vec![child_pid])?,
-                u64_property("TasksMax", policy.splint_tasks_max),
-                u32_property(
-                    "MemoryHighScale",
-                    percent_scale(policy.splint_memory_high_percent),
-                ),
-                string_property("CollectMode", "inactive-or-failed"),
-            ],
+            splint_scope_properties(names, child_pid, policy)?,
         );
         if let Err(error) = result {
             if !is_unit_exists(&error) {
@@ -296,10 +261,6 @@ fn string_property<'a>(name: &'a str, value: &str) -> (&'a str, OwnedValue) {
     (name, OwnedValue::from(Str::from(value.to_owned())))
 }
 
-fn u64_property(name: &str, value: u64) -> (&str, OwnedValue) {
-    (name, OwnedValue::from(value))
-}
-
 fn u32_property(name: &str, value: u32) -> (&str, OwnedValue) {
     (name, OwnedValue::from(value))
 }
@@ -319,6 +280,57 @@ fn vec_string_property(
         name,
         OwnedValue::try_from(Value::from(value)).map_err(WorkloadUnitError::Property)?,
     ))
+}
+
+type UnitProperty = (&'static str, OwnedValue);
+
+fn capability_probe_properties(
+    owner_unit: Option<&str>,
+) -> Result<Vec<UnitProperty>, WorkloadUnitError> {
+    let mut properties = vec![
+        string_property("Description", "Splinterm workload capability probe"),
+        u32_property("MemoryHighScale", percent_scale(1)),
+        string_property("CollectMode", "inactive-or-failed"),
+    ];
+    if let Some(owner_unit) = owner_unit {
+        properties.push(vec_string_property("PartOf", vec![owner_unit.to_owned()])?);
+    }
+    Ok(properties)
+}
+
+fn dojo_slice_properties(
+    owner_unit: Option<&str>,
+    policy: WorkloadMemoryPolicy,
+) -> Result<Vec<UnitProperty>, WorkloadUnitError> {
+    let mut properties = vec![
+        string_property("Description", "Splinterm Dojo workload"),
+        u32_property(
+            "MemoryHighScale",
+            percent_scale(policy.dojo_memory_high_percent),
+        ),
+        string_property("CollectMode", "inactive-or-failed"),
+    ];
+    if let Some(owner_unit) = owner_unit {
+        properties.push(vec_string_property("PartOf", vec![owner_unit.to_owned()])?);
+    }
+    Ok(properties)
+}
+
+fn splint_scope_properties(
+    names: &WorkloadUnitNames,
+    child_pid: u32,
+    policy: WorkloadMemoryPolicy,
+) -> Result<Vec<UnitProperty>, WorkloadUnitError> {
+    Ok(vec![
+        string_property("Description", "Splinterm Splint workload"),
+        string_property("Slice", &names.dojo_slice),
+        vec_u32_property("PIDs", vec![child_pid])?,
+        u32_property(
+            "MemoryHighScale",
+            percent_scale(policy.splint_memory_high_percent),
+        ),
+        string_property("CollectMode", "inactive-or-failed"),
+    ])
 }
 
 #[zbus::proxy(
@@ -351,13 +363,13 @@ struct WorkloadUnitState {
 #[derive(Clone)]
 pub(crate) struct WorkloadUnitManager {
     adapter: Arc<dyn SystemdUnitAdapter>,
-    policy: WorkloadResourcePolicy,
+    policy: WorkloadMemoryPolicy,
     state: Arc<Mutex<WorkloadUnitState>>,
 }
 
 impl WorkloadUnitManager {
     pub(crate) fn connect(
-        policy: WorkloadResourcePolicy,
+        policy: WorkloadMemoryPolicy,
         owner_unit: Option<&str>,
     ) -> Result<Self, WorkloadUnitError> {
         Self::new(Arc::new(SystemdUserManager::connect(owner_unit)?), policy)
@@ -365,7 +377,7 @@ impl WorkloadUnitManager {
 
     fn new(
         adapter: Arc<dyn SystemdUnitAdapter>,
-        policy: WorkloadResourcePolicy,
+        policy: WorkloadMemoryPolicy,
     ) -> Result<Self, WorkloadUnitError> {
         let policy = policy.validate()?;
         adapter.probe()?;
@@ -558,7 +570,7 @@ mod tests {
         fn start_dojo_slice(
             &self,
             name: &str,
-            _policy: WorkloadResourcePolicy,
+            _policy: WorkloadMemoryPolicy,
         ) -> Result<(), WorkloadUnitError> {
             self.calls
                 .lock()
@@ -571,7 +583,7 @@ mod tests {
             &self,
             names: &WorkloadUnitNames,
             child_pid: u32,
-            _policy: WorkloadResourcePolicy,
+            _policy: WorkloadMemoryPolicy,
         ) -> Result<(), WorkloadUnitError> {
             self.calls.lock().unwrap().push(AdapterCall::StartSplint(
                 names.dojo_slice.clone(),
@@ -624,11 +636,25 @@ mod tests {
         ));
     }
 
+    fn user_manager_property(unit: Option<&str>, property: &str) -> String {
+        let mut command = std::process::Command::new("systemctl");
+        command.args(["--user", "show"]);
+        if let Some(unit) = unit {
+            command.arg(unit);
+        }
+        let output = command
+            .args(["--property", property, "--value"])
+            .output()
+            .unwrap();
+        assert!(output.status.success());
+        String::from_utf8(output.stdout).unwrap().trim().to_owned()
+    }
+
     #[test]
     fn manager_creation_requires_a_successful_capability_probe() {
         let adapter = Arc::new(FakeAdapter::default());
         *adapter.fail_probe.lock().unwrap() = true;
-        assert!(WorkloadUnitManager::new(adapter, WorkloadResourcePolicy::default()).is_err());
+        assert!(WorkloadUnitManager::new(adapter, WorkloadMemoryPolicy::default()).is_err());
     }
 
     #[test]
@@ -653,20 +679,44 @@ mod tests {
     }
 
     #[test]
-    fn resource_policy_requires_nested_ordering() {
-        assert!(WorkloadResourcePolicy::default().validate().is_ok());
-        assert!(
-            WorkloadResourcePolicy {
-                splint_tasks_max: 1_024,
-                ..WorkloadResourcePolicy::default()
-            }
-            .validate()
-            .is_err()
+    fn workload_units_inherit_the_user_manager_task_limit() {
+        let property_names = |properties: Vec<UnitProperty>| {
+            let mut names = properties
+                .into_iter()
+                .map(|(name, _)| name)
+                .collect::<Vec<_>>();
+            names.sort_unstable();
+            names
+        };
+        let policy = WorkloadMemoryPolicy::default();
+        let names = WorkloadUnitNames::new(DojoId::new(), SplintId::new(), 7);
+        assert_eq!(
+            property_names(capability_probe_properties(Some("splinterd.service")).unwrap()),
+            ["CollectMode", "Description", "MemoryHighScale", "PartOf"]
         );
+        assert_eq!(
+            property_names(dojo_slice_properties(Some("splinterd.service"), policy).unwrap()),
+            ["CollectMode", "Description", "MemoryHighScale", "PartOf"]
+        );
+        assert_eq!(
+            property_names(splint_scope_properties(&names, 123, policy).unwrap()),
+            [
+                "CollectMode",
+                "Description",
+                "MemoryHighScale",
+                "PIDs",
+                "Slice"
+            ]
+        );
+    }
+
+    #[test]
+    fn memory_policy_requires_nested_ordering() {
+        assert!(WorkloadMemoryPolicy::default().validate().is_ok());
         assert!(
-            WorkloadResourcePolicy {
+            WorkloadMemoryPolicy {
                 splint_memory_high_percent: 50,
-                ..WorkloadResourcePolicy::default()
+                ..WorkloadMemoryPolicy::default()
             }
             .validate()
             .is_err()
@@ -679,7 +729,7 @@ mod tests {
     fn scopes_share_one_dojo_reference_and_last_release_stops_slice() {
         let adapter = Arc::new(FakeAdapter::default());
         let manager =
-            WorkloadUnitManager::new(adapter.clone(), WorkloadResourcePolicy::default()).unwrap();
+            WorkloadUnitManager::new(adapter.clone(), WorkloadMemoryPolicy::default()).unwrap();
         let dojo_id = DojoId::new();
         let first_prepared = manager.prepare(dojo_id, SplintId::new(), 1).unwrap();
         let second_prepared = manager.prepare(dojo_id, SplintId::new(), 2).unwrap();
@@ -718,7 +768,7 @@ mod tests {
     fn immediate_reprepare_waits_for_completed_last_slice_stop() {
         let adapter = Arc::new(FakeAdapter::default());
         let manager =
-            WorkloadUnitManager::new(adapter.clone(), WorkloadResourcePolicy::default()).unwrap();
+            WorkloadUnitManager::new(adapter.clone(), WorkloadMemoryPolicy::default()).unwrap();
         let dojo_id = DojoId::new();
         let active = manager
             .prepare(dojo_id, SplintId::new(), 1)
@@ -762,7 +812,7 @@ mod tests {
         let adapter = Arc::new(FakeAdapter::default());
         *adapter.fail_scope.lock().unwrap() = true;
         let manager =
-            WorkloadUnitManager::new(adapter.clone(), WorkloadResourcePolicy::default()).unwrap();
+            WorkloadUnitManager::new(adapter.clone(), WorkloadMemoryPolicy::default()).unwrap();
         let prepared = manager.prepare(DojoId::new(), SplintId::new(), 1).unwrap();
 
         assert!(prepared.place(identity(103)).is_err());
@@ -780,7 +830,7 @@ mod tests {
     #[ignore = "requires a running systemd user manager and creates disposable transient units"]
     fn systemd_adapter_moves_and_cleans_up_a_disposable_child() {
         let manager = WorkloadUnitManager::connect(
-            WorkloadResourcePolicy::default(),
+            WorkloadMemoryPolicy::default(),
             Some("splinterd.service"),
         )
         .unwrap();
@@ -792,6 +842,11 @@ mod tests {
         let prepared = manager.prepare(DojoId::new(), SplintId::new(), 1).unwrap();
         let names = prepared.names.clone();
         let active = prepared.place(identity(pid)).unwrap();
+
+        assert_eq!(
+            user_manager_property(Some(&names.splint_scope), "TasksMax"),
+            user_manager_property(None, "DefaultTasksMax")
+        );
 
         active.release().unwrap();
         child.wait().unwrap();
@@ -815,8 +870,7 @@ mod tests {
             .unwrap()
             .join("splinterm-pty-child");
         assert!(helper.is_file(), "missing PTY helper: {}", helper.display());
-        let manager =
-            WorkloadUnitManager::connect(WorkloadResourcePolicy::default(), None).unwrap();
+        let manager = WorkloadUnitManager::connect(WorkloadMemoryPolicy::default(), None).unwrap();
         let prepared = manager.prepare(DojoId::new(), SplintId::new(), 1).unwrap();
         let names = prepared.names.clone();
         let command = PtyCommand::new("/bin/sh", "/tmp").args([

--- a/crates/splinterd/src/main.rs
+++ b/crates/splinterd/src/main.rs
@@ -22,7 +22,7 @@ use std::{
 };
 
 use anyhow::{Context, Result, bail};
-use cgroup::{WorkloadResourcePolicy, WorkloadUnitManager};
+use cgroup::{WorkloadMemoryPolicy, WorkloadUnitManager};
 use consent::{GrantStore, PeerIdentity};
 use persistence::MetadataStore;
 use rustix::net::{SendAncillaryBuffer, SendAncillaryMessage, SendFlags, sendmsg};
@@ -894,7 +894,7 @@ async fn main() -> Result<()> {
         inode: Some(daemon_identity.inode),
     };
     let workload_units = match WorkloadUnitManager::connect(
-        WorkloadResourcePolicy::default(),
+        WorkloadMemoryPolicy::default(),
         require_workload_cgroups.then_some("splinterd.service"),
     ) {
         Ok(manager) => Some(manager),

--- a/crates/splinterm/src/wayland/tabs.rs
+++ b/crates/splinterm/src/wayland/tabs.rs
@@ -129,6 +129,31 @@ fn tab_strip_background_rgba(theme: ResolvedTheme) -> [u8; 4] {
     premultiplied_theme_rgba(theme.background, theme.background_alpha)
 }
 
+fn paint_inactive_tab_divider(
+    canvas: &mut [u8],
+    width: u32,
+    height: u32,
+    rect: Rect,
+    scale_120: u32,
+    theme: ResolvedTheme,
+) -> Result<()> {
+    let divider = logical_extent_to_buffer(1, scale_120)?.max(1);
+    fill_rect(
+        canvas,
+        width,
+        height,
+        (
+            i32::try_from(rect.x.saturating_add(rect.width).saturating_sub(divider))
+                .unwrap_or(i32::MAX),
+            i32::try_from(rect.y).unwrap_or(i32::MAX),
+            divider.min(rect.width),
+            rect.height,
+        ),
+        opaque_rgba(theme.pane_border),
+    );
+    Ok(())
+}
+
 fn is_legacy_generated_lair_name(value: &str) -> bool {
     let Some(suffix) = value.strip_prefix("terminal-") else {
         return false;
@@ -550,19 +575,7 @@ impl App {
                     opaque_rgba(theme.ui_accent),
                 );
             } else {
-                let divider = logical_extent_to_buffer(1, scale_120)?.max(1);
-                fill_rect(
-                    canvas,
-                    width,
-                    height,
-                    (
-                        position(rect.x.saturating_add(rect.width).saturating_sub(divider)),
-                        position(rect.y),
-                        divider.min(rect.width),
-                        rect.height,
-                    ),
-                    opaque_rgba(theme.pane_border),
-                );
+                paint_inactive_tab_divider(canvas, width, height, rect, scale_120, theme)?;
             }
             let label_rect = Self::buffer_rect(tab.label_rect, scale_120)?;
             if let Some(label) = labels.get(&tab.dojo_id) {

--- a/crates/splinterm/src/wayland/tabs.rs
+++ b/crates/splinterm/src/wayland/tabs.rs
@@ -93,9 +93,9 @@ pub(super) fn tab_strip_layout(
         },
         tabs,
         new_rect: Rect {
-            x: width.saturating_sub(new_width),
+            x,
             y: 0,
-            width: new_width,
+            width: new_width.min(width.saturating_sub(x)),
             height: TAB_STRIP_LOGICAL_HEIGHT,
         },
     })
@@ -127,6 +127,33 @@ const fn opaque_rgba(color: u32) -> [u8; 4] {
 
 fn tab_strip_background_rgba(theme: ResolvedTheme) -> [u8; 4] {
     premultiplied_theme_rgba(theme.background, theme.background_alpha)
+}
+
+fn is_legacy_generated_lair_name(value: &str) -> bool {
+    let Some(suffix) = value.strip_prefix("terminal-") else {
+        return false;
+    };
+    let mut components = suffix.split('-');
+    let Some(stamp) = components.next() else {
+        return false;
+    };
+    let process = components.next();
+    components.next().is_none()
+        && !stamp.is_empty()
+        && stamp.bytes().all(|byte| byte.is_ascii_digit())
+        && process.is_none_or(|process| {
+            !process.is_empty() && process.bytes().all(|byte| byte.is_ascii_digit())
+        })
+}
+
+fn tab_dojo_label(identity: &WindowDojoIdentity) -> String {
+    if identity.dojo_name == identity.lair_name
+        && is_legacy_generated_lair_name(&identity.lair_name)
+    {
+        "Dojo 1".to_owned()
+    } else {
+        sanitized_tab_label(&identity.dojo_name, 128, 48)
+    }
 }
 
 pub(super) fn tab_strip_hit_test(
@@ -364,11 +391,10 @@ impl TabsState {
         let Some(identity) = self.tab_identity(dojo_id) else {
             return "Untitled Dojo".to_owned();
         };
-        let dojo_label = sanitized_tab_label(&identity.dojo_name, 128, 48);
+        let dojo_label = tab_dojo_label(identity);
         let ambiguous = self.tabs.iter().filter(|tab| {
-            self.tab_identity(tab.dojo_id).is_some_and(|candidate| {
-                sanitized_tab_label(&candidate.dojo_name, 128, 48) == dojo_label
-            })
+            self.tab_identity(tab.dojo_id)
+                .is_some_and(|candidate| tab_dojo_label(candidate) == dojo_label)
         });
         if ambiguous.count() > 1 {
             sanitized_tab_label(
@@ -523,6 +549,20 @@ impl App {
                     ),
                     opaque_rgba(theme.ui_accent),
                 );
+            } else {
+                let divider = logical_extent_to_buffer(1, scale_120)?.max(1);
+                fill_rect(
+                    canvas,
+                    width,
+                    height,
+                    (
+                        position(rect.x.saturating_add(rect.width).saturating_sub(divider)),
+                        position(rect.y),
+                        divider.min(rect.width),
+                        rect.height,
+                    ),
+                    opaque_rgba(theme.pane_border),
+                );
             }
             let label_rect = Self::buffer_rect(tab.label_rect, scale_120)?;
             if let Some(label) = labels.get(&tab.dojo_id) {
@@ -583,9 +623,12 @@ impl App {
 mod tests {
     use std::collections::HashMap;
 
+    use splinterm_core::{LairId, TopologyRevision};
+
     use super::{
-        App, DojoId, ResolvedTheme, TAB_STRIP_LOGICAL_HEIGHT, TabHitTarget, opaque_rgba,
-        tab_context_target, tab_foreground, tab_strip_hit_test, tab_strip_layout,
+        App, DojoId, ResolvedTheme, TAB_STRIP_LOGICAL_HEIGHT, TabHitTarget, WindowDojoIdentity,
+        is_legacy_generated_lair_name, opaque_rgba, tab_context_target, tab_dojo_label,
+        tab_foreground, tab_strip_hit_test, tab_strip_layout,
     };
 
     #[test]
@@ -677,11 +720,89 @@ mod tests {
         for pair in layout.tabs.windows(2) {
             assert!(pair[0].rect.x.saturating_add(pair[0].rect.width) <= pair[1].rect.x);
         }
+        assert_eq!(
+            layout.new_rect.x,
+            layout
+                .tabs
+                .last()
+                .unwrap()
+                .rect
+                .x
+                .saturating_add(layout.tabs.last().unwrap().rect.width)
+        );
         let close = layout.tabs[0].close_rect;
         assert_eq!(
             tab_strip_hit_test(&layout, (f64::from(close.x), f64::from(close.y)),),
             Some(TabHitTarget::Close(layout.tabs[0].dojo_id))
         );
+    }
+
+    #[test]
+    fn inactive_tabs_have_exact_semantic_dividers() {
+        let inactive_dojo = DojoId::new();
+        let active_dojo = DojoId::new();
+        let layout = tab_strip_layout(420, &[inactive_dojo, active_dojo], 1).unwrap();
+        let theme = ResolvedTheme {
+            background: 0x10_20_30,
+            pane_border: 0x44_55_66,
+            ..ResolvedTheme::default()
+        };
+        let mut canvas = vec![0; 420 * usize::try_from(TAB_STRIP_LOGICAL_HEIGHT).unwrap() * 4];
+        App::paint_tab_strip(
+            &mut canvas,
+            420,
+            TAB_STRIP_LOGICAL_HEIGHT,
+            &layout,
+            120,
+            theme,
+            active_dojo,
+            &HashMap::new(),
+            None,
+            None,
+        )
+        .unwrap();
+
+        let inactive = &layout.tabs[0].rect;
+        let divider_x =
+            usize::try_from(inactive.x.saturating_add(inactive.width).saturating_sub(1)).unwrap();
+        let divider_y = usize::try_from(inactive.height / 2).unwrap();
+        let divider_offset = (divider_y * 420 + divider_x) * 4;
+        assert_eq!(
+            &canvas[divider_offset..divider_offset + 4],
+            &[0x66, 0x55, 0x44, 0xff]
+        );
+    }
+
+    #[test]
+    fn legacy_generated_initial_dojo_names_have_a_stable_friendly_tab_label() {
+        assert!(is_legacy_generated_lair_name("terminal-324324573264238"));
+        assert!(is_legacy_generated_lair_name(
+            "terminal-324324573264238-4132"
+        ));
+        for explicit in [
+            "terminal",
+            "terminal-work",
+            "terminal-123-work",
+            "terminal-123-456-extra",
+        ] {
+            assert!(!is_legacy_generated_lair_name(explicit));
+        }
+
+        let identity = WindowDojoIdentity {
+            topology_revision: TopologyRevision::new(1),
+            lair_id: LairId::new(),
+            dojo_id: DojoId::new(),
+            lair_name: "terminal-324324573264238-4132".to_owned(),
+            lair_retention: splinterm_core::LairRetention::Disposable,
+            dojo_name: "terminal-324324573264238-4132".to_owned(),
+        };
+        assert_eq!(tab_dojo_label(&identity), "Dojo 1");
+
+        let explicitly_named = WindowDojoIdentity {
+            dojo_name: "logs".to_owned(),
+            ..identity
+        };
+        assert_eq!(tab_dojo_label(&explicitly_named), "logs");
     }
 
     #[test]

--- a/crates/splinterm/src/wayland/tabs.rs
+++ b/crates/splinterm/src/wayland/tabs.rs
@@ -164,20 +164,42 @@ fn is_legacy_generated_lair_name(value: &str) -> bool {
     };
     let process = components.next();
     components.next().is_none()
-        && !stamp.is_empty()
+        && (15..=20).contains(&stamp.len())
         && stamp.bytes().all(|byte| byte.is_ascii_digit())
         && process.is_none_or(|process| {
-            !process.is_empty() && process.bytes().all(|byte| byte.is_ascii_digit())
+            (1..=10).contains(&process.len()) && process.bytes().all(|byte| byte.is_ascii_digit())
         })
 }
 
+fn uses_legacy_generated_dojo_label(identity: &WindowDojoIdentity) -> bool {
+    identity.dojo_name == identity.lair_name && is_legacy_generated_lair_name(&identity.lair_name)
+}
+
 fn tab_dojo_label(identity: &WindowDojoIdentity) -> String {
-    if identity.dojo_name == identity.lair_name
-        && is_legacy_generated_lair_name(&identity.lair_name)
-    {
+    if uses_legacy_generated_dojo_label(identity) {
         "Dojo 1".to_owned()
     } else {
         sanitized_tab_label(&identity.dojo_name, 128, 48)
+    }
+}
+
+fn ambiguous_tab_label(
+    identity: &WindowDojoIdentity,
+    dojo_label: &str,
+    matching_ordinal: usize,
+) -> String {
+    if uses_legacy_generated_dojo_label(identity) {
+        sanitized_tab_label(
+            &format!("{dojo_label} ({})", matching_ordinal.saturating_add(1)),
+            128,
+            48,
+        )
+    } else {
+        sanitized_tab_label(
+            &format!("{} / {}", identity.lair_name, identity.dojo_name),
+            128,
+            48,
+        )
     }
 }
 
@@ -417,16 +439,21 @@ impl TabsState {
             return "Untitled Dojo".to_owned();
         };
         let dojo_label = tab_dojo_label(identity);
-        let ambiguous = self.tabs.iter().filter(|tab| {
-            self.tab_identity(tab.dojo_id)
+        let mut matching_count = 0;
+        let mut matching_ordinal = 0;
+        for tab in self.tabs.iter() {
+            if self
+                .tab_identity(tab.dojo_id)
                 .is_some_and(|candidate| tab_dojo_label(candidate) == dojo_label)
-        });
-        if ambiguous.count() > 1 {
-            sanitized_tab_label(
-                &format!("{} / {}", identity.lair_name, identity.dojo_name),
-                128,
-                48,
-            )
+            {
+                if tab.dojo_id == dojo_id {
+                    matching_ordinal = matching_count;
+                }
+                matching_count += 1;
+            }
+        }
+        if matching_count > 1 {
+            ambiguous_tab_label(identity, &dojo_label, matching_ordinal)
         } else {
             dojo_label
         }
@@ -640,8 +667,8 @@ mod tests {
 
     use super::{
         App, DojoId, ResolvedTheme, TAB_STRIP_LOGICAL_HEIGHT, TabHitTarget, WindowDojoIdentity,
-        is_legacy_generated_lair_name, opaque_rgba, tab_context_target, tab_dojo_label,
-        tab_foreground, tab_strip_hit_test, tab_strip_layout,
+        ambiguous_tab_label, is_legacy_generated_lair_name, opaque_rgba, tab_context_target,
+        tab_dojo_label, tab_foreground, tab_strip_hit_test, tab_strip_layout,
     };
 
     #[test]
@@ -794,9 +821,12 @@ mod tests {
         ));
         for explicit in [
             "terminal",
+            "terminal-123",
             "terminal-work",
             "terminal-123-work",
             "terminal-123-456-extra",
+            "terminal-12345678901234-456",
+            "terminal-123456789012345-12345678901",
         ] {
             assert!(!is_legacy_generated_lair_name(explicit));
         }
@@ -811,11 +841,16 @@ mod tests {
         };
         assert_eq!(tab_dojo_label(&identity), "Dojo 1");
 
+        assert_eq!(ambiguous_tab_label(&identity, "Dojo 1", 0), "Dojo 1 (1)");
+        assert_eq!(ambiguous_tab_label(&identity, "Dojo 1", 1), "Dojo 1 (2)");
+        assert!(!ambiguous_tab_label(&identity, "Dojo 1", 1).contains("terminal-"));
+
         let explicitly_named = WindowDojoIdentity {
-            dojo_name: "logs".to_owned(),
+            lair_name: "terminal-123".to_owned(),
+            dojo_name: "terminal-123".to_owned(),
             ..identity
         };
-        assert_eq!(tab_dojo_label(&explicitly_named), "logs");
+        assert_eq!(tab_dojo_label(&explicitly_named), "terminal-123");
     }
 
     #[test]

--- a/crates/splinterm/src/wayland/tabs.rs
+++ b/crates/splinterm/src/wayland/tabs.rs
@@ -162,17 +162,18 @@ fn is_legacy_generated_lair_name(value: &str) -> bool {
     let Some(stamp) = components.next() else {
         return false;
     };
-    let process = components.next();
+    let Some(process) = components.next() else {
+        return false;
+    };
     components.next().is_none()
-        && (15..=20).contains(&stamp.len())
+        && stamp.len() == 10
         && stamp.bytes().all(|byte| byte.is_ascii_digit())
-        && process.is_none_or(|process| {
-            (1..=10).contains(&process.len()) && process.bytes().all(|byte| byte.is_ascii_digit())
-        })
+        && (1..=10).contains(&process.len())
+        && process.bytes().all(|byte| byte.is_ascii_digit())
 }
 
 fn uses_legacy_generated_dojo_label(identity: &WindowDojoIdentity) -> bool {
-    identity.dojo_name == identity.lair_name && is_legacy_generated_lair_name(&identity.lair_name)
+    identity.dojo_name == "terminal" && is_legacy_generated_lair_name(&identity.lair_name)
 }
 
 fn tab_dojo_label(identity: &WindowDojoIdentity) -> String {
@@ -815,18 +816,17 @@ mod tests {
 
     #[test]
     fn legacy_generated_initial_dojo_names_have_a_stable_friendly_tab_label() {
-        assert!(is_legacy_generated_lair_name("terminal-324324573264238"));
-        assert!(is_legacy_generated_lair_name(
-            "terminal-324324573264238-4132"
-        ));
+        assert!(is_legacy_generated_lair_name("terminal-1787899189-4132"));
         for explicit in [
             "terminal",
             "terminal-123",
             "terminal-work",
             "terminal-123-work",
-            "terminal-123-456-extra",
-            "terminal-12345678901234-456",
-            "terminal-123456789012345-12345678901",
+            "terminal-1787899189",
+            "terminal-178789918-4132",
+            "terminal-17878991890-4132",
+            "terminal-1787899189-12345678901",
+            "terminal-1787899189-4132-extra",
         ] {
             assert!(!is_legacy_generated_lair_name(explicit));
         }
@@ -835,15 +835,24 @@ mod tests {
             topology_revision: TopologyRevision::new(1),
             lair_id: LairId::new(),
             dojo_id: DojoId::new(),
-            lair_name: "terminal-324324573264238-4132".to_owned(),
+            lair_name: "terminal-1787899189-4132".to_owned(),
             lair_retention: splinterm_core::LairRetention::Disposable,
-            dojo_name: "terminal-324324573264238-4132".to_owned(),
+            dojo_name: "terminal".to_owned(),
         };
         assert_eq!(tab_dojo_label(&identity), "Dojo 1");
 
         assert_eq!(ambiguous_tab_label(&identity, "Dojo 1", 0), "Dojo 1 (1)");
         assert_eq!(ambiguous_tab_label(&identity, "Dojo 1", 1), "Dojo 1 (2)");
         assert!(!ambiguous_tab_label(&identity, "Dojo 1", 1).contains("terminal-"));
+
+        let explicitly_generated_looking = WindowDojoIdentity {
+            dojo_name: "terminal-1787899189-4132".to_owned(),
+            ..identity.clone()
+        };
+        assert_eq!(
+            tab_dojo_label(&explicitly_generated_looking),
+            "terminal-1787899189-4132"
+        );
 
         let explicitly_named = WindowDojoIdentity {
             lair_name: "terminal-123".to_owned(),

--- a/dist/systemd/user/app-splinterm.slice
+++ b/dist/systemd/user/app-splinterm.slice
@@ -4,5 +4,4 @@ Documentation=file:///usr/share/doc/splinterm/headless.md
 StopWhenUnneeded=yes
 
 [Slice]
-TasksMax=2048
 MemoryHigh=75%

--- a/docs/headless.md
+++ b/docs/headless.md
@@ -49,14 +49,17 @@ app-splinterm.slice                all terminal workloads
     └── one transient scope per live Splint
 ```
 
-Both `splinterd.service` and the aggregate workload slice have `TasksMax=2048`
-and `MemoryHigh=75%`. The independent daemon boundary keeps a workload failure
-from consuming the daemon's task or memory-pressure budget. Transient Dojo
-slices use 1024 tasks and 50% memory pressure; Splint scopes use 512 tasks and
-25% memory pressure. These are task ceilings and soft memory-pressure
-thresholds. `MemoryHigh` asks the kernel to reclaim and throttle under sustained
-pressure; Splinterm does not install a `MemoryMax` hard kill boundary in this
-release.
+`splinterd.service` retains `TasksMax=2048` and `MemoryHigh=75%` as an
+independent control-plane guard. Terminal workload units do not set `TasksMax`:
+each Splint scope receives the systemd user manager's normal `DefaultTasksMax`,
+subject to any stricter administrator or ancestor policy. This matches ordinary
+application-scope behavior and avoids rejecting legitimate thread-heavy browser,
+test, editor, build, and agent workloads.
+
+The aggregate workload slice retains `MemoryHigh=75%`; transient Dojo slices use
+50% and Splint scopes use 25% memory pressure. `MemoryHigh` asks the kernel to
+reclaim and throttle under sustained pressure; Splinterm does not install a
+`MemoryMax` hard kill boundary in this release.
 
 A new Splint is rejected if its exact helper PID cannot be verified inside its
 scope while still blocked before target execution. Existing Dojos are not
@@ -68,12 +71,21 @@ bounded warning; only the packaged service passes the strict
 Inspect both boundaries without changing them:
 
 ```bash
+systemctl --user show -p DefaultTasksMax
 systemctl --user show splinterd.service \
-  -p TasksCurrent -p TasksMax -p MemoryCurrent -p MemoryHigh -p MemoryMax
+  -p TasksCurrent -p TasksMax -p EffectiveTasksMax \
+  -p MemoryCurrent -p MemoryHigh -p MemoryMax
+systemctl --user show <splint.scope> \
+  -p TasksCurrent -p TasksMax -p EffectiveTasksMax
 systemctl --user status app-splinterm.slice
 systemd-cgls --user-unit app-splinterm.slice
 systemd-cgtop
 ```
+
+`EffectiveTasksMax` is authoritative because systemd applies the strictest limit
+from the scope and its ancestors. Existing transient scopes created by an older
+daemon retain their old explicit task ceiling until that workload hierarchy is
+recreated; package installation does not restart the daemon automatically.
 
 `MemoryCurrent` includes page cache charged to each cgroup. Inactive file cache
 is normally reclaimable under pressure, but it is neither immediately free nor

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -3,11 +3,11 @@
 Release authority, candidate construction, approval boundaries, and the future
 n8n notification role are defined in [Release automation](release-automation.md).
 
-Splinterm's `packaging/PKGBUILD` prepares the `0.1.0beta2` split packages for
+Splinterm's `packaging/PKGBUILD` prepares the `0.1.0beta3` split packages for
 reviewed local and CI candidate builds. Its local source archive and `SKIP` checksum are
 valid only in that workflow. The current public versioned release is
-[`v0.1.0-beta1`](https://github.com/OldJobobo/splinterm/releases/tag/v0.1.0-beta1),
-and both AUR package bases publish `0.1.0beta1-1`. The closed
+[`v0.1.0-beta2`](https://github.com/OldJobobo/splinterm/releases/tag/v0.1.0-beta2),
+and both AUR package bases publish `0.1.0beta2-1`. The closed
 `packaging/release-state.json` record is the machine-readable authority for that
 current public predecessor; candidate construction and promotion both reject a
 different supplied tag even when it exists. `docs/status.md` carries the same
@@ -106,8 +106,8 @@ complete package test suite. This is the mode used by `./install.sh --source`;
 Its equivalent manual build from a clean checkout is:
 
 ```bash
-git archive --format=tar.gz --prefix=splinterm-0.1.0beta2/ \
-  -o packaging/splinterm-0.1.0beta2.tar.gz HEAD
+git archive --format=tar.gz --prefix=splinterm-0.1.0beta3/ \
+  -o packaging/splinterm-0.1.0beta3.tar.gz HEAD
 ```
 
 The archive honors `.gitattributes` `export-ignore` entries; website source and
@@ -126,8 +126,8 @@ creates the main package plus the explicitly optional `splinterm-mcp` split
 package without installing either. Inspect them with:
 
 ```bash
-pacman -Qlp packaging/splinterm-0.1.0beta2-1-x86_64.pkg.tar.zst
-pacman -Qlp packaging/splinterm-mcp-0.1.0beta2-1-x86_64.pkg.tar.zst
+pacman -Qlp packaging/splinterm-0.1.0beta3-1-x86_64.pkg.tar.zst
+pacman -Qlp packaging/splinterm-mcp-0.1.0beta3-1-x86_64.pkg.tar.zst
 namcap packaging/PKGBUILD packaging/*.pkg.tar.zst   # optional
 ```
 
@@ -239,7 +239,7 @@ The equivalent manual lifecycle is:
 
 ```bash
 systemctl --user stop splinterd.service
-sudo pacman -U packaging/splinterm-0.1.0beta2-1-x86_64.pkg.tar.zst
+sudo pacman -U packaging/splinterm-0.1.0beta3-1-x86_64.pkg.tar.zst
 systemctl --user daemon-reload
 systemctl --user start splinterd.service
 ```
@@ -247,7 +247,7 @@ systemctl --user start splinterd.service
 Install the adapter only when an MCP host will be configured:
 
 ```bash
-sudo pacman -U packaging/splinterm-mcp-0.1.0beta2-1-x86_64.pkg.tar.zst
+sudo pacman -U packaging/splinterm-mcp-0.1.0beta3-1-x86_64.pkg.tar.zst
 ```
 
 The guarded upgrade script upgrades `splinterm-mcp` only when that optional

--- a/docs/status.md
+++ b/docs/status.md
@@ -58,10 +58,10 @@ memory-pressure boundaries remain intact.
 
 The candidate also places the New Dojo control immediately after the final
 visible tab, gives inactive tabs exact semantic dividers, and presents the strict
-historical unnamed `terminal-<timestamp>[-<pid>]` initial-Dojo shape as `Dojo 1`
-without changing ordinary explicit names or daemon-owned topology. Focused
-implementation tests have passed; complete non-graphical release validation,
-independent review, candidate construction,
+historical initial Dojo `terminal` under Lair `terminal-<epoch-seconds>-<pid>`
+as `Dojo 1` without changing ordinary explicit names or daemon-owned topology.
+Focused implementation tests have passed; complete non-graphical release
+validation, independent review, candidate construction,
 protected publication, installation, and AUR updates remain pending. Beta 2
 remains the current public release.
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -57,10 +57,11 @@ systemd user manager's `DefaultTasksMax`. The daemon retains its independent
 memory-pressure boundaries remain intact.
 
 The candidate also places the New Dojo control immediately after the final
-visible tab, gives inactive tabs exact semantic dividers, and presents legacy
-unnamed `terminal-…` initial Dojos as `Dojo 1` without changing explicit names
-or daemon-owned topology. Focused implementation tests have passed; complete
-non-graphical release validation, independent review, candidate construction,
+visible tab, gives inactive tabs exact semantic dividers, and presents the strict
+historical unnamed `terminal-<timestamp>[-<pid>]` initial-Dojo shape as `Dojo 1`
+without changing ordinary explicit names or daemon-owned topology. Focused
+implementation tests have passed; complete non-graphical release validation,
+independent review, candidate construction,
 protected publication, installation, and AUR updates remain pending. Beta 2
 remains the current public release.
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,6 +1,6 @@
 # Current product status
 
-- **Current public version tag:** `v0.1.0-beta1`
+- **Current public version tag:** `v0.1.0-beta2`
 
 This document is the repository authority for Splinterm's current maturity,
 validated product scope, availability, and release gates. The [product roadmap](product-roadmap.md)
@@ -33,33 +33,71 @@ The current product target is:
 - native Wayland under the documented Hyprland environment;
 - Foot 1.27.0 commit `3c5b584b0eafa772eb4376fb6eaf6643399e190e`
   as the terminal-behavior oracle;
-- public Beta 1 `0.1.0beta1-1` Arch packages built from clean committed
+- public Beta 2 `0.1.0beta2-1` Arch packages built from clean committed
   source; and
 - guarded installed-package evidence for the Alpha3 command, scrollback,
   saved-Lair, Wayland file-drop, and Omarchy screensaver workflows; isolated
-  exact-package acceptance for the Alpha3.1 transient-tab hotfixes; and accepted
+  exact-package acceptance for the Alpha3.1 transient-tab hotfixes; accepted
   Beta 1 graphical, package, provenance, wide-grid, sparse-publication, and
-  active-tab contrast evidence.
+  active-tab contrast evidence; and accepted Beta 2 terminal-lifetime,
+  font-family, workload-isolation, package, and release evidence.
 
 Other Linux distributions, compositors, architectures, and package formats are
 not current compatibility promises. Headless `splinterd` does not require a
 graphical environment, but its packaged and remote workflows remain beta
 interfaces on the documented platform.
 
-## Beta 2 candidate preparation
+## Beta 3 candidate preparation
 
-The `0.1.0-beta2` source and package metadata are under review. The candidate
-adds backward-compatible graphical lifetime settings, owner-only atomic
-promotion through Dojo creation or explicit Dojo naming, and the startup
-font-family correction for newly opened Windows. It also separates the daemon
-from terminal workload resource boundaries through an aggregate workload slice,
-per-Dojo slices, per-Splint scopes, and a pre-exec placement gate. Packaged
-startup fails closed when that placement capability is unavailable. Complete
-non-graphical workspace, package, release-tooling, portable-provenance,
-documentation, real-systemd, local installed-package, and isolated staged-package
-graphical validation has passed. Final release review and protected publication
-remain pending. No Beta 2 tag, public release, or AUR update exists yet; Beta 1
+The `0.1.0-beta3` maintenance candidate removes Splinterm's provisional
+512/1024/2048 task ceilings from terminal workload scopes and slices so ordinary
+Chromium, Node, editor, build, and agent workloads inherit the surrounding
+systemd user manager's `DefaultTasksMax`. The daemon retains its independent
+`TasksMax=2048` control-plane guard and the existing nested workload and
+memory-pressure boundaries remain intact.
+
+The candidate also places the New Dojo control immediately after the final
+visible tab, gives inactive tabs exact semantic dividers, and presents legacy
+unnamed `terminal-…` initial Dojos as `Dojo 1` without changing explicit names
+or daemon-owned topology. Focused implementation tests have passed; complete
+non-graphical release validation, independent review, candidate construction,
+protected publication, installation, and AUR updates remain pending. Beta 2
 remains the current public release.
+
+## Beta 2 release
+
+[`v0.1.0-beta2`](https://github.com/OldJobobo/splinterm/releases/tag/v0.1.0-beta2)
+was published as a GitHub prerelease on 2026-08-24 and distributed through both
+AUR package bases as `0.1.0beta2-1`. Beta 2 adds configurable Window-owned
+terminal lifetimes with atomic promotion to persistent Lairs, follows the
+selected Fontconfig family for newly opened Windows, and places packaged
+terminal workloads in verified nested systemd user units so the daemon retains
+an independent resource-failure boundary.
+
+- Release commit `f0c5dd176e36ce88abc1328c8e67839da263e56a` passed exact-SHA CI
+  run `32684539475`. Candidate run `32685119499` built the release once, and
+  protected promotion run `32690770541` published and reverified the exact
+  five public assets; publication receipt artifact `9507412607` remains the
+  release record.
+- Source archive SHA-256:
+  `ba8f953c2bf7562923af0c2e131b86a469ab2b4788c352ab3cfaec521125a1f2`.
+  Main package SHA-256:
+  `1e7060fea06867743a88a0021ad33385f32f5cc4a20a22afb45448130ebdded5`.
+  MCP package SHA-256:
+  `889b7a6457789ee601f095dfaf8e208172177fa93aba232fa20394e07ff3eacd`.
+- AUR source package commit: `0dfb8e31fcb8dcefebff9b1735bcd9e8b0b33093`.
+  AUR prebuilt package commit: `eae0d825a0331f5494eb61dfd9e01734374025f2`.
+  Both visible recipes identify `0.1.0beta2-1` and pin the immutable GitHub
+  source or package assets to the release hashes above.
+- Complete serialized workspace, package, release-tooling, portable Foot
+  provenance, documentation, independent review, disposable real-systemd
+  placement, local package-integrity, and guarded staged-package graphical
+  boundaries passed before publication.
+
+Upgrading Beta 2 to Beta 3 recreates the `0.1` daemon and workload hierarchy and
+therefore ends active Dojos. The [packaging guide](packaging.md) documents the
+required external-terminal upgrade and rollback workflow; package installation
+does not restart the user service automatically.
 
 ## Beta 1 release
 

--- a/packaging/PKGBUILD
+++ b/packaging/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: OldJobobo
 pkgbase=splinterm
 pkgname=('splinterm' 'splinterm-mcp')
-pkgver=0.1.0beta2
+pkgver=0.1.0beta3
 pkgrel=1
 arch=('x86_64')
 url='https://github.com/oldjobobo/splinterm'

--- a/packaging/aur-bin/.SRCINFO
+++ b/packaging/aur-bin/.SRCINFO
@@ -1,15 +1,15 @@
 pkgbase = splinterm-bin
-	pkgver = 0.1.0beta2
+	pkgver = 0.1.0beta3
 	pkgrel = 1
 	url = https://github.com/oldjobobo/splinterm
 	arch = x86_64
 	license = MIT
-	noextract = splinterm-0.1.0beta2-x86_64.pkg.tar.zst
-	noextract = splinterm-mcp-0.1.0beta2-x86_64.pkg.tar.zst
+	noextract = splinterm-0.1.0beta3-x86_64.pkg.tar.zst
+	noextract = splinterm-mcp-0.1.0beta3-x86_64.pkg.tar.zst
 	options = !strip
 	options = !debug
-	source = splinterm-0.1.0beta2-x86_64.pkg.tar.zst::https://github.com/OldJobobo/splinterm/releases/download/v0.1.0-beta2/splinterm-11742b60cb5b502cdadb60a582b9c3c838120d2b-x86_64.pkg.tar.zst
-	source = splinterm-mcp-0.1.0beta2-x86_64.pkg.tar.zst::https://github.com/OldJobobo/splinterm/releases/download/v0.1.0-beta2/splinterm-mcp-11742b60cb5b502cdadb60a582b9c3c838120d2b-x86_64.pkg.tar.zst
+	source = splinterm-0.1.0beta3-x86_64.pkg.tar.zst::https://github.com/OldJobobo/splinterm/releases/download/v0.1.0-beta3/splinterm-11742b60cb5b502cdadb60a582b9c3c838120d2b-x86_64.pkg.tar.zst
+	source = splinterm-mcp-0.1.0beta3-x86_64.pkg.tar.zst::https://github.com/OldJobobo/splinterm/releases/download/v0.1.0-beta3/splinterm-mcp-11742b60cb5b502cdadb60a582b9c3c838120d2b-x86_64.pkg.tar.zst
 	sha256sums = 1a7f2a31c04dfc87495740938a3e8410f2a464f99c382a0f5d563045d8798cfb
 	sha256sums = e53a2b567619d6d8058522c4e18ef077e3b575cc99889d26cc1a18d65647ead0
 
@@ -31,13 +31,13 @@ pkgname = splinterm-bin
 	depends = xdg-terminal-exec
 	optdepends = fcitx5: Wayland text-input support
 	optdepends = splinterm-mcp-bin: explicitly configured MCP stdio adapter
-	provides = splinterm=0.1.0beta2-1
+	provides = splinterm=0.1.0beta3-1
 	conflicts = splinterm
 
 pkgname = splinterm-mcp-bin
 	pkgdesc = Policy-scoped MCP stdio adapter for Splinterm (prebuilt binary)
-	depends = splinterm=0.1.0beta2-1
+	depends = splinterm=0.1.0beta3-1
 	depends = gcc-libs
 	depends = glibc
-	provides = splinterm-mcp=0.1.0beta2-1
+	provides = splinterm-mcp=0.1.0beta3-1
 	conflicts = splinterm-mcp

--- a/packaging/aur-bin/PKGBUILD
+++ b/packaging/aur-bin/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: OldJobobo
 pkgbase=splinterm-bin
 pkgname=('splinterm-bin' 'splinterm-mcp-bin')
-pkgver=0.1.0beta2
+pkgver=0.1.0beta3
 pkgrel=1
 _commit=11742b60cb5b502cdadb60a582b9c3c838120d2b
 arch=('x86_64')
@@ -9,8 +9,8 @@ url='https://github.com/oldjobobo/splinterm'
 license=('MIT')
 options=('!strip' '!debug')
 source=(
-  "splinterm-$pkgver-$CARCH.pkg.tar.zst::https://github.com/OldJobobo/splinterm/releases/download/v0.1.0-beta2/splinterm-$_commit-$CARCH.pkg.tar.zst"
-  "splinterm-mcp-$pkgver-$CARCH.pkg.tar.zst::https://github.com/OldJobobo/splinterm/releases/download/v0.1.0-beta2/splinterm-mcp-$_commit-$CARCH.pkg.tar.zst"
+  "splinterm-$pkgver-$CARCH.pkg.tar.zst::https://github.com/OldJobobo/splinterm/releases/download/v0.1.0-beta3/splinterm-$_commit-$CARCH.pkg.tar.zst"
+  "splinterm-mcp-$pkgver-$CARCH.pkg.tar.zst::https://github.com/OldJobobo/splinterm/releases/download/v0.1.0-beta3/splinterm-mcp-$_commit-$CARCH.pkg.tar.zst"
 )
 noextract=(
   "splinterm-$pkgver-$CARCH.pkg.tar.zst"

--- a/packaging/aur-bin/splinterm.install
+++ b/packaging/aur-bin/splinterm.install
@@ -6,7 +6,9 @@ post_install() {
 }
 
 post_upgrade() {
-  echo 'Restart running user splinterd services after protocol upgrades; the launcher does this when ping negotiation fails.'
+  echo 'Beta 3 removes terminal workload TasksMax overrides; existing daemon and workload units keep their old policy until recreated.'
+  echo 'From an external terminal, stop splinterd.service, run systemctl --user daemon-reload, then start splinterd.service; stopping ends active Dojos.'
+  echo 'This package does not restart user services automatically.'
   echo 'Check Omarchy screensaver integration: splinterm integration omarchy-screensaver status'
 }
 

--- a/packaging/aur/.SRCINFO
+++ b/packaging/aur/.SRCINFO
@@ -1,5 +1,5 @@
 pkgbase = splinterm
-	pkgver = 0.1.0beta2
+	pkgver = 0.1.0beta3
 	pkgrel = 1
 	url = https://github.com/oldjobobo/splinterm
 	arch = x86_64
@@ -19,7 +19,7 @@ pkgbase = splinterm
 	makedepends = ttf-jetbrains-mono-nerd
 	makedepends = wayland
 	makedepends = xdg-terminal-exec
-	source = https://github.com/OldJobobo/splinterm/releases/download/v0.1.0-beta2/splinterm-0.1.0-beta2.tar.gz
+	source = https://github.com/OldJobobo/splinterm/releases/download/v0.1.0-beta3/splinterm-0.1.0-beta3.tar.gz
 	sha256sums = d59bf82a5e2218112613d4a69adb20ce2b6cd8c133cc9b14da8fbfa1de4d0644
 
 pkgname = splinterm
@@ -43,6 +43,6 @@ pkgname = splinterm
 
 pkgname = splinterm-mcp
 	pkgdesc = Policy-scoped MCP stdio adapter for Splinterm
-	depends = splinterm=0.1.0beta2-1
+	depends = splinterm=0.1.0beta3-1
 	depends = gcc-libs
 	depends = glibc

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -1,8 +1,8 @@
 # Maintainer: OldJobobo
 pkgbase=splinterm
 pkgname=('splinterm' 'splinterm-mcp')
-pkgver=0.1.0beta2
-_upstream_ver=0.1.0-beta2
+pkgver=0.1.0beta3
+_upstream_ver=0.1.0-beta3
 pkgrel=1
 arch=('x86_64')
 url='https://github.com/oldjobobo/splinterm'

--- a/packaging/aur/splinterm.install
+++ b/packaging/aur/splinterm.install
@@ -6,7 +6,9 @@ post_install() {
 }
 
 post_upgrade() {
-  echo 'Restart running user splinterd services after protocol upgrades; the launcher does this when ping negotiation fails.'
+  echo 'Beta 3 removes terminal workload TasksMax overrides; existing daemon and workload units keep their old policy until recreated.'
+  echo 'From an external terminal, stop splinterd.service, run systemctl --user daemon-reload, then start splinterd.service; stopping ends active Dojos.'
+  echo 'This package does not restart user services automatically.'
   echo 'Check Omarchy screensaver integration: splinterm integration omarchy-screensaver status'
 }
 

--- a/packaging/release-state.json
+++ b/packaging/release-state.json
@@ -1,4 +1,4 @@
 {
   "schema": 1,
-  "current_version_tag": "v0.1.0-beta1"
+  "current_version_tag": "v0.1.0-beta2"
 }

--- a/packaging/splinterm.install
+++ b/packaging/splinterm.install
@@ -6,7 +6,9 @@ post_install() {
 }
 
 post_upgrade() {
-  echo 'Restart running user splinterd services after protocol upgrades; the launcher does this when ping negotiation fails.'
+  echo 'Beta 3 removes terminal workload TasksMax overrides; existing daemon and workload units keep their old policy until recreated.'
+  echo 'From an external terminal, stop splinterd.service, run systemctl --user daemon-reload, then start splinterd.service; stopping ends active Dojos.'
+  echo 'This package does not restart user services automatically.'
   echo 'Check Omarchy screensaver integration: splinterm integration omarchy-screensaver status'
 }
 

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -5745,9 +5745,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/site/src/content/docs/docs/status.md
+++ b/site/src/content/docs/docs/status.md
@@ -5,9 +5,9 @@ description: What is implemented, validated, limited, planned, and unreleased in
 
 Splinterm is a **public beta**. Source, documentation, and immutable versioned GitHub and AUR packages are public. Substantial core behavior is implemented and validated, while the validated target remains narrow and stable compatibility guarantees have not been released.
 
-[`v0.1.0-beta1`](https://github.com/OldJobobo/splinterm/releases/tag/v0.1.0-beta1) is the current public prerelease. It adds wide-grid support through `480×128`, bounded sparse terminal publication frames, and active-tab contrast that remains independent from terminal selection colors, while retaining the accepted Alpha3 command, persistence, input, and Omarchy integration behavior.
+[`v0.1.0-beta2`](https://github.com/OldJobobo/splinterm/releases/tag/v0.1.0-beta2) is the current public prerelease. It adds configurable Window-owned terminal lifetimes, corrected startup font-family and glyph fallback resolution, and verified nested systemd workload isolation.
 
-Beta 2 candidate preparation is in progress. Its source tree adds configurable ordinary graphical lifetime, owner-only promotion when users organize tabs, and corrected startup font-family resolution. Complete non-graphical, clean-package, and isolated staged-package graphical validation has passed. Fresh review approved the complete implementation and bounded post-graphical naming fix with no blocker or fix worth doing now. No Beta 2 tag, package publication, AUR update, or installed-package acceptance is claimed yet.
+Beta 3 candidate preparation is in progress. It removes provisional per-workload task ceilings so terminal applications inherit the user manager's normal task policy while the daemon retains its independent guard. It also places the New Dojo control beside the final tab, separates inactive tabs with semantic dividers, and gives legacy unnamed Dojos a stable `Dojo 1` tab label. Focused tests pass; complete release validation, review, publication, installation, and AUR updates remain pending.
 
 ## What that means
 
@@ -37,7 +37,7 @@ Beta 2 candidate preparation is in progress. Its source tree adds configurable o
 | Sixel, practical Kitty static images, inline iTerm2 PNG | Documented supported subsets |
 | Arch/Omarchy package | Versioned GitHub release and AUR packages validated |
 | Public source and versioned builds | Available |
-| [AUR packages](https://aur.archlinux.org/packages/splinterm-bin) | Recommended prebuilt `splinterm-bin`; source-built `splinterm` also available, both `0.1.0beta1-1` |
+| [AUR packages](https://aur.archlinux.org/packages/splinterm-bin) | Recommended prebuilt `splinterm-bin`; source-built `splinterm` also available, both `0.1.0beta2-1` |
 | Stable support and broader compatibility | Not released |
 | Nix and broader distributions | Planned |
 

--- a/site/src/content/docs/docs/troubleshooting.md
+++ b/site/src/content/docs/docs/troubleshooting.md
@@ -40,7 +40,7 @@ systemctl --user show splinterd.service \
 journalctl --user-unit splinterd.service -n 50 --no-pager
 ```
 
-The packaged task ceiling protects the daemon from unbounded process creation, while `MemoryHigh` causes reclaim and throttling rather than imposing a hard memory ceiling. Terminal workloads run in a separate aggregate slice with nested per-Dojo and per-Splint boundaries, so they do not share the daemon's task or memory-pressure budget. `MemoryCurrent` includes charged page cache, some of which may be reclaimable under pressure.
+The packaged task ceiling protects the daemon control plane from unbounded process creation, while `MemoryHigh` causes reclaim and throttling rather than imposing a hard memory ceiling. Terminal workloads run in a separate aggregate slice with nested per-Dojo and per-Splint boundaries. Workload units do not set `TasksMax`; Splint scopes receive the systemd user manager's normal `DefaultTasksMax`, subject to stricter administrator or ancestor policy. `EffectiveTasksMax` is the authoritative runtime value. `MemoryCurrent` includes charged page cache, some of which may be reclaimable under pressure.
 
 After a daemon restart, inspect exited topology with `splinterm list --all`. Restoration is explicit because Splinterm never reruns saved commands automatically.
 
@@ -50,7 +50,10 @@ The packaged daemon fails closed when it cannot place a terminal helper in its e
 
 ```bash
 journalctl --user-unit splinterd.service -n 40 --no-pager
+systemctl --user show -p DefaultTasksMax
 systemctl --user status app-splinterm.slice
+systemctl --user show <splint.scope> \
+  -p TasksCurrent -p TasksMax -p EffectiveTasksMax
 systemd-cgls --user-unit app-splinterm.slice
 ```
 

--- a/tools/foot-oracle/provenance.json
+++ b/tools/foot-oracle/provenance.json
@@ -59,7 +59,7 @@
   "rust": {
     "rustc": "1.91.0",
     "cargo": "1.91.0",
-    "cargo_lock_sha256": "bce77695bdf0a5cff67dd892f1141f81c2420923faf15d3981de7beec1ea7fe6",
+    "cargo_lock_sha256": "c6f97db22c022a2283ef44022bf1f2e08f56aec7860b991860ae11cb4c4dec0f",
     "dependencies": {
       "fontdb": "0.23.0",
       "freetype-rs": "0.38.0",
@@ -112,7 +112,7 @@
     },
     "foreground": "ebebeb",
     "background": "0e1216",
-    "cargo_lock_sha256": "bce77695bdf0a5cff67dd892f1141f81c2420923faf15d3981de7beec1ea7fe6"
+    "cargo_lock_sha256": "c6f97db22c022a2283ef44022bf1f2e08f56aec7860b991860ae11cb4c4dec0f"
   },
   "semantic_fixture_schema": "fixtures/terminal/v1/schema.md",
   "final_buffer_schema": "tools/foot-oracle/final-buffer-schema.md",

--- a/tools/package/test_workload_units.py
+++ b/tools/package/test_workload_units.py
@@ -37,7 +37,6 @@ Description=Splinterm terminal workloads
 StopWhenUnneeded=yes
 
 [Slice]
-TasksMax=2048
 MemoryHigh=75%
 """
 
@@ -70,6 +69,17 @@ class WorkloadUnitPackageTests(unittest.TestCase):
             )
             with self.assertRaisesRegex(
                 AssertionError, "headless safety or resource settings"
+            ):
+                validate_package.validate_systemd_unit(root)
+
+    def test_workload_slice_rejects_explicit_task_ceiling(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = unit_root(
+                Path(directory),
+                workload_slice=WORKLOAD_SLICE + "TasksMax=2048\n",
+            )
+            with self.assertRaisesRegex(
+                AssertionError, "inherit the user manager task limit"
             ):
                 validate_package.validate_systemd_unit(root)
 

--- a/tools/package/validate-package.py
+++ b/tools/package/validate-package.py
@@ -229,13 +229,15 @@ def validate_systemd_unit(root: Path) -> None:
     required_slice = {
         "StopWhenUnneeded=yes",
         "[Slice]",
-        "TasksMax=2048",
         "MemoryHigh=75%",
     }
     missing_slice = required_slice - slice_lines
     assert not missing_slice, (
         "workload slice is missing aggregate guards: "
         f"{sorted(missing_slice)}"
+    )
+    assert not any(line.startswith("TasksMax=") for line in slice_lines), (
+        "workload units must inherit the user manager task limit"
     )
     assert not any(line.startswith("MemoryMax=") for line in slice_lines)
 

--- a/tools/release/test_prepare_candidate.py
+++ b/tools/release/test_prepare_candidate.py
@@ -150,30 +150,30 @@ class PrepareCandidateTests(unittest.TestCase):
                 "OldJobobo/splinterm",
                 commit,
                 "9.9.9-alpha9",
-                "v0.1.0-beta1",
+                "v0.1.0-beta2",
             )
 
     def test_previous_release_is_explicit_existing_and_distinct(self) -> None:
-        release_tag = "v9.9.9-beta2"
+        release_tag = "v9.9.9-beta3"
         with mock.patch.object(MODULE, "run", return_value="a" * 40):
             self.assertEqual(
-                MODULE.validate_previous_version_tag("v0.1.0-beta1", release_tag),
-                "v0.1.0-beta1",
+                MODULE.validate_previous_version_tag("v0.1.0-beta2", release_tag),
+                "v0.1.0-beta2",
             )
         with self.assertRaisesRegex(ValueError, "v-prefixed SemVer"):
-            MODULE.validate_previous_version_tag("0.1.0-beta1", release_tag)
+            MODULE.validate_previous_version_tag("0.1.0-beta2", release_tag)
         with self.assertRaisesRegex(ValueError, "must differ"):
             MODULE.validate_previous_version_tag(release_tag, release_tag)
         with self.assertRaisesRegex(ValueError, "current public release"):
-            MODULE.validate_previous_version_tag("v0.1.0-alpha3.3", release_tag)
+            MODULE.validate_previous_version_tag("v0.1.0-beta1", release_tag)
         with (
             mock.patch.object(MODULE, "run", side_effect=ValueError("missing tag")),
             self.assertRaisesRegex(ValueError, "missing tag"),
         ):
-            MODULE.validate_previous_version_tag("v0.1.0-beta1", release_tag)
+            MODULE.validate_previous_version_tag("v0.1.0-beta2", release_tag)
 
     def test_public_release_state_is_closed_and_versioned(self) -> None:
-        self.assertEqual(MODULE.current_public_release_tag(), "v0.1.0-beta1")
+        self.assertEqual(MODULE.current_public_release_tag(), "v0.1.0-beta2")
         state = json.loads(
             (ROOT / "packaging/release-state.json").read_text(encoding="utf-8")
         )
@@ -181,7 +181,7 @@ class PrepareCandidateTests(unittest.TestCase):
         self.assertEqual(state["schema"], 1)
         status = (ROOT / "docs/status.md").read_text(encoding="utf-8")
         self.assertEqual(
-            status.count("**Current public version tag:** `v0.1.0-beta1`"), 1
+            status.count("**Current public version tag:** `v0.1.0-beta2`"), 1
         )
 
     def test_release_notes_are_read_from_the_exact_candidate_commit(self) -> None:
@@ -193,7 +193,7 @@ class PrepareCandidateTests(unittest.TestCase):
                 output.read_text(encoding="utf-8"),
                 MODULE.run(["git", "show", f"{commit}:RELEASE_NOTES.md"]) + "\n",
             )
-            self.assertIn("Workload isolation", output.read_text(encoding="utf-8"))
+            self.assertIn("Room to Work", output.read_text(encoding="utf-8"))
 
     def test_manifest_example_is_json_serializable(self) -> None:
         manifest = {

--- a/tools/release/test_promote_release.py
+++ b/tools/release/test_promote_release.py
@@ -22,7 +22,7 @@ RUN_ID = 12345
 
 class CandidateFixture:
     def __init__(
-        self, root: Path, previous_version_tag: str = "v0.1.0-beta1"
+        self, root: Path, previous_version_tag: str = "v0.1.0-beta2"
     ) -> None:
         self.root = root
         self.assets = MODULE.expected_assets(COMMIT, VERSION)


### PR DESCRIPTION
## Summary

- inherit user-manager task limits for terminal workloads while preserving memory-pressure boundaries
- place the New Dojo control after the final visible tab and add semantic inactive-tab dividers
- present strict historical unnamed Dojos with friendly, collision-safe labels
- prepare the 0.1.0-beta3 release, package metadata, provenance, and upgrade lifecycle guidance
- update Nanoid to the patched 3.3.18 transitive release

## Validation

- focused tab and cgroup tests
- full workspace tests, serialized
- workspace Clippy with all targets/features and warnings denied
- package/release automation and systemd verification
- portable Foot provenance and release candidate checks
- clean committed-HEAD package build and extracted package validation
- site build/link validation and zero-vulnerability npm audit
- isolated tiled graphical client stress: smoke + 16 MiB + 64 MiB + 128 MiB ANSI bursts; no OOM/crash
- `git diff --check`

## Review

Independent review found three release blockers; all were fixed in `9829d5c`. Fresh focused follow-up review returned OK with no P0/P1/P2 findings.

## Residual risks

- host Foot provenance reports local fontconfig version drift; repository-owned portable provenance passes
- graphical stress did not reproduce the previously observed client-side failure
- package installation deliberately does not restart user services; release guidance requires explicit stop, daemon-reload, and start
