### PR TITLE
Prepare 0.1.0 RC1 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1400,9 +1400,10 @@ dependencies = [
 
 [[package]]
 name = "splinterd"
-version = "0.1.0-beta3"
+version = "0.1.0-rc.1"
 dependencies = [
  "anyhow",
+ "libc",
  "nix",
  "rustix",
  "serde",
@@ -1424,7 +1425,7 @@ dependencies = [
 
 [[package]]
 name = "splinterm"
-version = "0.1.0-beta3"
+version = "0.1.0-rc.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -1454,7 +1455,7 @@ dependencies = [
 
 [[package]]
 name = "splinterm-automation-client"
-version = "0.1.0-beta3"
+version = "0.1.0-rc.1"
 dependencies = [
  "anyhow",
  "rustix",
@@ -1470,7 +1471,7 @@ dependencies = [
 
 [[package]]
 name = "splinterm-core"
-version = "0.1.0-beta3"
+version = "0.1.0-rc.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -1480,7 +1481,7 @@ dependencies = [
 
 [[package]]
 name = "splinterm-filemap"
-version = "0.1.0-beta3"
+version = "0.1.0-rc.1"
 dependencies = [
  "memmap2",
  "rustix",
@@ -1488,16 +1489,17 @@ dependencies = [
 
 [[package]]
 name = "splinterm-freetype"
-version = "0.1.0-beta3"
+version = "0.1.0-rc.1"
 dependencies = [
  "freetype-rs",
+ "splinterm-filemap",
  "splinterm-pixman",
  "thiserror",
 ]
 
 [[package]]
 name = "splinterm-graphical-relay"
-version = "0.1.0-beta3"
+version = "0.1.0-rc.1"
 dependencies = [
  "anyhow",
  "tokio",
@@ -1506,7 +1508,7 @@ dependencies = [
 
 [[package]]
 name = "splinterm-mcp"
-version = "0.1.0-beta3"
+version = "0.1.0-rc.1"
 dependencies = [
  "anyhow",
  "rmcp",
@@ -1521,7 +1523,7 @@ dependencies = [
 
 [[package]]
 name = "splinterm-pixman"
-version = "0.1.0-beta3"
+version = "0.1.0-rc.1"
 dependencies = [
  "libc",
  "pixman-sys",
@@ -1530,7 +1532,7 @@ dependencies = [
 
 [[package]]
 name = "splinterm-protocol"
-version = "0.1.0-beta3"
+version = "0.1.0-rc.1"
 dependencies = [
  "base64",
  "rustix",
@@ -1543,7 +1545,7 @@ dependencies = [
 
 [[package]]
 name = "splinterm-pty"
-version = "0.1.0-beta3"
+version = "0.1.0-rc.1"
 dependencies = [
  "rustix",
  "thiserror",
@@ -1552,7 +1554,7 @@ dependencies = [
 
 [[package]]
 name = "splinterm-relay"
-version = "0.1.0-beta3"
+version = "0.1.0-rc.1"
 dependencies = [
  "anyhow",
  "nix",
@@ -1564,7 +1566,7 @@ dependencies = [
 
 [[package]]
 name = "splinterm-terminal"
-version = "0.1.0-beta3"
+version = "0.1.0-rc.1"
 dependencies = [
  "base64",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.1.0-beta3"
+version = "0.1.0-rc.1"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ Authoritative references:
 
 Splinterm uses `${XDG_CONFIG_HOME:-~/.config}/splinterm/config.ini` for its focused configuration surface. It supports fonts and sizing, shell behavior, scrollback, cursor settings, pane chrome, keymap overlays, and explicit theme overrides.
 
-On Omarchy, Splinterm can read the active theme's effective `foot.ini` and `colors.toml` directly and safely reload valid palette changes without restarting the daemon or shell.
+On Omarchy, Splinterm reads the active theme's effective `foot.ini` and `colors.toml` and safely reloads valid palette changes without restarting the daemon or shell. When `main.font` is unset, graphical clients also follow fontconfig's effective `monospace` family live; explicit font patterns remain user-owned, and invalid live generations retain the last valid font without restarting the Window or its processes.
 
 See the [configuration guide](https://splinterm.com/docs/configure/configuration/) for supported keys, keymap inspection, Omarchy integration, and Foot migration.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -19,9 +19,11 @@ family.
 
 Font changes preserve configured size and sizing policy, padding, DPI, runtime
 zoom, topology, focus, history, modal and IME state, and controller authority.
-Observer panes never acquire control solely to resize after a font change.
+Observer panes never acquire control solely to resize after a font change, and
+deferred font-driven resizes retry after transient command-queue backpressure.
 Fontconfig named instances in variable fonts are preserved through shaping,
-metrics, and rasterization.
+metrics, and rasterization. Ambient Fontconfig checks run at a bounded ten-second
+cadence.
 
 ## Yazi uses bounded Sixel previews
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,65 +1,92 @@
-# Splinterm 0.1.0 Beta 3 — Room to Work
+# Splinterm 0.1.0 RC1 — Stable Ground
 
-Beta 3 removes task ceilings that were too small for ordinary applications,
-polishes the Dojo tab strip, and gives legacy unnamed Dojos a stable readable
-label.
+This is the first release candidate for Splinterm 0.1.0. It freezes the 0.1
+feature line for stabilization and carries the complete public Beta 3 baseline
+plus bounded fixes for Omarchy environment refresh, live font following, Yazi
+image previews, and legacy Dojo restore names.
 
-## Workloads inherit the user manager's task policy
+RC1 is intended for normal daily use and soak testing on the documented target:
+x86_64 Omarchy/Arch Linux with native Wayland under Hyprland. A code change after
+RC1 requires another release candidate before the final `v0.1.0` release.
 
-Beta 2 introduced the correct nested systemd hierarchy but shipped provisional
-fixed ceilings of 512 tasks per Splint, 1024 per Dojo, and 2048 across all
-terminal workloads. Because Linux counts both processes and threads, ordinary
-Chromium, Node, editor, build, and coding-agent workloads can reach those limits.
-Rejected task creation may then appear as an application failure even though the
-workload is not runaway.
+## Live Omarchy font following
 
-Beta 3 keeps the containment hierarchy and exact pre-exec PTY placement:
+When `main.font` is unset, a valid change to Fontconfig's effective `monospace`
+family now replaces one complete immutable renderer generation without
+restarting the Window, daemon, shell, or applications. Explicit font patterns
+remain authoritative, and an invalid live generation retains the last valid
+family.
+
+Font changes preserve configured size and sizing policy, padding, DPI, runtime
+zoom, topology, focus, history, modal and IME state, and controller authority.
+Observer panes never acquire control solely to resize after a font change.
+Fontconfig named instances in variable fonts are preserved through shaping,
+metrics, and rasterization.
+
+## Yazi uses bounded Sixel previews
+
+When Sixel is enabled, Splinterm now advertises primary device attribute `4`.
+Yazi therefore selects its Sixel image path instead of the incompatible legacy
+per-cell Kitty placement path. The capability remains conditional, and the
+existing image-content and 256-placement bounds are unchanged.
+
+## Legacy Dojo names normalize on restore
+
+Loading schema-v2, schema-v3, or schema-v4 metadata now replaces only the exact
+historical generated forms `terminal`, `terminal-<timestamp>`, and
+`terminal-<timestamp>-<pid>` with collision-free `Dojo N` names. Numeric fields
+may be zero-padded, matching names emitted by older builds. Explicit names in
+current schema metadata are preserved.
+
+## New Splints follow the current Gum palette
+
+`splinterd` is persistent, so environment variables inherited when the daemon
+started can outlive an Omarchy theme change. Before RC1, a newly created shell
+could therefore receive stale Gum colors even though Splinterm's graphical
+palette already reflected the active theme.
+
+For every new Splint, the daemon now reads the active rendered palette from:
 
 ```text
-splinterd.service
-app-splinterm.slice
-└── app-splinterm-dojo<ID>.slice
-    └── splinterm-splint<ID>-<incarnation>.scope
+${XDG_STATE_HOME:-$HOME/.local/state}/omarchy/current/theme/gum_env.lua
 ```
 
-The corrected policy is:
+It refreshes only Omarchy's bounded Gum environment namespace:
 
-- `splinterd.service` retains `TasksMax=2048` for the small control plane;
-- the aggregate workload slice does not set `TasksMax`;
-- transient Dojo slices do not set `TasksMax`; and
-- transient Splint scopes do not set `TasksMax`.
+- `GUM_*`;
+- `FOREGROUND` and `BACKGROUND`; and
+- `BORDER_FOREGROUND` and `BORDER_BACKGROUND`.
 
-Terminal workloads therefore inherit the systemd user manager's
-`DefaultTasksMax`, subject to any stricter administrator or ancestor policy.
-`EffectiveTasksMax` is the authoritative runtime value. The existing
-`MemoryHigh` pressure boundaries remain 75% aggregate, 50% per Dojo, and 25%
-per Splint; Beta 3 still sets no `MemoryMax`.
+A complete valid palette replaces current managed values and removes obsolete
+managed `GUM_*` entries. Unrelated environment variables remain untouched.
+Existing PTYs keep the environment with which they were created; only later
+Splints see a later valid theme.
 
-## Clearer Dojo tabs
+Missing, malformed, oversized, symlinked, or non-regular palette state fails
+closed. In those cases the new PTY preserves the daemon's inherited environment
+rather than receiving a partial palette.
 
-The New Dojo `+` control now sits immediately after the final visible tab instead
-of being pinned to the far-right edge of the Window. When the strip is full, the
-existing bounded active-tab visibility and hit targets remain unchanged.
+## Stabilized Beta 3 baseline
 
-Inactive tabs now use the theme's semantic pane-border color for a narrow exact
-divider. The active tab retains its exact theme-provided body, contrasting
-foreground, and accent underline.
+RC1 retains the Beta 3 workload and interface corrections:
 
-Older persisted unnamed Lairs may still carry historical generated identities
-such as `terminal-1787899189-4132`. Reopening one from the Dojo picker now
-presents its initial tab as `Dojo 1`. This is a presentation-only compatibility
-rule: explicit Dojo names remain unchanged and daemon-owned topology is not
-renamed.
+- terminal workloads inherit the systemd user manager's task policy while
+  `splinterd.service` keeps its independent `TasksMax=2048` guard;
+- the New Dojo control sits after the final visible tab;
+- inactive tabs use semantic dividers; and
+- the strict historical unnamed initial Dojo form is presented as `Dojo 1`
+  without mutating daemon-owned topology.
+
+Persistent topology, explicit restore, scrollback and search, terminal images,
+remote graphical access, JSON/NDJSON automation, MCP, configurable terminal
+lifetime, presets, and the documented native Wayland path remain part of the
+0.1 baseline.
 
 ## Upgrade boundary
 
-The corrected task policy applies when the daemon and transient workload
-hierarchy are recreated. Existing Beta 2 scopes retain their old explicit limits
-until then.
-
-Splinterm 0.1 does not support live daemon upgrade handoff. Upgrading Beta 2 to
-Beta 3 therefore ends active Dojos. From Foot or another terminal not owned by
-`splinterd`, use this lifecycle around the package upgrade:
+Splinterm 0.1 does not support live daemon upgrade handoff. Upgrading Beta 3 to
+RC1 therefore ends active Dojos. Run the upgrade from Foot or another terminal
+that is not owned by `splinterd`:
 
 ```bash
 systemctl --user stop splinterd.service
@@ -71,13 +98,16 @@ systemctl --user start splinterd.service
 Then reopen Splinterm Windows. Package installation does not silently reload or
 restart the user service.
 
-## Compatibility
+## RC1 soak focus
 
-- Persistent topology, restore, history, remote, automation, MCP, preset, and
-  terminal protocol contracts are unchanged.
-- Exact cgroup placement and workload cleanup remain mandatory in packaged mode.
-- Explicit Dojo names remain authoritative; only the strict historical pair of
-  initial Dojo `terminal` under Lair `terminal-<epoch-seconds>-<pid>` is
-  presented as unnamed.
-- Beta 2 tags and packages remain immutable.
-- Beta 3 continues to target x86_64 Omarchy/Arch Linux with native Wayland.
+During the release-candidate soak, please pay particular attention to:
+
+- repeated Omarchy theme changes followed by newly created Splints;
+- existing PTYs retaining their original environment;
+- clean installation and Beta 3 upgrade/rollback;
+- saved-Lair restore and ordinary long-running terminal workloads;
+- trusted graphical-client identity and desktop launching; and
+- optional MCP package behavior when installed.
+
+RC1 remains a prerelease. If stabilization requires any code change, the next
+public build will be RC2 rather than the final `v0.1.0` release.

--- a/config/splinterm/config.ini
+++ b/config/splinterm/config.ini
@@ -1,8 +1,9 @@
 # Splinterm Phase 8 supported configuration subset.
 # Install as ${XDG_CONFIG_HOME:-~/.config}/splinterm/config.ini.
 [main]
-# Uses Omarchy's effective Fontconfig monospace family by default.
-# font=monospace:style=Regular
+# Leave font unset to follow Omarchy's effective Fontconfig monospace family.
+# Setting font makes that pattern explicitly authoritative for this client.
+# font=JetBrains Mono Nerd Font:style=Regular
 font-pixelsize=14
 font-sizing-policy=output-scale
 padding-left=12

--- a/crates/splinterd/Cargo.toml
+++ b/crates/splinterd/Cargo.toml
@@ -9,6 +9,7 @@ repository.workspace = true
 
 [dependencies]
 anyhow.workspace = true
+libc.workspace = true
 nix.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/splinterd/src/main.rs
+++ b/crates/splinterd/src/main.rs
@@ -1,6 +1,7 @@
 mod audit;
 mod cgroup;
 mod consent;
+mod omarchy_environment;
 mod persistence;
 
 use std::{
@@ -2486,6 +2487,7 @@ async fn spawn_runtime_with_size(
     .env("SPLINTERM_LAIR_ID", context.lair.to_string())
     .env("SPLINTERM_DOJO_ID", context.dojo.to_string())
     .env("SPLINTERM_SPLINT_ID", context.splint.to_string());
+    let pty_command = omarchy_environment::refresh_gum_environment(pty_command).await;
     let mut config = LiveSplintConfig::default();
     #[cfg(debug_assertions)]
     if let Some(grace) = debug_test_shutdown_grace(env::var_os("SPLINTERM_TEST_SHUTDOWN_GRACE_MS"))

--- a/crates/splinterd/src/omarchy_environment.rs
+++ b/crates/splinterd/src/omarchy_environment.rs
@@ -1,0 +1,281 @@
+use std::{
+    collections::BTreeMap,
+    env,
+    ffi::OsString,
+    fs,
+    io::Read,
+    os::unix::fs::OpenOptionsExt,
+    path::{Path, PathBuf},
+};
+
+use anyhow::{Context, Result, bail};
+use splinterm_pty::PtyCommand;
+use tracing::debug;
+
+const MAX_GUM_ENVIRONMENT_BYTES: u64 = 64 * 1024;
+const GENERIC_GUM_VARIABLES: [&str; 4] = [
+    "FOREGROUND",
+    "BACKGROUND",
+    "BORDER_FOREGROUND",
+    "BORDER_BACKGROUND",
+];
+
+pub(crate) async fn refresh_gum_environment(mut command: PtyCommand) -> PtyCommand {
+    let path = default_gum_environment_path();
+    let diagnostic_path = path.clone();
+    let inherited_names = env::vars_os().map(|(name, _)| name).collect::<Vec<_>>();
+    let updates =
+        tokio::task::spawn_blocking(move || gum_environment_updates(&path, inherited_names)).await;
+    let updates = match updates {
+        Ok(Ok(updates)) => updates,
+        Ok(Err(error)) => {
+            debug!(%error, path = %diagnostic_path.display(), "active Omarchy Gum environment unavailable; preserving daemon environment");
+            return command;
+        }
+        Err(error) => {
+            debug!(%error, path = %diagnostic_path.display(), "Omarchy Gum environment task failed; preserving daemon environment");
+            return command;
+        }
+    };
+
+    for (name, value) in updates {
+        command = if let Some(value) = value {
+            command.env(name, value)
+        } else {
+            command.env_remove(name)
+        };
+    }
+    command
+}
+
+fn default_gum_environment_path() -> PathBuf {
+    gum_environment_path(env::var_os("XDG_STATE_HOME"), env::var_os("HOME"))
+}
+
+fn gum_environment_path(xdg_state_home: Option<OsString>, home: Option<OsString>) -> PathBuf {
+    xdg_state_home
+        .filter(|value| !value.is_empty())
+        .map_or_else(
+            || {
+                home.filter(|value| !value.is_empty())
+                    .map_or_else(|| PathBuf::from("."), PathBuf::from)
+                    .join(".local/state")
+            },
+            PathBuf::from,
+        )
+        .join("omarchy/current/theme/gum_env.lua")
+}
+
+fn gum_environment_updates(
+    path: &Path,
+    inherited_names: impl IntoIterator<Item = OsString>,
+) -> Result<BTreeMap<OsString, Option<OsString>>> {
+    let raw = read_bounded_regular_file(path)?;
+    let palette = parse_gum_environment(&raw)?;
+    let mut updates = inherited_names
+        .into_iter()
+        .filter(|name| is_managed_gum_variable(name.to_string_lossy().as_ref()))
+        .map(|name| (name, None))
+        .collect::<BTreeMap<_, _>>();
+    updates.extend(
+        palette
+            .into_iter()
+            .map(|(name, value)| (OsString::from(name), Some(OsString::from(value)))),
+    );
+    Ok(updates)
+}
+
+fn read_bounded_regular_file(path: &Path) -> Result<String> {
+    let file = fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_CLOEXEC | libc::O_NONBLOCK | libc::O_NOFOLLOW)
+        .open(path)
+        .with_context(|| format!("open {}", path.display()))?;
+    let metadata = file
+        .metadata()
+        .with_context(|| format!("inspect {}", path.display()))?;
+    if !metadata.file_type().is_file() {
+        bail!("active Omarchy Gum environment is not a regular file");
+    }
+    if metadata.len() > MAX_GUM_ENVIRONMENT_BYTES {
+        bail!("active Omarchy Gum environment exceeds the byte limit");
+    }
+
+    let mut raw = String::new();
+    file.take(MAX_GUM_ENVIRONMENT_BYTES + 1)
+        .read_to_string(&mut raw)
+        .with_context(|| format!("read {}", path.display()))?;
+    if u64::try_from(raw.len()).unwrap_or(u64::MAX) > MAX_GUM_ENVIRONMENT_BYTES {
+        bail!("active Omarchy Gum environment exceeds the byte limit");
+    }
+    Ok(raw)
+}
+
+fn parse_gum_environment(raw: &str) -> Result<BTreeMap<String, String>> {
+    let mut palette = BTreeMap::new();
+    for (line_number, raw_line) in raw.lines().enumerate() {
+        let line = raw_line.trim();
+        let Some(arguments) = line.strip_prefix("hl.env(") else {
+            continue;
+        };
+        let arguments = arguments
+            .strip_suffix(')')
+            .with_context(|| format!("invalid hl.env call on line {}", line_number + 1))?;
+        let (name, value) = arguments
+            .split_once(',')
+            .with_context(|| format!("invalid hl.env call on line {}", line_number + 1))?;
+        let name = quoted_literal(name.trim())
+            .with_context(|| format!("invalid environment name on line {}", line_number + 1))?;
+        let value = quoted_literal(value.trim())
+            .with_context(|| format!("invalid environment value on line {}", line_number + 1))?;
+        if !is_managed_gum_variable(name) {
+            continue;
+        }
+        if !is_hex_color(value) {
+            bail!("invalid Gum color on line {}", line_number + 1);
+        }
+        if palette.insert(name.to_owned(), value.to_owned()).is_some() {
+            bail!("duplicate Gum variable {name}");
+        }
+    }
+
+    for name in GENERIC_GUM_VARIABLES {
+        if !palette.contains_key(name) {
+            bail!("active Omarchy Gum environment is missing {name}");
+        }
+    }
+    if !palette.keys().any(|name| name.starts_with("GUM_")) {
+        bail!("active Omarchy Gum environment has no GUM_* variables");
+    }
+    Ok(palette)
+}
+
+fn quoted_literal(value: &str) -> Option<&str> {
+    let value = value.strip_prefix('"')?.strip_suffix('"')?;
+    (!value.contains(['"', '\\'])).then_some(value)
+}
+
+fn is_managed_gum_variable(name: &str) -> bool {
+    GENERIC_GUM_VARIABLES.contains(&name)
+        || name.strip_prefix("GUM_").is_some_and(|suffix| {
+            !suffix.is_empty()
+                && suffix
+                    .bytes()
+                    .all(|byte| byte.is_ascii_uppercase() || byte.is_ascii_digit() || byte == b'_')
+        })
+}
+
+fn is_hex_color(value: &str) -> bool {
+    matches!(value.len(), 7 | 9)
+        && value.starts_with('#')
+        && value[1..].bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn write_palette(contents: &str) -> PathBuf {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let path = env::temp_dir().join(format!(
+            "splinterd-gum-environment-{}-{nonce}.lua",
+            std::process::id()
+        ));
+        fs::write(&path, contents).unwrap();
+        path
+    }
+
+    const PALETTE: &str = r##"
+-- unrelated Lua is ignored
+hl.env("FOREGROUND", "#afaaa2")
+hl.env("BACKGROUND", "#0c1928")
+hl.env("BORDER_FOREGROUND", "#d4bda2")
+hl.env("BORDER_BACKGROUND", "#0c1928")
+hl.env("GUM_CHOOSE_SELECTED_BACKGROUND", "#d4bda2")
+hl.env("NOT_SPLINTERM_OWNED", "#ffffff")
+"##;
+
+    #[test]
+    fn empty_xdg_state_home_uses_the_home_fallback() {
+        let expected = PathBuf::from("/home/test/.local/state/omarchy/current/theme/gum_env.lua");
+        assert_eq!(
+            gum_environment_path(Some(OsString::new()), Some(OsString::from("/home/test"))),
+            expected
+        );
+        assert_eq!(
+            gum_environment_path(None, Some(OsString::from("/home/test"))),
+            expected
+        );
+    }
+
+    #[test]
+    fn oversized_palette_is_rejected_before_parsing() {
+        let oversized_length = usize::try_from(MAX_GUM_ENVIRONMENT_BYTES).unwrap() + 1;
+        let path = write_palette(&"x".repeat(oversized_length));
+        assert!(read_bounded_regular_file(&path).is_err());
+        fs::remove_file(path).unwrap();
+    }
+
+    #[test]
+    fn current_palette_replaces_stale_managed_values_only() {
+        let path = write_palette(PALETTE);
+        let updates = gum_environment_updates(
+            &path,
+            [
+                OsString::from("GUM_OLD_THEME_ONLY"),
+                OsString::from("BACKGROUND"),
+                OsString::from("UNRELATED"),
+            ],
+        )
+        .unwrap();
+        fs::remove_file(path).unwrap();
+
+        assert_eq!(
+            updates.get(&OsString::from("GUM_OLD_THEME_ONLY")),
+            Some(&None)
+        );
+        assert_eq!(
+            updates.get(&OsString::from("BACKGROUND")),
+            Some(&Some(OsString::from("#0c1928")))
+        );
+        assert_eq!(
+            updates.get(&OsString::from("GUM_CHOOSE_SELECTED_BACKGROUND")),
+            Some(&Some(OsString::from("#d4bda2")))
+        );
+        assert!(!updates.contains_key(&OsString::from("UNRELATED")));
+        assert!(!updates.contains_key(&OsString::from("NOT_SPLINTERM_OWNED")));
+    }
+
+    #[test]
+    fn malformed_or_incomplete_palette_is_rejected() {
+        assert!(parse_gum_environment("hl.env(\"BACKGROUND\", \"old\")").is_err());
+        assert!(
+            parse_gum_environment(
+                "hl.env(\"FOREGROUND\", \"#ffffff\")\n\
+                 hl.env(\"BACKGROUND\", \"#000000\")\n\
+                 hl.env(\"BORDER_FOREGROUND\", \"#ffffff\")\n\
+                 hl.env(\"BORDER_BACKGROUND\", \"#000000\")"
+            )
+            .is_err()
+        );
+        assert!(
+            parse_gum_environment(&format!(
+                "{PALETTE}\nhl.env(\"GUM_FILTER_INDICATOR\", \"#ffffff\""
+            ))
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn managed_namespace_is_bounded() {
+        assert!(is_managed_gum_variable("FOREGROUND"));
+        assert!(is_managed_gum_variable("GUM_FILTER_SELECTED_BACKGROUND"));
+        assert!(!is_managed_gum_variable("GUM_"));
+        assert!(!is_managed_gum_variable("GUM_bad"));
+        assert!(!is_managed_gum_variable("PATH"));
+    }
+}

--- a/crates/splinterd/src/persistence.rs
+++ b/crates/splinterd/src/persistence.rs
@@ -79,8 +79,8 @@ impl MetadataStore {
         }
 
         // Schema-v2 installations used lair.json. Decode through the core's
-        // strict legacy DTO, commit canonical schema-v3 state, and retain the
-        // legacy file so a failed migration can never destroy the only copy.
+        // strict legacy DTO, commit canonical current-schema state, and retain
+        // the legacy file so a failed migration can never destroy the only copy.
         for legacy in [&self.legacy_primary, &self.legacy_backup] {
             match Self::read_if_present(legacy) {
                 Ok(Some(document)) => {
@@ -292,6 +292,39 @@ mod tests {
             0o700
         );
         assert_eq!(fs::metadata(&store.primary).unwrap().mode() & 0o777, 0o600);
+        fs::remove_dir_all(base).unwrap();
+    }
+
+    #[test]
+    fn schema_v4_primary_normalizes_generated_dojo_names_on_load() {
+        let base = test_base("schema-v4-generated-dojo-name");
+        let store = MetadataStore::from_base(&base);
+        store.prepare_directory().unwrap();
+        let legacy = serde_json::json!({
+            "schema_version": 4,
+            "revision": 7,
+            "lairs": [{
+                "id": "018f4d8c-2a18-4b31-8c2f-9e7c5de77101",
+                "name": "main",
+                "dojos": [{
+                    "id": "018f4d8c-2a18-4b31-8c2f-9e7c5de77102",
+                    "name": "terminal-123456789",
+                    "default_focus": "018f4d8c-2a18-4b31-8c2f-9e7c5de77103",
+                    "root": {"Leaf": {
+                        "id": "018f4d8c-2a18-4b31-8c2f-9e7c5de77103",
+                        "title": "shell",
+                        "cwd": "/tmp",
+                        "command": [],
+                        "state": {"Exited": 0}
+                    }}
+                }]
+            }]
+        });
+        fs::write(&store.primary, serde_json::to_vec(&legacy).unwrap()).unwrap();
+        fs::set_permissions(&store.primary, fs::Permissions::from_mode(0o600)).unwrap();
+
+        let topology = store.load().unwrap().unwrap().into_topology().unwrap();
+        assert_eq!(topology.lairs().next().unwrap().dojos[0].name, "Dojo 1");
         fs::remove_dir_all(base).unwrap();
     }
 

--- a/crates/splinterd/tests/end_to_end.rs
+++ b/crates/splinterd/tests/end_to_end.rs
@@ -51,6 +51,22 @@ impl Daemon {
         policy: Option<&Path>,
         development_terminal_access: bool,
     ) -> Child {
+        Self::spawn_configured_with_environment(
+            runtime,
+            socket,
+            policy,
+            development_terminal_access,
+            &[],
+        )
+    }
+
+    fn spawn_configured_with_environment(
+        runtime: &Path,
+        socket: &Path,
+        policy: Option<&Path>,
+        development_terminal_access: bool,
+        environment: &[(&str, &str)],
+    ) -> Child {
         let stderr = fs::OpenOptions::new()
             .create(true)
             .append(true)
@@ -76,6 +92,7 @@ impl Daemon {
             )
             .env_remove("DISPLAY")
             .env_remove("WAYLAND_DISPLAY")
+            .envs(environment.iter().copied())
             .stdin(Stdio::null())
             .stdout(Stdio::null())
             .stderr(stderr);
@@ -120,6 +137,40 @@ impl Daemon {
         fs::create_dir(&runtime).unwrap();
         let socket = runtime.join("splinterd.sock");
         let child = Self::spawn_child(&runtime, &socket);
+        Self::wait_until_ready(&socket).await;
+        Self {
+            child,
+            runtime,
+            socket,
+            policy: None,
+            development_terminal_access: true,
+        }
+    }
+
+    async fn start_with_gum_environment(palette: &str) -> Self {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let runtime = std::env::temp_dir().join(format!(
+            "splinterm-gum-environment-{}-{nonce}",
+            std::process::id()
+        ));
+        let theme = runtime.join("state/omarchy/current/theme");
+        fs::create_dir_all(&theme).unwrap();
+        fs::write(theme.join("gum_env.lua"), palette).unwrap();
+        let socket = runtime.join("splinterd.sock");
+        let child = Self::spawn_configured_with_environment(
+            &runtime,
+            &socket,
+            None,
+            true,
+            &[
+                ("BACKGROUND", "#1b1b1b"),
+                ("GUM_CHOOSE_SELECTED_BACKGROUND", "#808080"),
+                ("GUM_OLD_THEME_ONLY", "#f4f4f4"),
+            ],
+        );
         Self::wait_until_ready(&socket).await;
         Self {
             child,
@@ -2490,6 +2541,173 @@ async fn shutdown_reaps_signal_resistant_child_and_removes_socket() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 #[allow(
     clippy::too_many_lines,
+    reason = "one lifecycle scenario compares existing and post-theme-change PTY environments"
+)]
+async fn new_splint_refreshes_the_active_omarchy_gum_environment() {
+    time::timeout(TEST_TIMEOUT, async {
+        let old_palette = r##"
+hl.env("FOREGROUND", "#f4f4f4")
+hl.env("BACKGROUND", "#1b1b1b")
+hl.env("BORDER_FOREGROUND", "#808080")
+hl.env("BORDER_BACKGROUND", "#1b1b1b")
+hl.env("GUM_CHOOSE_SELECTED_BACKGROUND", "#808080")
+hl.env("GUM_OLD_THEME_ONLY", "#f4f4f4")
+"##;
+        let current_palette = r##"
+hl.env("FOREGROUND", "#afaaa2")
+hl.env("BACKGROUND", "#0c1928")
+hl.env("BORDER_FOREGROUND", "#d4bda2")
+hl.env("BORDER_BACKGROUND", "#0c1928")
+hl.env("GUM_CHOOSE_SELECTED_BACKGROUND", "#d4bda2")
+"##;
+        let daemon = Daemon::start_with_gum_environment(old_palette).await;
+        let existing_ready = daemon.runtime.join("existing-gum-ready");
+        let existing_trigger = daemon.runtime.join("existing-gum-trigger");
+        let existing_marker = daemon.runtime.join("existing-gum-environment");
+        let refreshed_marker = daemon.runtime.join("refreshed-gum-environment");
+        let malformed_marker = daemon.runtime.join("malformed-gum-environment");
+        let mut connection = daemon.connect().await;
+        let Response::LairCreated { .. } = connection
+            .request(Request::CreateLair {
+                expected_topology_revision: TopologyRevision::default(),
+                name: "old-gum-environment".into(),
+                launch: LaunchParameters {
+                    cwd: std::env::current_dir().unwrap(),
+                    command: vec![
+                        "/bin/sh".into(),
+                        "-c".into(),
+                        format!(
+                            "touch {}; while [ ! -e {} ]; do sleep 0.01; done; printf '%s|%s|%s' \"$BACKGROUND\" \"$GUM_CHOOSE_SELECTED_BACKGROUND\" \"${{GUM_OLD_THEME_ONLY-unset}}\" > {}",
+                            existing_ready.display(),
+                            existing_trigger.display(),
+                            existing_marker.display()
+                        ),
+                    ],
+                    shell: None,
+                    login_shell: false,
+                    scrollback_lines: 100,
+                },
+            })
+            .await
+        else {
+            panic!("existing Gum environment test Lair was not created");
+        };
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while !existing_ready.exists() {
+            assert!(
+                Instant::now() < deadline,
+                "existing Gum environment did not become ready"
+            );
+            time::sleep(Duration::from_millis(10)).await;
+        }
+
+        let theme = daemon.runtime.join("state/omarchy/current/theme");
+        let replacement = theme.join("gum_env.lua.next");
+        fs::write(&replacement, current_palette).unwrap();
+        fs::rename(replacement, theme.join("gum_env.lua")).unwrap();
+        let revision = connection.topology_revision().await;
+        let Response::LairCreated { .. } = connection
+            .request(Request::CreateLair {
+                expected_topology_revision: revision,
+                name: "current-gum-environment".into(),
+                launch: LaunchParameters {
+                    cwd: std::env::current_dir().unwrap(),
+                    command: vec![
+                        "/bin/sh".into(),
+                        "-c".into(),
+                        format!(
+                            "printf '%s|%s|%s' \"$BACKGROUND\" \"$GUM_CHOOSE_SELECTED_BACKGROUND\" \"${{GUM_OLD_THEME_ONLY-unset}}\" > {}",
+                            refreshed_marker.display()
+                        ),
+                    ],
+                    shell: None,
+                    login_shell: false,
+                    scrollback_lines: 100,
+                },
+            })
+            .await
+        else {
+            panic!("refreshed Gum environment test Lair was not created");
+        };
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while !refreshed_marker.exists() {
+            assert!(
+                Instant::now() < deadline,
+                "refreshed Gum environment marker timed out"
+            );
+            time::sleep(Duration::from_millis(10)).await;
+        }
+
+        let malformed = format!(
+            "{current_palette}\nhl.env(\"GUM_FILTER_INDICATOR\", \"#ffffff\""
+        );
+        let replacement = theme.join("gum_env.lua.next");
+        fs::write(&replacement, malformed).unwrap();
+        fs::rename(replacement, theme.join("gum_env.lua")).unwrap();
+        let revision = connection.topology_revision().await;
+        let Response::LairCreated { .. } = connection
+            .request(Request::CreateLair {
+                expected_topology_revision: revision,
+                name: "malformed-gum-environment".into(),
+                launch: LaunchParameters {
+                    cwd: std::env::current_dir().unwrap(),
+                    command: vec![
+                        "/bin/sh".into(),
+                        "-c".into(),
+                        format!(
+                            "printf '%s|%s|%s' \"$BACKGROUND\" \"$GUM_CHOOSE_SELECTED_BACKGROUND\" \"${{GUM_OLD_THEME_ONLY-unset}}\" > {}",
+                            malformed_marker.display()
+                        ),
+                    ],
+                    shell: None,
+                    login_shell: false,
+                    scrollback_lines: 100,
+                },
+            })
+            .await
+        else {
+            panic!("malformed Gum environment test Lair was not created");
+        };
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while !malformed_marker.exists() {
+            assert!(
+                Instant::now() < deadline,
+                "malformed Gum environment marker timed out"
+            );
+            time::sleep(Duration::from_millis(10)).await;
+        }
+
+        fs::write(existing_trigger, b"ready").unwrap();
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while !existing_marker.exists() {
+            assert!(
+                Instant::now() < deadline,
+                "existing Gum environment marker timed out"
+            );
+            time::sleep(Duration::from_millis(10)).await;
+        }
+
+        assert_eq!(
+            fs::read_to_string(refreshed_marker).unwrap(),
+            "#0c1928|#d4bda2|unset"
+        );
+        assert_eq!(
+            fs::read_to_string(existing_marker).unwrap(),
+            "#1b1b1b|#808080|#f4f4f4"
+        );
+        assert_eq!(
+            fs::read_to_string(malformed_marker).unwrap(),
+            "#1b1b1b|#808080|#f4f4f4"
+        );
+        daemon.shutdown();
+    })
+    .await
+    .expect("Gum environment integration timed out");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[allow(
+    clippy::too_many_lines,
     reason = "one lifecycle scenario correlates create, restore, and new-Dojo context"
 )]
 async fn new_dojo_and_restore_inject_exact_current_context() {
@@ -3878,10 +4096,18 @@ async fn phase8_detach_reattach_overflow_resync_and_cleanup() {
             .await
             .expect("drained subscriber did not observe the overflow marker")
             .expect("drained subscriber task failed");
+        let _pre_pressure_snapshot = stable_snapshot_after_marker(
+            &mut reattached,
+            splint_id,
+            incarnation,
+            "overflow-finished",
+        )
+        .await;
 
         // The actively drained client has exited. Create a fresh unread
-        // MAX_SUBSCRIPTIONS connection so only the following unpaced pressure
-        // stream can force its resynchronization or disconnection.
+        // MAX_SUBSCRIPTIONS connection so the following unpaced pressure stream
+        // must resolve through exact coalesced delivery, resynchronization, or
+        // disconnection.
         let mut slow = daemon.connect().await;
         nix::sys::socket::setsockopt(
             &slow.stream,
@@ -3889,8 +4115,12 @@ async fn phase8_detach_reattach_overflow_resync_and_cleanup() {
             &4096,
         )
         .unwrap();
+        let mut slow_subscriptions = std::collections::BTreeMap::new();
         for _ in 0..MAX_SUBSCRIPTIONS {
-            let (_subscription_id, _) = slow.attach(splint_id, incarnation).await;
+            let (subscription_id, snapshot) = slow.attach(splint_id, incarnation).await;
+            assert!(slow_subscriptions
+                .insert(subscription_id, (snapshot, 1_u64))
+                .is_none());
         }
         producer
             .input(
@@ -3907,7 +4137,15 @@ async fn phase8_detach_reattach_overflow_resync_and_cleanup() {
             Duration::from_secs(60),
         )
         .await;
+        let final_snapshot = stable_snapshot_after_marker(
+            &mut reattached,
+            splint_id,
+            incarnation,
+            "pressure-finished",
+        )
+        .await;
 
+        let mut caught_up = false;
         let mut saw_resync = false;
         let mut disconnected = false;
         let slow_read_deadline = Instant::now() + Duration::from_secs(30);
@@ -3924,28 +4162,61 @@ async fn phase8_detach_reattach_overflow_resync_and_cleanup() {
                 disconnected = true;
                 break;
             };
-            if let ServerFrame::Event {
-                event: SubscriptionEvent::ResyncRequired { .. },
-                ..
+            let ServerFrame::Event {
+                subscription_id,
+                sequence,
+                event,
             } = frame
-            {
-                saw_resync = true;
-                break;
+            else {
+                continue;
+            };
+            let (reconstructed, expected_sequence) = slow_subscriptions
+                .get_mut(&subscription_id)
+                .expect("slow connection emitted an event for an unknown subscription");
+            match event {
+                SubscriptionEvent::Update { update } => {
+                    assert_eq!(sequence, *expected_sequence);
+                    *expected_sequence += 1;
+                    apply_terminal_update(reconstructed, update);
+                    if reconstructed.revision == final_snapshot.revision
+                        && snapshot_text(reconstructed).contains("pressure-finished")
+                    {
+                        assert_eq!(&*reconstructed, &final_snapshot);
+                        caught_up = true;
+                        break;
+                    }
+                }
+                SubscriptionEvent::Snapshot { snapshot } => {
+                    assert_eq!(sequence, *expected_sequence);
+                    *expected_sequence += 1;
+                    snapshot.validate().expect("slow subscriber snapshot is valid");
+                    assert_eq!(snapshot.splint_id, splint_id);
+                    assert_eq!(snapshot.incarnation, incarnation);
+                    *reconstructed = snapshot;
+                    if reconstructed.revision == final_snapshot.revision
+                        && snapshot_text(reconstructed).contains("pressure-finished")
+                    {
+                        assert_eq!(&*reconstructed, &final_snapshot);
+                        caught_up = true;
+                        break;
+                    }
+                }
+                SubscriptionEvent::ResyncRequired { .. } => {
+                    assert!(sequence >= *expected_sequence);
+                    saw_resync = true;
+                    break;
+                }
+                _ => {
+                    assert_eq!(sequence, *expected_sequence);
+                    *expected_sequence += 1;
+                }
             }
         }
         assert!(
-            saw_resync || disconnected,
-            "slow subscriber was neither forced to resynchronize nor disconnected"
+            caught_up || saw_resync || disconnected,
+            "slow subscriber neither received final state, required resync, nor disconnected"
         );
         drop(producer);
-
-        let final_snapshot = stable_snapshot_after_marker(
-            &mut reattached,
-            splint_id,
-            incarnation,
-            "pressure-finished",
-        )
-        .await;
         assert!(final_snapshot.revision > detached.revision);
 
         let mut before_row_id = final_snapshot

--- a/crates/splinterm-core/src/persistence.rs
+++ b/crates/splinterm-core/src/persistence.rs
@@ -13,8 +13,9 @@ use crate::{
 };
 
 const LEGACY_LAIR_SCHEMA_VERSION: u32 = 2;
-const LEGACY_TOPOLOGY_SCHEMA_VERSION: u32 = 3;
-pub const TOPOLOGY_SCHEMA_VERSION: u32 = 4;
+const LEGACY_TOPOLOGY_SCHEMA_VERSION_V3: u32 = 3;
+const LEGACY_TOPOLOGY_SCHEMA_VERSION_V4: u32 = 4;
+pub const TOPOLOGY_SCHEMA_VERSION: u32 = 5;
 pub const MAX_TOPOLOGY_DOCUMENT_BYTES: usize = 1024 * 1024;
 pub const MAX_PERSISTENT_LAIRS: usize = 64;
 const MAX_DOJOS_PER_LAIR: usize = 64;
@@ -59,23 +60,45 @@ struct LegacyLairV3 {
 }
 
 impl LegacyTopologyDocumentV3 {
-    fn migrate(self) -> TopologyDocument {
-        TopologyDocument {
+    fn migrate(self) -> Result<TopologyDocument, PersistenceError> {
+        let mut lairs = self
+            .lairs
+            .into_iter()
+            .map(|lair| Lair {
+                id: lair.id,
+                name: lair.name,
+                lifetime: lair.lifetime,
+                retention: LairRetention::Disposable,
+                provenance: None,
+                dojos: lair.dojos,
+            })
+            .collect::<Vec<_>>();
+        normalize_legacy_default_dojo_names(&mut lairs)?;
+        Ok(TopologyDocument {
             schema_version: TOPOLOGY_SCHEMA_VERSION,
             revision: self.revision,
-            lairs: self
-                .lairs
-                .into_iter()
-                .map(|lair| Lair {
-                    id: lair.id,
-                    name: lair.name,
-                    lifetime: lair.lifetime,
-                    retention: LairRetention::Disposable,
-                    provenance: None,
-                    dojos: lair.dojos,
-                })
-                .collect(),
-        }
+            lairs,
+        })
+    }
+}
+
+/// Schema-v4 could persist generated fallback names for unnamed Dojos.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct LegacyTopologyDocumentV4 {
+    schema_version: u32,
+    revision: TopologyRevision,
+    lairs: Vec<Lair>,
+}
+
+impl LegacyTopologyDocumentV4 {
+    fn migrate(mut self) -> Result<TopologyDocument, PersistenceError> {
+        normalize_legacy_default_dojo_names(&mut self.lairs)?;
+        Ok(TopologyDocument {
+            schema_version: TOPOLOGY_SCHEMA_VERSION,
+            revision: self.revision,
+            lairs: self.lairs,
+        })
     }
 }
 
@@ -106,8 +129,8 @@ struct LegacyWindowV2 {
 }
 
 impl LegacyLairDocumentV2 {
-    fn migrate(self) -> TopologyDocument {
-        let lairs = self
+    fn migrate(self) -> Result<TopologyDocument, PersistenceError> {
+        let mut lairs = self
             .dojos
             .into_iter()
             .map(|legacy_lair| Lair {
@@ -127,13 +150,48 @@ impl LegacyLairDocumentV2 {
                     })
                     .collect(),
             })
-            .collect();
-        TopologyDocument {
+            .collect::<Vec<_>>();
+        normalize_legacy_default_dojo_names(&mut lairs)?;
+        Ok(TopologyDocument {
             schema_version: TOPOLOGY_SCHEMA_VERSION,
             revision: self.revision,
             lairs,
+        })
+    }
+}
+
+fn is_decimal_digits(value: &str) -> bool {
+    !value.is_empty() && value.bytes().all(|byte| byte.is_ascii_digit())
+}
+
+fn is_legacy_default_dojo_name(name: &str) -> bool {
+    if name == "terminal" {
+        return true;
+    }
+    let Some(suffix) = name.strip_prefix("terminal-") else {
+        return false;
+    };
+    let mut components = suffix.split('-');
+    let Some(timestamp) = components.next() else {
+        return false;
+    };
+    let process_id = components.next();
+    components.next().is_none()
+        && is_decimal_digits(timestamp)
+        && process_id.is_none_or(is_decimal_digits)
+}
+
+fn normalize_legacy_default_dojo_names(lairs: &mut [Lair]) -> Result<(), PersistenceError> {
+    for lair in lairs {
+        for index in 0..lair.dojos.len() {
+            if is_legacy_default_dojo_name(&lair.dojos[index].name) {
+                lair.dojos[index].name = lair
+                    .next_default_dojo_name()
+                    .map_err(|_| PersistenceError::DefaultDojoNameExhausted)?;
+            }
         }
     }
+    Ok(())
 }
 
 impl TopologyDocument {
@@ -163,7 +221,7 @@ impl TopologyDocument {
         Ok(document)
     }
 
-    /// Decodes and validates a bounded schema-v3 document or migrates schema v2.
+    /// Decodes and validates current metadata or migrates supported legacy schemas.
     ///
     /// # Errors
     ///
@@ -177,13 +235,21 @@ impl TopologyDocument {
         let document = match version.schema_version {
             TOPOLOGY_SCHEMA_VERSION => serde_json::from_slice(bytes)
                 .map_err(|error| PersistenceError::Decode(error.to_string()))?,
-            LEGACY_TOPOLOGY_SCHEMA_VERSION => {
-                let legacy: LegacyTopologyDocumentV3 = serde_json::from_slice(bytes)
+            LEGACY_TOPOLOGY_SCHEMA_VERSION_V4 => {
+                let legacy: LegacyTopologyDocumentV4 = serde_json::from_slice(bytes)
                     .map_err(|error| PersistenceError::Decode(error.to_string()))?;
-                if legacy.schema_version != LEGACY_TOPOLOGY_SCHEMA_VERSION {
+                if legacy.schema_version != LEGACY_TOPOLOGY_SCHEMA_VERSION_V4 {
                     return Err(PersistenceError::UnsupportedVersion(legacy.schema_version));
                 }
-                legacy.migrate()
+                legacy.migrate()?
+            }
+            LEGACY_TOPOLOGY_SCHEMA_VERSION_V3 => {
+                let legacy: LegacyTopologyDocumentV3 = serde_json::from_slice(bytes)
+                    .map_err(|error| PersistenceError::Decode(error.to_string()))?;
+                if legacy.schema_version != LEGACY_TOPOLOGY_SCHEMA_VERSION_V3 {
+                    return Err(PersistenceError::UnsupportedVersion(legacy.schema_version));
+                }
+                legacy.migrate()?
             }
             LEGACY_LAIR_SCHEMA_VERSION => {
                 let legacy: LegacyLairDocumentV2 = serde_json::from_slice(bytes)
@@ -191,7 +257,7 @@ impl TopologyDocument {
                 if legacy.schema_version != LEGACY_LAIR_SCHEMA_VERSION {
                     return Err(PersistenceError::UnsupportedVersion(legacy.schema_version));
                 }
-                legacy.migrate()
+                legacy.migrate()?
             }
             other => return Err(PersistenceError::UnsupportedVersion(other)),
         };
@@ -199,7 +265,7 @@ impl TopologyDocument {
         Ok(document)
     }
 
-    /// Serializes validated schema-v3 metadata.
+    /// Serializes validated current-schema metadata.
     ///
     /// # Errors
     ///
@@ -380,6 +446,8 @@ pub enum PersistenceError {
     CollectionTooLarge(&'static str),
     #[error("metadata contains a duplicate {0} ID")]
     DuplicateId(&'static str),
+    #[error("metadata cannot allocate a numbered name for a legacy unnamed Dojo")]
+    DefaultDojoNameExhausted,
     #[error("metadata contains duplicate Lair names")]
     DuplicateLairName,
     #[error("metadata contains an invalid {0}")]
@@ -421,6 +489,16 @@ mod tests {
             "command": [],
             "state": {"Exited": 0}
         }})
+    }
+
+    fn dojo(name: &str) -> Value {
+        let splint_id = Uuid::new_v4();
+        json!({
+            "id": Uuid::new_v4(),
+            "name": name,
+            "default_focus": splint_id,
+            "root": leaf(&splint_id.to_string(), "/tmp")
+        })
     }
 
     fn valid_v3_document() -> Value {
@@ -588,13 +666,68 @@ mod tests {
     }
 
     #[test]
-    fn schema_v3_migration_defaults_to_disposable_without_provenance() {
+    fn schema_v3_migration_defaults_lifecycle_and_normalizes_legacy_dojo_names() {
         let mut value = valid_v3_document();
-        value["schema_version"] = json!(LEGACY_TOPOLOGY_SCHEMA_VERSION);
+        value["schema_version"] = json!(LEGACY_TOPOLOGY_SCHEMA_VERSION_V3);
         let topology = decode(&value).unwrap().into_topology().unwrap();
         let lair = topology.lairs().next().unwrap();
         assert_eq!(lair.retention, LairRetention::Disposable);
         assert_eq!(lair.provenance, None);
+        assert_eq!(lair.dojos[0].name, "Dojo 1");
+    }
+
+    #[test]
+    fn schema_v4_migration_replaces_only_numeric_generated_fallback_names() {
+        let mut value = valid_v3_document();
+        value["schema_version"] = json!(LEGACY_TOPOLOGY_SCHEMA_VERSION_V4);
+        let dojos = value["lairs"][0]["dojos"].as_array_mut().unwrap();
+        dojos.extend([
+            dojo("terminal-123"),
+            dojo("terminal-123-45"),
+            dojo("Dojo 3"),
+            dojo("terminal-012"),
+            dojo("terminal-000-007"),
+            dojo("terminal-123-worker"),
+            dojo("my-terminal-123"),
+        ]);
+
+        let topology = decode(&value).unwrap().into_topology().unwrap();
+        let names = topology
+            .lairs()
+            .next()
+            .unwrap()
+            .dojos
+            .iter()
+            .map(|dojo| dojo.name.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            names,
+            [
+                "Dojo 4",
+                "Dojo 5",
+                "Dojo 6",
+                "Dojo 3",
+                "Dojo 7",
+                "Dojo 8",
+                "terminal-123-worker",
+                "my-terminal-123",
+            ]
+        );
+    }
+
+    #[test]
+    fn legacy_generated_name_migration_rejects_number_exhaustion() {
+        let mut value = valid_v3_document();
+        value["schema_version"] = json!(LEGACY_TOPOLOGY_SCHEMA_VERSION_V4);
+        value["lairs"][0]["dojos"]
+            .as_array_mut()
+            .unwrap()
+            .push(dojo(&format!("Dojo {}", u64::MAX)));
+
+        assert_eq!(
+            decode(&value),
+            Err(PersistenceError::DefaultDojoNameExhausted)
+        );
     }
 
     #[test]
@@ -632,7 +765,7 @@ mod tests {
         assert_eq!(lair.name, "main");
         assert_eq!(lair.dojos.len(), 2);
         assert_eq!(lair.dojos[0].id.to_string(), DOJO_ID);
-        assert_eq!(lair.dojos[0].name, "terminal");
+        assert_eq!(lair.dojos[0].name, "Dojo 1");
         assert_eq!(lair.dojos[0].default_focus.to_string(), SPLINT_ID);
         assert_eq!(lair.dojos[1].id.to_string(), SECOND_DOJO_ID);
         assert_eq!(lair.dojos[1].name, "logs");
@@ -649,7 +782,7 @@ mod tests {
     }
 
     #[test]
-    fn accepts_current_version_exited_metadata() {
+    fn accepts_current_version_exited_metadata_without_rewriting_explicit_names() {
         let document = decode(&valid_v3_document()).unwrap();
         let encoded = document.encode().unwrap();
         let topology = TopologyDocument::decode(&encoded)
@@ -658,6 +791,7 @@ mod tests {
             .unwrap();
         assert_eq!(topology.revision().get(), 7);
         assert_eq!(topology.lairs().count(), 1);
+        assert_eq!(topology.lairs().next().unwrap().dojos[0].name, "terminal");
     }
 
     #[test]

--- a/crates/splinterm-filemap/src/lib.rs
+++ b/crates/splinterm-filemap/src/lib.rs
@@ -5,20 +5,56 @@
 //! The unsafe operating-system mapping boundary stays in this leaf crate. Callers
 //! receive only an immutable byte slice and cannot mutate or resize the mapping.
 
-use std::{fs::File, io, ops::Deref, os::fd::OwnedFd, path::Path};
+use std::{
+    fs::File,
+    io::{self, Read, Write},
+    ops::Deref,
+    os::{fd::OwnedFd, unix::fs::MetadataExt},
+    path::Path,
+};
 
 use memmap2::{Mmap, MmapOptions};
-use rustix::fs::{SealFlags, fcntl_get_seals, fstat};
+use rustix::fs::{MemfdFlags, SealFlags, fcntl_add_seals, fcntl_get_seals, fstat, memfd_create};
 
 const REQUIRED_IMMUTABLE_SEALS: SealFlags = SealFlags::WRITE
     .union(SealFlags::GROW)
     .union(SealFlags::SHRINK)
     .union(SealFlags::SEAL);
 
+/// Identity captured from the exact opened file backing a mapping.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct FileIdentity {
+    pub device: u64,
+    pub inode: u64,
+    pub length: u64,
+    pub modified_seconds: i64,
+    pub modified_nanoseconds: i64,
+}
+
+impl FileIdentity {
+    fn from_metadata(metadata: &std::fs::Metadata) -> Self {
+        Self {
+            device: metadata.dev(),
+            inode: metadata.ino(),
+            length: metadata.len(),
+            modified_seconds: metadata.mtime(),
+            modified_nanoseconds: metadata.mtime_nsec(),
+        }
+    }
+}
+
+/// Immutable snapshot plus the identity of the exact source file that was copied.
+#[derive(Debug)]
+pub struct ImmutableFileSnapshot {
+    pub mapping: ReadOnlyFileMap,
+    pub source_identity: FileIdentity,
+}
+
 /// An owned, read-only mapping of one non-empty regular file.
 #[derive(Debug)]
 pub struct ReadOnlyFileMap {
     mapping: Mmap,
+    identity: FileIdentity,
 }
 
 impl ReadOnlyFileMap {
@@ -32,7 +68,10 @@ impl ReadOnlyFileMap {
     /// # Errors
     /// Returns an I/O error for missing, empty, non-regular, or unmappable files.
     pub fn open(path: impl AsRef<Path>) -> io::Result<Self> {
-        let file = File::open(path)?;
+        Self::map_file(&File::open(path)?)
+    }
+
+    fn map_file(file: &File) -> io::Result<Self> {
         let metadata = file.metadata()?;
         if !metadata.is_file() || metadata.len() == 0 {
             return Err(io::Error::new(
@@ -40,12 +79,91 @@ impl ReadOnlyFileMap {
                 "mapped asset must be a non-empty regular file",
             ));
         }
-        // SAFETY: This leaf API is restricted to package-managed immutable assets.
-        // Splinterm opens system font files read-only; Arch package upgrades replace
-        // those paths with new inodes rather than mutating an active inode. `Mmap`
-        // owns the mapping for as long as the returned slice can be borrowed.
-        let mapping = unsafe { MmapOptions::new().map(&file)? };
-        Ok(Self { mapping })
+        let identity = FileIdentity::from_metadata(&metadata);
+        // SAFETY: Callers provide either a read-only package-managed asset or a
+        // descriptor whose immutable seals were verified before this helper. The
+        // private mapping owns the opened file's pages and exposes only immutable bytes.
+        let mapping = unsafe { MmapOptions::new().map(file)? };
+        Ok(Self { mapping, identity })
+    }
+
+    /// Returns metadata captured from the exact file descriptor that was mapped.
+    #[must_use]
+    pub const fn identity(&self) -> FileIdentity {
+        self.identity
+    }
+
+    /// Copies one regular file into a bounded sealed anonymous snapshot.
+    ///
+    /// Source identity is checked before and after copying. The returned mapping
+    /// is backed by a sealed memfd, so later source replacement, mutation, or
+    /// truncation cannot change or fault the staged bytes.
+    ///
+    /// # Errors
+    /// Returns an I/O error for an invalid source, an exceeded bound, source
+    /// identity drift during copying, sealing failure, or mapping failure.
+    pub fn immutable_snapshot(
+        path: impl AsRef<Path>,
+        maximum_len: usize,
+    ) -> io::Result<ImmutableFileSnapshot> {
+        if maximum_len == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "immutable snapshot bound must be positive",
+            ));
+        }
+        let mut source = File::open(path)?;
+        let before = source.metadata()?;
+        if !before.is_file() || before.len() == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "snapshot source must be a non-empty regular file",
+            ));
+        }
+        let maximum_len_u64 = u64::try_from(maximum_len).map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "snapshot bound does not fit u64",
+            )
+        })?;
+        if before.len() > maximum_len_u64 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "snapshot source exceeds its byte bound",
+            ));
+        }
+        let source_identity = FileIdentity::from_metadata(&before);
+        let expected_len = usize::try_from(before.len()).map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "snapshot length does not fit usize",
+            )
+        })?;
+        let mut bytes = Vec::with_capacity(expected_len);
+        (&mut source)
+            .take(maximum_len_u64.saturating_add(1))
+            .read_to_end(&mut bytes)?;
+        let after_identity = FileIdentity::from_metadata(&source.metadata()?);
+        if after_identity != source_identity || bytes.len() != expected_len {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "snapshot source changed while it was copied",
+            ));
+        }
+
+        let descriptor = memfd_create(
+            "splinterm-immutable-snapshot",
+            MemfdFlags::CLOEXEC | MemfdFlags::ALLOW_SEALING,
+        )?;
+        let mut sealed_file = File::from(descriptor);
+        sealed_file.write_all(&bytes)?;
+        let descriptor: OwnedFd = sealed_file.into();
+        fcntl_add_seals(&descriptor, REQUIRED_IMMUTABLE_SEALS)?;
+        let mapping = Self::from_sealed_fd(descriptor, bytes.len())?;
+        Ok(ImmutableFileSnapshot {
+            mapping,
+            source_identity,
+        })
     }
 
     /// Verifies and maps an exactly-sized sealed descriptor read-only.
@@ -70,11 +188,7 @@ impl ReadOnlyFileMap {
             ));
         }
         let file = File::from(fd);
-        // SAFETY: All mutations and size changes are prohibited by verified
-        // kernel-enforced seals before mapping. The mapping owns its file-backed
-        // pages and exposes only immutable bytes.
-        let mapping = unsafe { MmapOptions::new().map(&file)? };
-        Ok(Self { mapping })
+        Self::map_file(&file)
     }
 }
 
@@ -108,9 +222,40 @@ mod tests {
         let path = temporary_path("bytes");
         fs::write(&path, b"mapped font bytes").unwrap();
         let mapping = ReadOnlyFileMap::open(&path).unwrap();
+        let first_identity = mapping.identity();
+        assert_eq!(&*mapping, b"mapped font bytes");
+        fs::remove_file(&path).unwrap();
+        fs::write(&path, b"replacement font bytes are different").unwrap();
+        let replacement = ReadOnlyFileMap::open(&path).unwrap();
+        assert_ne!(replacement.identity(), first_identity);
         assert_eq!(&*mapping, b"mapped font bytes");
         fs::remove_file(path).unwrap();
-        assert_eq!(&*mapping, b"mapped font bytes");
+    }
+
+    #[test]
+    fn immutable_snapshot_is_bounded_and_detached_from_source_mutation() {
+        let path = temporary_path("immutable-snapshot");
+        fs::write(&path, b"original font bytes").unwrap();
+        let snapshot = ReadOnlyFileMap::immutable_snapshot(&path, 64).unwrap();
+        assert_eq!(snapshot.source_identity.length, 19);
+        assert_eq!(&*snapshot.mapping, b"original font bytes");
+
+        fs::write(&path, b"x").unwrap();
+        assert_eq!(&*snapshot.mapping, b"original font bytes");
+        assert_eq!(
+            ReadOnlyFileMap::immutable_snapshot(&path, 0)
+                .unwrap_err()
+                .kind(),
+            io::ErrorKind::InvalidInput
+        );
+        fs::write(&path, b"too large").unwrap();
+        assert_eq!(
+            ReadOnlyFileMap::immutable_snapshot(&path, 4)
+                .unwrap_err()
+                .kind(),
+            io::ErrorKind::InvalidData
+        );
+        fs::remove_file(path).unwrap();
     }
 
     #[test]

--- a/crates/splinterm-freetype/Cargo.toml
+++ b/crates/splinterm-freetype/Cargo.toml
@@ -9,6 +9,7 @@ repository.workspace = true
 
 [dependencies]
 freetype-rs.workspace = true
+splinterm-filemap = { path = "../splinterm-filemap" }
 splinterm-pixman = { path = "../splinterm-pixman" }
 thiserror.workspace = true
 

--- a/crates/splinterm-freetype/src/lib.rs
+++ b/crates/splinterm-freetype/src/lib.rs
@@ -11,12 +11,14 @@ use std::path::{Path, PathBuf};
 use freetype::{
     Face, Library, RenderMode, bitmap::PixelMode, face::LoadFlag, tt_os2::TrueTypeOS2Table,
 };
+use splinterm_filemap::ReadOnlyFileMap;
 use thiserror::Error;
 
 pub const MIN_PIXEL_SIZE_26_6: isize = 6 * 64;
 pub const MAX_PIXEL_SIZE_26_6: isize = 768 * 64;
 pub const MAX_GLYPH_DIMENSION: u32 = 4_096;
 pub const MAX_GLYPH_PIXELS: usize = 16 * 1024 * 1024;
+pub const MAX_STAGED_FONT_BYTES: usize = 64 * 1024 * 1024;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct FontMetrics {
@@ -57,14 +59,17 @@ pub enum RasterError {
     InvalidPixelSize,
     #[error("font face index does not fit FreeType's signed index")]
     InvalidFaceIndex,
+    #[error("staged font exceeds the 64 MiB per-face byte bound")]
+    FontTooLarge,
     #[error("initialize FreeType: {0}")]
     Initialize(freetype::Error),
-    #[error("open font face {path} index {index}: {source}")]
-    OpenFace {
+    #[error("map font face {path}: {source}")]
+    MapFace {
         path: PathBuf,
-        index: u32,
-        source: freetype::Error,
+        source: std::io::Error,
     },
+    #[error("open owned font face index {index}: {source}")]
+    OpenMemoryFace { index: u32, source: freetype::Error },
     #[error("set FreeType character size: {0}")]
     SetSize(freetype::Error),
     #[error("load glyph {glyph_id}: {source}")]
@@ -109,13 +114,34 @@ impl RasterFace {
         if !(MIN_PIXEL_SIZE_26_6..=MAX_PIXEL_SIZE_26_6).contains(&pixel_size_26_6) {
             return Err(RasterError::InvalidPixelSize);
         }
+        let path = path.as_ref();
+        let data = ReadOnlyFileMap::open(path).map_err(|source| RasterError::MapFace {
+            path: path.to_path_buf(),
+            source,
+        })?;
+        Self::open_memory(&data, face_index, pixel_size_26_6)
+    }
+
+    /// Opens one face from immutable generation-owned bytes.
+    ///
+    /// # Errors
+    /// Returns a typed error for invalid bounds or any `FreeType` failure.
+    pub fn open_memory(
+        data: &ReadOnlyFileMap,
+        face_index: u32,
+        pixel_size_26_6: isize,
+    ) -> Result<Self, RasterError> {
+        if !(MIN_PIXEL_SIZE_26_6..=MAX_PIXEL_SIZE_26_6).contains(&pixel_size_26_6) {
+            return Err(RasterError::InvalidPixelSize);
+        }
+        if data.len() > MAX_STAGED_FONT_BYTES {
+            return Err(RasterError::FontTooLarge);
+        }
         let index = isize::try_from(face_index).map_err(|_| RasterError::InvalidFaceIndex)?;
         let library = Library::init().map_err(RasterError::Initialize)?;
-        let path = path.as_ref();
         let face = library
-            .new_face(path, index)
-            .map_err(|source| RasterError::OpenFace {
-                path: path.to_path_buf(),
+            .new_memory_face(data.to_vec(), index)
+            .map_err(|source| RasterError::OpenMemoryFace {
                 index: face_index,
                 source,
             })?;
@@ -144,29 +170,87 @@ impl RasterFace {
         {
             return Err(RasterError::InvalidPixelSize);
         }
+        let path = path.as_ref();
+        let data = ReadOnlyFileMap::open(path).map_err(|source| RasterError::MapFace {
+            path: path.to_path_buf(),
+            source,
+        })?;
+        Self::rasterize_color_memory(
+            &data,
+            face_index,
+            requested_pixel_size_26_6,
+            selected_pixel_size_26_6,
+            glyph_id,
+        )
+    }
+
+    /// Rasterizes one fixed-strike color glyph from immutable generation-owned bytes.
+    ///
+    /// # Errors
+    /// Returns a typed error for invalid bounds, `FreeType` failures, non-BGRA
+    /// output, malformed bitmap geometry, or pixman scaling failures.
+    pub fn rasterize_color_memory(
+        data: &ReadOnlyFileMap,
+        face_index: u32,
+        requested_pixel_size_26_6: isize,
+        selected_pixel_size_26_6: isize,
+        glyph_id: u32,
+    ) -> Result<RasterizedColorGlyph, RasterError> {
+        if !(MIN_PIXEL_SIZE_26_6..=MAX_PIXEL_SIZE_26_6).contains(&requested_pixel_size_26_6)
+            || !(MIN_PIXEL_SIZE_26_6..=MAX_PIXEL_SIZE_26_6).contains(&selected_pixel_size_26_6)
+        {
+            return Err(RasterError::InvalidPixelSize);
+        }
+        if data.len() > MAX_STAGED_FONT_BYTES {
+            return Err(RasterError::FontTooLarge);
+        }
         let index = isize::try_from(face_index).map_err(|_| RasterError::InvalidFaceIndex)?;
         let library = Library::init().map_err(RasterError::Initialize)?;
-        let path = path.as_ref();
         let face = library
-            .new_face(path, index)
-            .map_err(|source| RasterError::OpenFace {
-                path: path.to_path_buf(),
+            .new_memory_face(data.to_vec(), index)
+            .map_err(|source| RasterError::OpenMemoryFace {
                 index: face_index,
                 source,
             })?;
         face.set_char_size(selected_pixel_size_26_6, 0, 72, 72)
             .map_err(RasterError::SetSize)?;
-        face.load_glyph(
+        let mut raster = Self { face };
+        raster.rasterize_color_glyph(
+            requested_pixel_size_26_6,
+            selected_pixel_size_26_6,
             glyph_id,
-            LoadFlag::DEFAULT | LoadFlag::TARGET_LIGHT | LoadFlag::COLOR,
         )
-        .map_err(|source| RasterError::LoadGlyph { glyph_id, source })?;
-        if face.glyph().raw().format != freetype::ffi::FT_GLYPH_FORMAT_BITMAP {
-            face.glyph()
+    }
+
+    /// Rasterizes one color glyph through an already opened fixed-strike face.
+    ///
+    /// # Errors
+    /// Returns a typed error for invalid bounds, `FreeType` failures, non-BGRA
+    /// output, malformed bitmap geometry, or pixman scaling failures.
+    pub fn rasterize_color_glyph(
+        &mut self,
+        requested_pixel_size_26_6: isize,
+        selected_pixel_size_26_6: isize,
+        glyph_id: u32,
+    ) -> Result<RasterizedColorGlyph, RasterError> {
+        if !(MIN_PIXEL_SIZE_26_6..=MAX_PIXEL_SIZE_26_6).contains(&requested_pixel_size_26_6)
+            || !(MIN_PIXEL_SIZE_26_6..=MAX_PIXEL_SIZE_26_6).contains(&selected_pixel_size_26_6)
+        {
+            return Err(RasterError::InvalidPixelSize);
+        }
+        self.face
+            .load_glyph(
+                glyph_id,
+                LoadFlag::DEFAULT | LoadFlag::TARGET_LIGHT | LoadFlag::COLOR,
+            )
+            .map_err(|source| RasterError::LoadGlyph { glyph_id, source })?;
+        if self.face.glyph().raw().format != freetype::ffi::FT_GLYPH_FORMAT_BITMAP {
+            self.face
+                .glyph()
                 .render_glyph(RenderMode::Normal)
                 .map_err(|source| RasterError::RenderGlyph { glyph_id, source })?;
         }
-        let slot = face.glyph();
+        let slot = self.face.glyph();
         let bitmap = slot.bitmap();
         let mode = bitmap
             .pixel_mode()

--- a/crates/splinterm-terminal/src/terminal.rs
+++ b/crates/splinterm-terminal/src/terminal.rs
@@ -3014,6 +3014,7 @@ impl Terminal {
 
     fn device_attributes(&mut self, private: Option<u8>) {
         let reply = match private {
+            None if self.config.sixel.enabled => Some(b"\x1b[?62;4;22c".to_vec()),
             None => Some(b"\x1b[?62;22c".to_vec()),
             Some(b'>') => Some(b"\x1b[>0;1;0c".to_vec()),
             _ => None,
@@ -3699,7 +3700,7 @@ mod tests {
             vec![
                 TerminalEvent::PtyWrite(b"\x1b[0n".to_vec()),
                 TerminalEvent::PtyWrite(b"\x1b[2;3R".to_vec()),
-                TerminalEvent::PtyWrite(b"\x1b[?62;22c".to_vec()),
+                TerminalEvent::PtyWrite(b"\x1b[?62;4;22c".to_vec()),
             ]
         );
     }

--- a/crates/splinterm-terminal/tests/images.rs
+++ b/crates/splinterm-terminal/tests/images.rs
@@ -221,7 +221,7 @@ fn sixel_configuration_uses_foot_palette_and_can_disable_graphics() {
         },
     );
     disabled.set_cell_pixel_size(1, 6);
-    disabled.advance(b"\x1bP7;0;0q#1~\x1b\\X");
+    disabled.advance(b"\x1bP7;0;0q#1~\x1b\\X\x1b[c");
     assert_eq!(disabled.image_metrics().content_count, 0);
     assert_eq!(
         disabled
@@ -234,6 +234,12 @@ fn sixel_configuration_uses_foot_palette_and_can_disable_graphics() {
             .unwrap()
             .content(),
         splinterm_terminal::CellSnapshotContent::Scalar('X')
+    );
+    assert_eq!(
+        disabled.drain_events().collect::<Vec<_>>(),
+        vec![splinterm_terminal::TerminalEvent::PtyWrite(
+            b"\x1b[?62;22c".to_vec()
+        )]
     );
 }
 
@@ -363,7 +369,7 @@ fn xtsmgraphics_queries_are_bounded_and_ordered_before_later_replies() {
             splinterm_terminal::TerminalEvent::PtyWrite(b"\x1b[?1;0;64S".to_vec()),
             splinterm_terminal::TerminalEvent::PtyWrite(b"\x1b[?2;0;80;64S".to_vec()),
             splinterm_terminal::TerminalEvent::PtyWrite(b"\x1b[?2;0;4096;4096S".to_vec()),
-            splinterm_terminal::TerminalEvent::PtyWrite(b"\x1b[?62;22c".to_vec()),
+            splinterm_terminal::TerminalEvent::PtyWrite(b"\x1b[?62;4;22c".to_vec()),
         ]
     );
 }

--- a/crates/splinterm-terminal/tests/kitty.rs
+++ b/crates/splinterm-terminal/tests/kitty.rs
@@ -182,14 +182,55 @@ fn recorded_spec_fixture_manifest_executes_every_case() {
 }
 
 #[test]
-fn spec_query_reply_precedes_following_da1_and_never_commits_content() {
+fn yazi_query_reply_precedes_sixel_da1_and_never_commits_content() {
     let mut terminal = terminal();
-    terminal.advance(b"\x1b_Gi=31,s=1,v=1,a=q,t=d,f=24;/wAA\x1b\\\x1b[c");
+    terminal.advance(b"\x1b_Gi=278941603,s=1,v=1,a=q,t=d,f=24;AAAA\x1b\\\x1b[0c");
     assert_eq!(
         writes(&mut terminal),
-        vec![b"\x1b_Gi=31;OK\x1b\\".to_vec(), b"\x1b[?62;22c".to_vec()]
+        vec![
+            b"\x1b_Gi=278941603;OK\x1b\\".to_vec(),
+            b"\x1b[?62;4;22c".to_vec(),
+        ]
     );
     assert_eq!(terminal.image_metrics().content_count, 0);
+    assert_eq!(terminal.image_metrics().placement_count, 0);
+}
+
+#[test]
+fn yazi_kgp_old_cell_placements_remain_bounded_when_replies_are_quiet() {
+    let limit = ImageLimits::default().placements_per_terminal;
+    let width = limit + 1;
+    let mut terminal = Terminal::new(width, 1, TerminalConfig::default());
+    terminal.set_cell_pixel_size(1, 1);
+    terminal.advance(
+        format!(
+            "\x1b_Gq=2,a=t,i=42,f=24,s={width},v=1,m=0;{}\x1b\\",
+            STANDARD.encode(vec![0x7f_u8; width * 3])
+        )
+        .as_bytes(),
+    );
+
+    for column in 0..width {
+        terminal.advance(
+            format!(
+                "\x1b[1;{}H\x1b_Gq=2,a=p,i=42,p={},x={column},y=0,w=1,h=1,c=1,r=1,z=-1,C=1\x1b\\",
+                column + 1,
+                column + 1,
+            )
+            .as_bytes(),
+        );
+    }
+
+    assert!(terminal.drain_events().next().is_none());
+    assert_eq!(terminal.image_metrics().content_count, 1);
+    assert_eq!(terminal.image_metrics().placement_count, limit);
+    assert_eq!(
+        terminal
+            .snapshot(SnapshotRequest::default())
+            .image_placements()
+            .count(),
+        limit
+    );
 }
 
 #[test]

--- a/crates/splinterm/src/app/font_watch.rs
+++ b/crates/splinterm/src/app/font_watch.rs
@@ -1,0 +1,193 @@
+use std::sync::Arc;
+
+use splinterm::{
+    FontUpdate, WindowTopologyUpdate, WindowUpdate,
+    config::FontAuthority,
+    renderer::{
+        FontFingerprint, FontGeneration, probe_live_font_sources, stage_live_font_generation,
+    },
+};
+use tokio::sync::mpsc;
+
+pub(in crate::app) enum FontUpdateSink {
+    Panes(Vec<mpsc::Sender<WindowUpdate>>),
+    Topology(mpsc::Sender<WindowTopologyUpdate>),
+}
+
+#[derive(Debug)]
+struct FontReloadState<F> {
+    observed: Option<F>,
+    current: F,
+}
+
+impl<F: Eq> FontReloadState<F> {
+    fn new(current: F) -> Self {
+        Self {
+            observed: None,
+            current,
+        }
+    }
+
+    fn observe(&mut self, fingerprint: F) -> bool {
+        if self.observed.as_ref() == Some(&fingerprint) {
+            return false;
+        }
+        self.observed = Some(fingerprint);
+        true
+    }
+
+    fn reject_observed(&mut self) {
+        self.observed = None;
+    }
+
+    fn accept(&mut self, fingerprint: F) -> bool {
+        if self.current == fingerprint {
+            return false;
+        }
+        self.current = fingerprint;
+        true
+    }
+}
+
+#[derive(Default)]
+struct FontReloadDiagnostics {
+    rejection_reported: bool,
+}
+
+impl FontReloadDiagnostics {
+    fn accepted(&mut self) {
+        self.rejection_reported = false;
+    }
+
+    fn rejected(&mut self, error: &anyhow::Error) -> Option<String> {
+        if self.rejection_reported {
+            return None;
+        }
+        self.rejection_reported = true;
+        Some(format!("splinterm live font update rejected: {error:#}"))
+    }
+}
+
+async fn probe(pattern: String, authority: FontAuthority) -> anyhow::Result<FontFingerprint> {
+    tokio::task::spawn_blocking(move || probe_live_font_sources(&pattern, authority))
+        .await
+        .map_err(|error| anyhow::anyhow!("font probe worker failed: {error}"))?
+}
+
+async fn stage(pattern: String, authority: FontAuthority) -> anyhow::Result<FontGeneration> {
+    tokio::task::spawn_blocking(move || stage_live_font_generation(&pattern, authority))
+        .await
+        .map_err(|error| anyhow::anyhow!("font staging worker failed: {error}"))?
+}
+
+async fn deliver(sink: &FontUpdateSink, generation: Arc<FontGeneration>) -> bool {
+    let update = FontUpdate { generation };
+    match sink {
+        FontUpdateSink::Panes(updates) => {
+            let mut delivered = false;
+            for updates in updates {
+                delivered |= updates
+                    .send(WindowUpdate::Font(update.clone()))
+                    .await
+                    .is_ok();
+            }
+            delivered
+        }
+        FontUpdateSink::Topology(updates) => updates
+            .send(WindowTopologyUpdate::Font(update))
+            .await
+            .is_ok(),
+    }
+}
+
+pub(in crate::app) async fn watch_font(
+    pattern: String,
+    authority: FontAuthority,
+    current: Arc<FontGeneration>,
+    sink: FontUpdateSink,
+) {
+    if authority != FontAuthority::NativeOmarchy {
+        return;
+    }
+    let mut state = FontReloadState::new(current.fingerprint().clone());
+    let mut diagnostics = FontReloadDiagnostics::default();
+    let mut retry_after = None;
+    let mut poll = tokio::time::interval(std::time::Duration::from_secs(1));
+    poll.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    loop {
+        poll.tick().await;
+        if retry_after.is_some_and(|deadline| tokio::time::Instant::now() < deadline) {
+            continue;
+        }
+        retry_after = None;
+        let fingerprint = match probe(pattern.clone(), authority).await {
+            Ok(fingerprint) => fingerprint,
+            Err(error) => {
+                if let Some(diagnostic) = diagnostics.rejected(&error) {
+                    eprintln!("{diagnostic}");
+                }
+                continue;
+            }
+        };
+        if !state.observe(fingerprint) {
+            continue;
+        }
+        match stage(pattern.clone(), authority).await {
+            Ok(generation) => {
+                let generation = Arc::new(generation);
+                if !state.accept(generation.fingerprint().clone()) {
+                    diagnostics.accepted();
+                    continue;
+                }
+                diagnostics.accepted();
+                if !deliver(&sink, generation).await {
+                    break;
+                }
+            }
+            Err(error) => {
+                state.reject_observed();
+                retry_after = Some(tokio::time::Instant::now() + std::time::Duration::from_secs(5));
+                if let Some(diagnostic) = diagnostics.rejected(&error) {
+                    eprintln!("{diagnostic}");
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reload_state_coalesces_probes_and_publishes_only_changed_candidates() {
+        let mut state = FontReloadState::new(1_u8);
+        assert!(state.observe(1));
+        assert!(!state.accept(1));
+        assert!(!state.observe(1));
+        assert!(state.observe(2));
+        assert!(state.accept(2));
+        assert!(!state.accept(2));
+        assert!(state.observe(1));
+        assert!(state.accept(1));
+    }
+
+    #[test]
+    fn failed_staging_retries_the_same_observed_fingerprint() {
+        let mut state = FontReloadState::new(1_u8);
+        assert!(state.observe(2));
+        state.reject_observed();
+        assert!(state.observe(2));
+        assert!(state.accept(2));
+    }
+
+    #[test]
+    fn reload_rejection_diagnostics_are_bounded_until_acceptance() {
+        let mut diagnostics = FontReloadDiagnostics::default();
+        let error = anyhow::anyhow!("invalid candidate");
+        assert!(diagnostics.rejected(&error).is_some());
+        assert!(diagnostics.rejected(&error).is_none());
+        diagnostics.accepted();
+        assert!(diagnostics.rejected(&error).is_some());
+    }
+}

--- a/crates/splinterm/src/app/font_watch.rs
+++ b/crates/splinterm/src/app/font_watch.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use splinterm::{
     FontUpdate, WindowTopologyUpdate, WindowUpdate,
@@ -8,6 +8,8 @@ use splinterm::{
     },
 };
 use tokio::sync::mpsc;
+
+const FONT_PROBE_INTERVAL: Duration = Duration::from_secs(10);
 
 pub(in crate::app) enum FontUpdateSink {
     Panes(Vec<mpsc::Sender<WindowUpdate>>),
@@ -112,7 +114,10 @@ pub(in crate::app) async fn watch_font(
     let mut state = FontReloadState::new(current.fingerprint().clone());
     let mut diagnostics = FontReloadDiagnostics::default();
     let mut retry_after = None;
-    let mut poll = tokio::time::interval(std::time::Duration::from_secs(1));
+    // Startup already staged `current`; defer the first ambient Fontconfig
+    // resolution and keep idle subprocess churn bounded thereafter.
+    let first_probe = tokio::time::Instant::now() + FONT_PROBE_INTERVAL;
+    let mut poll = tokio::time::interval_at(first_probe, FONT_PROBE_INTERVAL);
     poll.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
     loop {
         poll.tick().await;
@@ -158,6 +163,11 @@ pub(in crate::app) async fn watch_font(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn ambient_font_probes_keep_a_coarse_idle_cadence() {
+        assert!(FONT_PROBE_INTERVAL >= Duration::from_secs(10));
+    }
 
     #[test]
     fn reload_state_coalesces_probes_and_publishes_only_changed_candidates() {

--- a/crates/splinterm/src/app/mod.rs
+++ b/crates/splinterm/src/app/mod.rs
@@ -4,6 +4,7 @@ mod cli;
 mod commands;
 mod consent;
 mod diagnostics_cli;
+mod font_watch;
 mod human_output;
 mod integrations;
 mod keymap_cli;

--- a/crates/splinterm/src/app/sessions.rs
+++ b/crates/splinterm/src/app/sessions.rs
@@ -133,6 +133,7 @@ pub(in crate::app) async fn select_dojo(
 fn configure_picker_renderer(config: &AppConfig, theme: ResolvedTheme) -> Result<()> {
     renderer::configure(RendererOptions {
         font: config.font.clone(),
+        font_authority: config.font_authority,
         font_size: config.font_size,
         font_sizing_policy: config.font_sizing_policy,
         physical_dpi: 96.0,

--- a/crates/splinterm/src/app/window.rs
+++ b/crates/splinterm/src/app/window.rs
@@ -1,12 +1,12 @@
 //! Graphical window lifecycle orchestration.
 
-use std::{collections::HashMap, env, path::PathBuf};
+use std::{collections::HashMap, env, path::PathBuf, sync::Arc};
 
 use anyhow::{Context, Result, bail};
 use splinterm::{
     PerfTraceCorrelation, WindowOptions, WindowUpdate,
     automation::{Connection, MAX_RENDERER_IMAGE_RESIDENT_BYTES, SharedImageContentCache},
-    config::AppConfig,
+    config::{AppConfig, FontAuthority},
     endpoint::{
         ConnectionFactory, ForcedControlTransfer, GraphicalFocusPublication, LaunchSemantics,
     },
@@ -21,6 +21,7 @@ use splinterm_protocol::{
 use tokio::sync::{mpsc, watch};
 
 use super::{
+    font_watch::{FontUpdateSink, watch_font},
     pane_bridge::{
         ControllerOutputs, EventAction, WINDOW_COMMAND_QUEUE, WINDOW_UPDATE_QUEUE, attach,
         classify_subscription_event, layout_splint_ids, lease_snapshot_images, lease_update_images,
@@ -32,6 +33,24 @@ use super::{
     theme_watch::{ThemeUpdateSink, load_startup_theme, watch_theme},
     topology_manager::{initial_window_dojo_identity, run_topology_manager, spawn_topology_smoke},
 };
+
+struct AbortOnDropTask(tokio::task::JoinHandle<()>);
+
+impl AbortOnDropTask {
+    fn new(task: tokio::task::JoinHandle<()>) -> Self {
+        Self(task)
+    }
+
+    fn abort(&self) {
+        self.0.abort();
+    }
+}
+
+impl Drop for AbortOnDropTask {
+    fn drop(&mut self) {
+        self.abort();
+    }
+}
 
 async fn run_graphical_focus_reporter(
     factory: ConnectionFactory,
@@ -171,12 +190,14 @@ async fn run_live_multipane_window_inner(
     let theme = load_startup_theme(&config);
     renderer::configure(RendererOptions {
         font: config.font.clone(),
+        font_authority: config.font_authority,
         font_size: config.font_size,
         font_sizing_policy: config.font_sizing_policy,
         physical_dpi: 96.0,
         padding: config.padding,
         background_alpha: theme.background_alpha,
     })?;
+    let initial_font_generation = Arc::clone(renderer::snapshot_font_generation()?);
     let mut ids = Vec::new();
     layout_splint_ids(&dojo_model.root, &mut ids);
     let image_cache =
@@ -201,13 +222,21 @@ async fn run_live_multipane_window_inner(
         factory.capabilities().forced_control_transfer == ForcedControlTransfer::Enabled;
     let optimistic_remote_splits =
         factory.capabilities().launch_semantics == LaunchSemantics::RemoteInteractive;
-    let theme_task = tokio::spawn(watch_theme(
+    let theme_task = AbortOnDropTask::new(tokio::spawn(watch_theme(
         config.theme_source(),
         config.background_alpha,
         config.background_blur,
         theme,
         ThemeUpdateSink::Topology(topology_update_sender.clone()),
-    ));
+    )));
+    let font_task = (config.font_authority == FontAuthority::NativeOmarchy).then(|| {
+        AbortOnDropTask::new(tokio::spawn(watch_font(
+            config.font.clone(),
+            config.font_authority,
+            initial_font_generation,
+            FontUpdateSink::Topology(topology_update_sender.clone()),
+        )))
+    });
     let mut panes = Vec::with_capacity(prepared.len());
     let mut tasks = HashMap::with_capacity(prepared.len());
     for pane in prepared {
@@ -264,6 +293,9 @@ async fn run_live_multipane_window_inner(
     .await
     .context("Wayland window task failed")?;
     theme_task.abort();
+    if let Some(font_task) = font_task {
+        font_task.abort();
+    }
     if let Some(smoke) = topology_smoke {
         smoke.await.context("topology smoke task failed")??;
     }
@@ -286,12 +318,14 @@ pub(super) async fn run_live_window(
     let theme = load_startup_theme(&config);
     renderer::configure(RendererOptions {
         font: config.font.clone(),
+        font_authority: config.font_authority,
         font_size: config.font_size,
         font_sizing_policy: config.font_sizing_policy,
         physical_dpi: 96.0,
         padding: config.padding,
         background_alpha: theme.background_alpha,
     })?;
+    let initial_font_generation = Arc::clone(renderer::snapshot_font_generation()?);
     let mut connection = factory.connect().await?;
     let terminal_grid_limits = terminal_grid_limits(connection.limits());
     let incarnation = connection.live_incarnation(splint_id).await?;
@@ -339,13 +373,21 @@ pub(super) async fn run_live_window(
         println!("Controller lease {controller_id} granted for live Splint");
     }
     let (updates, receiver) = mpsc::channel(WINDOW_UPDATE_QUEUE);
-    let _theme_watcher = tokio::spawn(watch_theme(
+    let _theme_watcher = AbortOnDropTask::new(tokio::spawn(watch_theme(
         config.theme_source(),
         config.background_alpha,
         config.background_blur,
         theme,
         ThemeUpdateSink::Panes(vec![updates.clone()]),
-    ));
+    )));
+    let _font_watcher = (config.font_authority == FontAuthority::NativeOmarchy).then(|| {
+        AbortOnDropTask::new(tokio::spawn(watch_font(
+            config.font.clone(),
+            config.font_authority,
+            initial_font_generation,
+            FontUpdateSink::Panes(vec![updates.clone()]),
+        )))
+    });
     let (command_sender, commands) = mpsc::channel(WINDOW_COMMAND_QUEUE);
     let (resync_sender, mut resyncs) = mpsc::channel(1);
     let controller_cancellation = tokio_util::sync::CancellationToken::new();
@@ -616,7 +658,7 @@ pub(super) async fn run_live_window(
 
 #[cfg(test)]
 mod tests {
-    use super::resolved_window_app_id;
+    use super::{AbortOnDropTask, resolved_window_app_id};
 
     #[test]
     fn xdg_window_identity_defaults_and_preserves_exact_override() {
@@ -625,5 +667,18 @@ mod tests {
             resolved_window_app_id(Some("org.omarchy.screensaver".to_owned())),
             "org.omarchy.screensaver"
         );
+    }
+
+    #[tokio::test]
+    async fn watcher_tasks_abort_on_scope_exit() {
+        let (sender, receiver) = tokio::sync::oneshot::channel::<()>();
+        let watcher = AbortOnDropTask::new(tokio::spawn(async move {
+            std::future::pending::<()>().await;
+            let _ = sender.send(());
+        }));
+
+        drop(watcher);
+
+        assert!(receiver.await.is_err());
     }
 }

--- a/crates/splinterm/src/bin/final-buffer-capture.rs
+++ b/crates/splinterm/src/bin/final-buffer-capture.rs
@@ -4,7 +4,7 @@ use anyhow::{Context, Result, bail};
 use clap::Parser;
 use serde::Deserialize;
 use splinterm::{
-    config::CursorStyle,
+    config::{CursorStyle, FontAuthority},
     geometry::{FontSize, FontSizingPolicy, TerminalPadding, resolve_font_size},
     renderer::{
         CursorPresentation, RendererOptions, UnfocusedCursorStyle, capture_final_buffer,
@@ -328,6 +328,7 @@ fn main() -> Result<()> {
     )?;
     configure(RendererOptions {
         font: arguments.font.clone(),
+        font_authority: FontAuthority::Explicit,
         font_size,
         font_sizing_policy,
         physical_dpi: arguments.physical_dpi,

--- a/crates/splinterm/src/config.rs
+++ b/crates/splinterm/src/config.rs
@@ -28,10 +28,19 @@ use crate::{
 
 pub const APP_ID: &str = "com.oldjobobo.splinterm";
 pub const DEFAULT_FONT: &str = "monospace:style=Regular";
+pub const STARTUP_FONT_FALLBACK: &str = "JetBrains Mono Nerd Font:style=Regular";
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum FontAuthority {
+    #[default]
+    NativeOmarchy,
+    Explicit,
+}
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct AppConfig {
     pub font: String,
+    pub font_authority: FontAuthority,
     pub font_size: FontSize,
     pub font_sizing_policy: FontSizingPolicy,
     pub padding: TerminalPadding,
@@ -111,6 +120,7 @@ impl Default for AppConfig {
     fn default() -> Self {
         Self {
             font: DEFAULT_FONT.to_owned(),
+            font_authority: FontAuthority::NativeOmarchy,
             font_size: FontSize::Pixels(14.0),
             font_sizing_policy: FontSizingPolicy::OutputScale,
             padding: TerminalPadding::DEFAULT,
@@ -266,6 +276,7 @@ fn parse_with_base(text: &str, config_dir: &Path) -> Result<ConfigLoad> {
                     );
                 }
                 config.font = font;
+                config.font_authority = FontAuthority::Explicit;
                 false
             }
             "main.font-size" | "font-size" | "main.font-pixelsize" => {
@@ -1053,6 +1064,7 @@ mod tests {
     fn defaults_match_foot_font_and_resize_behavior() {
         let defaults = AppConfig::default();
         assert_eq!(defaults.font, "monospace:style=Regular");
+        assert_eq!(defaults.font_authority, FontAuthority::NativeOmarchy);
         assert_eq!(defaults.font_size, FontSize::Pixels(14.0));
         assert_eq!(defaults.resize_delay_ms, 100);
         assert_eq!(defaults.keymap_profile, KeymapProfile::Splinterm);
@@ -1121,6 +1133,13 @@ mod tests {
         let unknown = parse("[multiplexer]\npersistence-by-default=no\n").unwrap();
         assert_eq!(unknown.diagnostics.len(), 1);
         assert!(unknown.diagnostics[0].contains("multiplexer.persistence-by-default"));
+    }
+
+    #[test]
+    fn explicit_monospace_pattern_retains_explicit_authority() {
+        let loaded = parse("[main]\nfont=monospace:style=Regular\n").unwrap();
+        assert_eq!(loaded.config.font, "monospace:style=Regular");
+        assert_eq!(loaded.config.font_authority, FontAuthority::Explicit);
     }
 
     #[test]

--- a/crates/splinterm/src/frontend/message.rs
+++ b/crates/splinterm/src/frontend/message.rs
@@ -1,12 +1,14 @@
 //! Bounded messages exchanged by the application owner and graphical adapter.
 
+use std::sync::Arc;
+
 use splinterm_automation_client::ImageContentLeaseSet;
 use splinterm_core::SplintId;
 use splinterm_protocol::{
     ControlTransferDecision, ControlTransferOutcome, SearchPage, TerminalSnapshot, TerminalUpdate,
 };
 
-use crate::config::ResolvedTheme;
+use crate::{config::ResolvedTheme, renderer::FontGeneration};
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct AuthorityStatus {
@@ -49,6 +51,7 @@ pub enum WindowUpdate {
     SearchResults(SearchPage),
     SearchResyncRequired,
     Theme(ThemeUpdate),
+    Font(FontUpdate),
     Exited {
         splint_id: SplintId,
     },
@@ -59,6 +62,11 @@ pub enum WindowUpdate {
 pub struct ThemeUpdate {
     pub generation: u64,
     pub theme: ResolvedTheme,
+}
+
+#[derive(Clone, Debug)]
+pub struct FontUpdate {
+    pub generation: Arc<FontGeneration>,
 }
 
 /// Bounded Wayland-to-protocol commands for the first interactive slice.

--- a/crates/splinterm/src/frontend/mod.rs
+++ b/crates/splinterm/src/frontend/mod.rs
@@ -18,7 +18,7 @@ pub(crate) use action_menu::{
 };
 pub(crate) use binding_help::{BINDING_HELP_PAGE_ITEMS, BindingHelpUi};
 pub use message::{
-    AuthorityStatus, PerfTraceCorrelation, ThemeUpdate, WindowCommand, WindowUpdate,
+    AuthorityStatus, FontUpdate, PerfTraceCorrelation, ThemeUpdate, WindowCommand, WindowUpdate,
 };
 pub use options::{TerminalGridLimits, TrustedConsentUi, WindowOptions, WindowPaneOptions};
 pub(crate) use picker::PickerHitTarget;

--- a/crates/splinterm/src/frontend/topology.rs
+++ b/crates/splinterm/src/frontend/topology.rs
@@ -7,7 +7,7 @@ use splinterm_core::{
 };
 use splinterm_protocol::{MutationTarget, PresetDojoLaunch, PresetTarget};
 
-use super::{SessionPickerItem, ThemeUpdate, WindowPaneOptions};
+use super::{FontUpdate, SessionPickerItem, ThemeUpdate, WindowPaneOptions};
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct WindowDojoIdentity {
@@ -188,6 +188,7 @@ pub enum WindowTopologyUpdate {
     },
     SessionPickerFailed(String),
     Theme(ThemeUpdate),
+    Font(FontUpdate),
     Closed,
     Shutdown(String),
 }

--- a/crates/splinterm/src/lib.rs
+++ b/crates/splinterm/src/lib.rs
@@ -28,9 +28,9 @@ pub mod viewport;
 pub mod wayland;
 
 pub use frontend::{
-    AuthorityStatus, LairDirection, LairPromptKind, LairPromptTarget, PerfTraceCorrelation,
-    SelectorKind, SessionPickerDecision, SessionPickerItem, SessionPickerUi, TerminalGridLimits,
-    ThemeUpdate, TrustedConsentUi, WindowCommand, WindowDojoIdentity, WindowOptions,
-    WindowPaneOptions, WindowTopologyCommand, WindowTopologyUpdate, WindowUpdate,
+    AuthorityStatus, FontUpdate, LairDirection, LairPromptKind, LairPromptTarget,
+    PerfTraceCorrelation, SelectorKind, SessionPickerDecision, SessionPickerItem, SessionPickerUi,
+    TerminalGridLimits, ThemeUpdate, TrustedConsentUi, WindowCommand, WindowDojoIdentity,
+    WindowOptions, WindowPaneOptions, WindowTopologyCommand, WindowTopologyUpdate, WindowUpdate,
 };
 pub use wayland::run as run_window;

--- a/crates/splinterm/src/renderer.rs
+++ b/crates/splinterm/src/renderer.rs
@@ -69,7 +69,7 @@ use decorations::DecorationMetrics;
 #[cfg(test)]
 use decorations::DecorationSpan;
 pub use evidence::{benchmark_json, phase4_benchmark_json, write_ppm};
-pub(super) use fonts::*;
+pub use fonts::*;
 pub use fonts::{ascii_glyph_evidence, production_ascii_glyph_evidence, snapshot_cache_metrics};
 pub(crate) use frame::SnapshotFrame;
 use frame::{SnapshotGlyph, packed_rgb};

--- a/crates/splinterm/src/renderer/fonts.rs
+++ b/crates/splinterm/src/renderer/fonts.rs
@@ -3,23 +3,30 @@
 use std::{
     cell::RefCell,
     collections::{HashMap, HashSet, VecDeque},
+    os::unix::fs::MetadataExt,
     path::PathBuf,
     process::Command,
-    sync::{Arc, OnceLock},
+    sync::{
+        Arc, OnceLock,
+        atomic::{AtomicU64, Ordering},
+    },
     time::Instant,
 };
 
 use anyhow::{Context, Result, bail};
-use splinterm_filemap::ReadOnlyFileMap;
-use splinterm_freetype::RasterFace;
+use splinterm_filemap::{FileIdentity, ReadOnlyFileMap};
+use splinterm_freetype::{MAX_STAGED_FONT_BYTES, RasterFace};
 use swash::{
-    FontRef,
+    FontRef, NormalizedCoord,
     scale::{Render, ScaleContext, Source, StrikeWith, image::Content},
     shape::ShapeContext,
     zeno::Format,
 };
 
-use crate::box_drawing;
+use crate::{
+    box_drawing,
+    config::{FontAuthority, STARTUP_FONT_FALLBACK},
+};
 
 use super::raster::{blend_glyph, fill_rect};
 use super::{BASE_FONT_SIZE, PRIMARY_FONT, effective_font_size, renderer_options};
@@ -41,19 +48,24 @@ pub(super) const SNAPSHOT_CJK: usize = 4;
 pub(super) const SNAPSHOT_EMOJI: usize = 5;
 pub(super) const SNAPSHOT_FALLBACK_START: usize = 6;
 
-pub(super) static SNAPSHOT_FACES: OnceLock<Result<Vec<FontFace>, String>> = OnceLock::new();
-
+static NEXT_FONT_GENERATION_ID: AtomicU64 = AtomicU64::new(1);
+pub(super) static SNAPSHOT_FONT_GENERATION: OnceLock<Result<Arc<FontGeneration>, String>> =
+    OnceLock::new();
 #[derive(Default)]
 pub(super) struct PersistentFontMappingCache {
-    pub(super) mappings: HashMap<PathBuf, Arc<ReadOnlyFileMap>>,
-    pub(super) order: VecDeque<PathBuf>,
+    pub(super) mappings: HashMap<(PathBuf, FileIdentity), Arc<ReadOnlyFileMap>>,
+    pub(super) order: VecDeque<(PathBuf, FileIdentity)>,
     pub(super) hits: u64,
     pub(super) misses: u64,
     pub(super) evictions: u64,
 }
 
 impl PersistentFontMappingCache {
-    fn insert(&mut self, key: PathBuf, mapping: Arc<ReadOnlyFileMap>) -> Arc<ReadOnlyFileMap> {
+    fn insert(
+        &mut self,
+        key: (PathBuf, FileIdentity),
+        mapping: Arc<ReadOnlyFileMap>,
+    ) -> Arc<ReadOnlyFileMap> {
         while self.mappings.len() >= SNAPSHOT_FALLBACK_MAPPING_BUDGET {
             let Some(oldest) = self.order.pop_front() else {
                 break;
@@ -70,11 +82,11 @@ impl PersistentFontMappingCache {
 
 #[derive(Default)]
 pub(super) struct PersistentGlyphCache {
-    pub(super) raster_faces: HashMap<(isize, usize), RasterFace>,
-    pub(super) raster_face_order: VecDeque<(isize, usize)>,
-    pub(super) glyphs: HashMap<(isize, GlyphKey), Arc<CachedGlyph>>,
-    pub(super) advances: HashMap<(isize, GlyphKey), i32>,
-    pub(super) order: VecDeque<(isize, GlyphKey)>,
+    pub(super) raster_faces: HashMap<(u64, isize, usize), RasterFace>,
+    pub(super) raster_face_order: VecDeque<(u64, isize, usize)>,
+    pub(super) glyphs: HashMap<(u64, isize, GlyphKey), Arc<CachedGlyph>>,
+    pub(super) advances: HashMap<(u64, isize, GlyphKey), i32>,
+    pub(super) order: VecDeque<(u64, isize, GlyphKey)>,
     pub(super) glyph_bytes: usize,
     pub(super) hits: u64,
     pub(super) misses: u64,
@@ -85,7 +97,7 @@ pub(super) struct PersistentGlyphCache {
 impl PersistentGlyphCache {
     pub(super) fn insert_glyph(
         &mut self,
-        cache_key: (isize, GlyphKey),
+        cache_key: (u64, isize, GlyphKey),
         glyph: Arc<CachedGlyph>,
         color_advance: Option<i32>,
     ) {
@@ -100,7 +112,7 @@ impl PersistentGlyphCache {
 
     pub(super) fn insert_glyph_bounded(
         &mut self,
-        cache_key: (isize, GlyphKey),
+        cache_key: (u64, isize, GlyphKey),
         glyph: Arc<CachedGlyph>,
         color_advance: Option<i32>,
         entry_budget: usize,
@@ -128,7 +140,7 @@ impl PersistentGlyphCache {
         self.glyphs.insert(cache_key, glyph);
     }
 
-    pub(super) fn prepare_raster_face_insert(&mut self, raster_key: (isize, usize)) {
+    pub(super) fn prepare_raster_face_insert(&mut self, raster_key: (u64, isize, usize)) {
         while self.raster_faces.len() >= SNAPSHOT_RASTER_FACE_BUDGET {
             let Some(oldest) = self.raster_face_order.pop_front() else {
                 break;
@@ -148,7 +160,7 @@ thread_local! {
         RefCell::new(PersistentFontMappingCache::default());
 }
 
-pub(super) fn clear_snapshot_caches() {
+pub(crate) fn clear_snapshot_caches() {
     SNAPSHOT_GLYPH_CACHE.with(|cache| *cache.borrow_mut() = PersistentGlyphCache::default());
     SNAPSHOT_FALLBACK_MAPPING_CACHE.with(|cache| {
         *cache.borrow_mut() = PersistentFontMappingCache::default();
@@ -182,18 +194,104 @@ pub(super) struct GlyphKey {
 
 pub(super) const BOX_DRAWING_FACE: usize = usize::MAX;
 
+/// Fontconfig exposes `FC_INDEX` using `FreeType`'s packed face index: the low
+/// 16 bits select a face in a collection and bits 16-30 select a one-based
+/// named variable instance. Swash expects only the collection index.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub(super) struct FontconfigFaceIndex(u32);
+
+impl FontconfigFaceIndex {
+    const COLLECTION_MASK: u32 = 0xffff;
+    const NAMED_INSTANCE_MASK: u32 = 0x7fff;
+
+    const fn new(raw: u32) -> Self {
+        Self(raw)
+    }
+
+    fn from_fontconfig(raw: u32) -> Result<Self> {
+        anyhow::ensure!(
+            raw & 0x8000_0000 == 0,
+            "Fontconfig face index sets reserved bit 31"
+        );
+        Ok(Self::new(raw))
+    }
+
+    pub(super) const fn raw(self) -> u32 {
+        self.0
+    }
+
+    pub(super) const fn collection_index(self) -> usize {
+        (self.0 & Self::COLLECTION_MASK) as usize
+    }
+
+    const fn named_instance_index(self) -> Option<usize> {
+        let one_based = (self.0 >> 16) & Self::NAMED_INSTANCE_MASK;
+        if one_based == 0 {
+            None
+        } else {
+            Some((one_based - 1) as usize)
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(super) struct FontFaceFingerprint {
+    pub(super) family: String,
+    pub(super) style: String,
+    pub(super) path: PathBuf,
+    pub(super) index: u32,
+    pub(super) weight: i32,
+    pub(super) slant: i32,
+    pub(super) selected_pixel_size_26_6: isize,
+    pub(super) source_identity: FileIdentity,
+}
+
+#[doc(hidden)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct FontFingerprint {
+    pub(super) pattern: String,
+    pub(super) authority: FontAuthority,
+    pub(super) faces: Vec<FontFaceFingerprint>,
+}
+
+#[doc(hidden)]
+#[derive(Debug)]
+pub struct FontGeneration {
+    pub(super) id: u64,
+    pub(super) fingerprint: FontFingerprint,
+    pub(super) faces: Vec<FontFace>,
+}
+
+impl FontGeneration {
+    /// Returns the process-local monotonic generation identity.
+    #[must_use]
+    pub const fn id(&self) -> u64 {
+        self.id
+    }
+
+    /// Returns the stable effective source fingerprint.
+    #[must_use]
+    pub const fn fingerprint(&self) -> &FontFingerprint {
+        &self.fingerprint
+    }
+}
+
+#[derive(Debug)]
 pub(super) struct FontFace {
     pub(super) label: &'static str,
     pub(super) family: String,
     pub(super) style: String,
     pub(super) path: PathBuf,
-    pub(super) index: usize,
+    pub(super) index: FontconfigFaceIndex,
     pub(super) weight: i32,
     pub(super) slant: i32,
+    pub(super) generation_id: u64,
     pub(super) selected_pixel_size_26_6: isize,
+    pub(super) source_identity: FileIdentity,
     pub(super) outline: bool,
     pub(super) coverage: Box<[(u32, u32)]>,
-    pub(super) data: Option<OnceLock<Result<ReadOnlyFileMap, String>>>,
+    pub(super) data: Option<Arc<ReadOnlyFileMap>>,
+    normalized_coords: OnceLock<Result<Box<[NormalizedCoord]>, String>>,
 }
 
 impl FontFace {
@@ -206,15 +304,18 @@ impl FontFace {
             index: self.index,
             weight: self.weight,
             slant: self.slant,
+            generation_id: self.generation_id,
             selected_pixel_size_26_6: self.selected_pixel_size_26_6,
+            source_identity: self.source_identity,
             outline: self.outline,
             coverage: self.coverage.clone(),
-            data: Some(OnceLock::new()),
+            data: self.data.clone(),
+            normalized_coords: OnceLock::new(),
         }
     }
 
-    fn identity(&self) -> (&std::path::Path, usize) {
-        (&self.path, self.index)
+    fn identity(&self) -> (&std::path::Path, u32) {
+        (&self.path, self.index.raw())
     }
 
     pub(super) fn covers_text(&self, text: &str) -> bool {
@@ -224,6 +325,19 @@ impl FontFace {
                 .iter()
                 .any(|(start, end)| (*start..=*end).contains(&codepoint))
         })
+    }
+
+    fn fingerprint(&self) -> FontFaceFingerprint {
+        FontFaceFingerprint {
+            family: self.family.clone(),
+            style: self.style.clone(),
+            path: self.path.clone(),
+            index: self.index.raw(),
+            weight: self.weight,
+            slant: self.slant,
+            selected_pixel_size_26_6: self.selected_pixel_size_26_6,
+            source_identity: self.source_identity,
+        }
     }
 }
 
@@ -320,7 +434,7 @@ impl TextRow {
             .checked_mul(i32::try_from(integer_scale).context("integer scale fits i32")?)
             .context("scaled row y overflow")?;
         let started = Instant::now();
-        let [primary, _, _, _] = resolve_primary_faces(PRIMARY_FONT)?;
+        let [primary, _, _, _] = resolve_primary_faces(PRIMARY_FONT, FontAuthority::Explicit)?;
         let faces = [
             primary,
             resolve_face("CJK fallback", CJK_FONT, "noto sans cjk")?,
@@ -353,9 +467,13 @@ impl TextRow {
             }
             if *kind == CorpusKind::Combining {
                 let face_index = 0;
-                let font = font_ref(&faces[face_index])?;
+                let (font, coords) = font_ref_with_coords(&faces[face_index])?;
                 let mut shaped_glyphs = Vec::new();
-                let mut shaper = shape_context.builder(font).size(font_size).build();
+                let mut shaper = shape_context
+                    .builder(font)
+                    .size(font_size)
+                    .normalized_coords(coords)
+                    .build();
                 shaper.add_str(text);
                 shaper.shape_with(|cluster| {
                     let cluster_advance = cluster.advance();
@@ -438,9 +556,9 @@ impl TextRow {
                     continue;
                 }
                 let (face_index, glyph_id) = select_glyph(&faces, *kind, character)?;
-                let font = font_ref(&faces[face_index])?;
+                let (font, coords) = font_ref_with_coords(&faces[face_index])?;
                 let advance = font
-                    .glyph_metrics(&[])
+                    .glyph_metrics(coords)
                     .scale(font_size)
                     .advance_width(glyph_id);
                 let raster_started = Instant::now();
@@ -509,8 +627,13 @@ pub(super) fn cache_glyph(
     if cache.contains_key(&key) {
         return Ok(());
     }
-    let font = font_ref(&faces[face_index])?;
-    let mut scaler = context.builder(font).size(font_size).hint(true).build();
+    let (font, coords) = font_ref_with_coords(&faces[face_index])?;
+    let mut scaler = context
+        .builder(font)
+        .size(font_size)
+        .hint(true)
+        .normalized_coords(coords)
+        .build();
     let image = Render::new(&[
         Source::ColorOutline(0),
         Source::ColorBitmap(StrikeWith::BestFit),
@@ -544,38 +667,25 @@ pub(super) fn cache_glyph(
     Ok(())
 }
 
-pub(super) fn snapshot_faces() -> Result<&'static [FontFace]> {
-    SNAPSHOT_FACES
+/// Returns the configured immutable startup generation.
+///
+/// # Errors
+/// Returns the retained startup staging failure.
+#[doc(hidden)]
+pub fn snapshot_font_generation() -> Result<&'static Arc<FontGeneration>> {
+    SNAPSHOT_FONT_GENERATION
         .get_or_init(|| {
-            let primary_pattern = &renderer_options().font;
-            let [regular, bold, italic, bold_italic] =
-                resolve_primary_faces(primary_pattern).map_err(|error| error.to_string())?;
-            let mut faces = Vec::from([
-                regular,
-                bold,
-                italic,
-                bold_italic,
-                resolve_face("CJK fallback", CJK_FONT, "noto sans cjk")
-                    .map_err(|error| error.to_string())?,
-                resolve_face("emoji fallback", EMOJI_FONT, "noto color emoji")
-                    .map_err(|error| error.to_string())?,
-            ]);
-            let excluded = faces
-                .iter()
-                .map(|face| (face.path.clone(), face.index))
-                .collect::<HashSet<_>>();
-            let fallback_faces = resolve_fallback_faces(primary_pattern, &excluded)
-                .map_err(|error| error.to_string())?;
-            eprintln!(
-                "Resolved {} ordered Fontconfig fallback faces",
-                fallback_faces.len()
-            );
-            faces.extend(fallback_faces);
-            Ok(faces)
+            let options = renderer_options();
+            stage_startup_font_generation(&options.font, options.font_authority)
+                .map(Arc::new)
+                .map_err(|error| error.to_string())
         })
         .as_ref()
-        .map(Vec::as_slice)
         .map_err(|error| anyhow::anyhow!(error.clone()))
+}
+
+pub(super) fn snapshot_faces() -> Result<&'static [FontFace]> {
+    Ok(&snapshot_font_generation()?.faces)
 }
 
 pub(super) fn snapshot_glyph(
@@ -585,27 +695,48 @@ pub(super) fn snapshot_glyph(
     font_size: f32,
 ) -> Result<Arc<CachedGlyph>> {
     let effective_size_26_6 = pixel_size_26_6(font_size)?;
+    let generation_id = faces
+        .get(face_index)
+        .context("glyph face index is in the active font generation")?
+        .generation_id;
     let key = GlyphKey {
         face: face_index,
         glyph: glyph_id,
     };
     SNAPSHOT_GLYPH_CACHE.with(|cache| {
         let mut cache = cache.borrow_mut();
-        if let Some(glyph) = cache.glyphs.get(&(effective_size_26_6, key)).cloned() {
+        if let Some(glyph) = cache
+            .glyphs
+            .get(&(generation_id, effective_size_26_6, key))
+            .cloned()
+        {
             cache.hits = cache.hits.saturating_add(1);
             return Ok(glyph);
         }
         cache.misses = cache.misses.saturating_add(1);
         let (glyph, color_advance) = if face_index == SNAPSHOT_EMOJI {
             let face = &faces[face_index];
-            let raster = RasterFace::rasterize_color(
-                &face.path,
-                u32::try_from(face.index).context("emoji face index fits u32")?,
-                effective_size_26_6,
-                face.selected_pixel_size_26_6,
-                u32::from(glyph_id),
-            )
-            .with_context(|| format!("rasterize color snapshot glyph {glyph_id}"))?;
+            let raster_key = (generation_id, face.selected_pixel_size_26_6, face_index);
+            if !cache.raster_faces.contains_key(&raster_key) {
+                let raster_face = RasterFace::open_memory(
+                    face.data.as_deref().context("emoji face is staged")?,
+                    face.index.raw(),
+                    face.selected_pixel_size_26_6,
+                )
+                .context("open staged emoji raster face")?;
+                cache.prepare_raster_face_insert(raster_key);
+                cache.raster_faces.insert(raster_key, raster_face);
+            }
+            let raster = cache
+                .raster_faces
+                .get_mut(&raster_key)
+                .context("inserted emoji raster face remains present")?
+                .rasterize_color_glyph(
+                    effective_size_26_6,
+                    face.selected_pixel_size_26_6,
+                    u32::from(glyph_id),
+                )
+                .with_context(|| format!("rasterize color snapshot glyph {glyph_id}"))?;
             (
                 CachedGlyph {
                     content: Content::Color,
@@ -618,16 +749,19 @@ pub(super) fn snapshot_glyph(
                 Some(raster.advance_x),
             )
         } else {
-            let raster_key = (effective_size_26_6, face_index);
+            let raster_key = (generation_id, effective_size_26_6, face_index);
             if !cache.raster_faces.contains_key(&raster_key) {
-                let raster_face = RasterFace::open(
-                    &faces[face_index].path,
-                    u32::try_from(faces[face_index].index).context("face index fits u32")?,
-                    pixel_size_26_6(font_size)?,
-                )
-                .with_context(|| {
-                    format!("open FreeType raster face {}", faces[face_index].label)
-                })?;
+                let face = &faces[face_index];
+                let pixel_size = pixel_size_26_6(font_size)?;
+                let fallback_mapping;
+                let data = if let Some(data) = face.data.as_deref() {
+                    data
+                } else {
+                    fallback_mapping = fallback_font_mapping(face)?;
+                    &fallback_mapping
+                };
+                let raster_face = RasterFace::open_memory(data, face.index.raw(), pixel_size)
+                    .with_context(|| format!("open FreeType raster face {}", face.label))?;
                 cache.prepare_raster_face_insert(raster_key);
                 cache.raster_faces.insert(raster_key, raster_face);
             }
@@ -651,7 +785,7 @@ pub(super) fn snapshot_glyph(
         };
         let glyph = Arc::new(glyph);
         cache.insert_glyph(
-            (effective_size_26_6, key),
+            (generation_id, effective_size_26_6, key),
             Arc::clone(&glyph),
             color_advance,
         );
@@ -672,17 +806,28 @@ pub(super) fn pixel_size_26_6(font_size: f32) -> Result<isize> {
 }
 
 pub(super) fn snapshot_color_advance(
+    faces: &[FontFace],
     face_index: usize,
     glyph_id: u16,
     font_size: f32,
 ) -> Result<i32> {
     let cache_key = (
+        faces
+            .get(face_index)
+            .context("color face index is in the active font generation")?
+            .generation_id,
         pixel_size_26_6(font_size)?,
         GlyphKey {
             face: face_index,
             glyph: glyph_id,
         },
     );
+    if let Some(advance) =
+        SNAPSHOT_GLYPH_CACHE.with(|cache| cache.borrow().advances.get(&cache_key).copied())
+    {
+        return Ok(advance);
+    }
+    snapshot_glyph(faces, face_index, glyph_id, font_size)?;
     SNAPSHOT_GLYPH_CACHE.with(|cache| {
         cache
             .borrow()
@@ -764,13 +909,13 @@ pub fn snapshot_cache_metrics() -> serde_json::Value {
 pub fn ascii_glyph_evidence() -> Result<Vec<serde_json::Value>> {
     let face = resolve_face("ASCII evidence", &renderer_options().font, "")?;
     let font_size = effective_font_size(120)?;
-    let font = font_ref(&face)?;
-    let metrics = font.metrics(&[]).scale(font_size);
+    let (font, coords) = font_ref_with_coords(&face)?;
+    let metrics = font.metrics(coords).scale(font_size);
     let font_ascent = ceil_to_i32(metrics.ascent);
     let font_descent = ceil_to_i32(metrics.descent);
     let resolved_metrics = cell_metrics(&face, font_size)?;
     let font_height = i32::try_from(resolved_metrics.height).context("font height fits i32")?;
-    let glyph_metrics = font.glyph_metrics(&[]).scale(font_size);
+    let glyph_metrics = font.glyph_metrics(coords).scale(font_size);
     let mut context = ScaleContext::new();
     let mut records = Vec::with_capacity(95);
 
@@ -778,7 +923,12 @@ pub fn ascii_glyph_evidence() -> Result<Vec<serde_json::Value>> {
         let character = char::from_u32(codepoint).context("printable ASCII is valid Unicode")?;
         let glyph_id = font.charmap().map(character);
         let advance = positive_round_to_u32(glyph_metrics.advance_width(glyph_id));
-        let mut scaler = context.builder(font).size(font_size).hint(true).build();
+        let mut scaler = context
+            .builder(font)
+            .size(font_size)
+            .hint(true)
+            .normalized_coords(coords)
+            .build();
         let rendered = Render::new(&[
             Source::ColorOutline(0),
             Source::ColorBitmap(StrikeWith::BestFit),
@@ -819,7 +969,7 @@ pub fn ascii_glyph_evidence() -> Result<Vec<serde_json::Value>> {
             "glyph_id": glyph_id,
             "font": face.family.as_str(),
             "font_path": face.path.display().to_string(),
-            "font_index": face.index,
+            "font_index": face.index.raw(),
             "font_ascent": font_ascent,
             "font_descent": font_descent,
             "font_height": font_height,
@@ -873,9 +1023,9 @@ pub fn production_ascii_glyph_evidence() -> Result<Vec<serde_json::Value>> {
         value.parse().context("parse evidence scale")
     })?;
     let font_size = effective_font_size(scale_120)?;
-    let font = font_ref(face)?;
+    let (font, coords) = font_ref_with_coords(face)?;
     let metrics = cell_metrics(face, font_size)?;
-    let glyph_metrics = font.glyph_metrics(&[]).scale(font_size);
+    let glyph_metrics = font.glyph_metrics(coords).scale(font_size);
     let mut records = Vec::with_capacity(96);
     for codepoint in 0x20_u32..=0x7e {
         let character = char::from_u32(codepoint).context("printable ASCII is valid Unicode")?;
@@ -896,7 +1046,7 @@ pub fn production_ascii_glyph_evidence() -> Result<Vec<serde_json::Value>> {
             "glyph_id": glyph_id,
             "font": face.family.as_str(),
             "font_path": face.path.display().to_string(),
-            "font_index": face.index,
+            "font_index": face.index.raw(),
             "font_ascent": metrics.ascent,
             "font_descent": metrics.descent,
             "font_height": metrics.font_height,
@@ -927,7 +1077,7 @@ pub fn production_ascii_glyph_evidence() -> Result<Vec<serde_json::Value>> {
 
     let codepoint = 0x754c;
     let fallback_face = &faces[SNAPSHOT_CJK];
-    let fallback_font = font_ref(fallback_face)?;
+    let (fallback_font, fallback_coords) = font_ref_with_coords(fallback_face)?;
     let glyph_id = fallback_font
         .charmap()
         .map(char::from_u32(codepoint).context("CJK codepoint")?);
@@ -938,7 +1088,9 @@ pub fn production_ascii_glyph_evidence() -> Result<Vec<serde_json::Value>> {
         right: 0,
         bottom: 0,
     });
-    let fallback_metrics = fallback_font.glyph_metrics(&[]).scale(font_size);
+    let fallback_metrics = fallback_font
+        .glyph_metrics(fallback_coords)
+        .scale(font_size);
     records.push(serde_json::json!({
         "schema": 1,
         "label": "CJK",
@@ -947,7 +1099,7 @@ pub fn production_ascii_glyph_evidence() -> Result<Vec<serde_json::Value>> {
         "glyph_id": glyph_id,
         "font": fallback_face.family.as_str(),
         "font_path": fallback_face.path.display().to_string(),
-        "font_index": fallback_face.index,
+        "font_index": fallback_face.index.raw(),
         "font_ascent": metrics.ascent,
         "font_descent": metrics.descent,
         "font_height": metrics.font_height,
@@ -988,7 +1140,7 @@ pub fn production_ascii_glyph_evidence() -> Result<Vec<serde_json::Value>> {
         right: 0,
         bottom: 0,
     });
-    let emoji_advance = snapshot_color_advance(SNAPSHOT_EMOJI, glyph_id, font_size)?;
+    let emoji_advance = snapshot_color_advance(faces, SNAPSHOT_EMOJI, glyph_id, font_size)?;
     records.push(serde_json::json!({
         "schema": 1,
         "label": "emoji",
@@ -997,7 +1149,7 @@ pub fn production_ascii_glyph_evidence() -> Result<Vec<serde_json::Value>> {
         "glyph_id": glyph_id,
         "font": emoji_face.family.as_str(),
         "font_path": emoji_face.path.display().to_string(),
-        "font_index": emoji_face.index,
+        "font_index": emoji_face.index.raw(),
         "font_ascent": metrics.ascent,
         "font_descent": metrics.descent,
         "font_height": metrics.font_height,
@@ -1025,7 +1177,11 @@ pub fn production_ascii_glyph_evidence() -> Result<Vec<serde_json::Value>> {
 
     let mut shaped_glyphs = Vec::new();
     let mut shape_context = ShapeContext::new();
-    let mut shaper = shape_context.builder(font).size(font_size).build();
+    let mut shaper = shape_context
+        .builder(font)
+        .size(font_size)
+        .normalized_coords(coords)
+        .build();
     shaper.add_str("e\u{301}");
     shaper.shape_with(|cluster| {
         let mut pen = 0.0;
@@ -1057,7 +1213,7 @@ pub fn production_ascii_glyph_evidence() -> Result<Vec<serde_json::Value>> {
         "glyph_id": glyph_id,
         "font": face.family.as_str(),
         "font_path": face.path.display().to_string(),
-        "font_index": face.index,
+        "font_index": face.index.raw(),
         "font_ascent": metrics.ascent,
         "font_descent": metrics.descent,
         "font_height": metrics.font_height,
@@ -1129,9 +1285,12 @@ pub(super) struct CellMetrics {
     reason = "the protocol-bounded integer terminal advance is exactly representable in f32"
 )]
 pub(super) fn cell_metrics(primary_face: &FontFace, font_size: f32) -> Result<CellMetrics> {
-    let mut face = RasterFace::open(
-        &primary_face.path,
-        u32::try_from(primary_face.index).context("primary face index")?,
+    let mut face = RasterFace::open_memory(
+        primary_face
+            .data
+            .as_deref()
+            .context("primary face is staged")?,
+        primary_face.index.raw(),
         pixel_size_26_6(font_size)?,
     )
     .context("open primary FreeType face for cell metrics")?;
@@ -1176,6 +1335,36 @@ pub(super) fn ceil_to_i32(value: f32) -> i32 {
     value.ceil() as i32
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct ResolvedFaceSource {
+    label: &'static str,
+    family: String,
+    style: String,
+    path: PathBuf,
+    index: FontconfigFaceIndex,
+    weight: i32,
+    slant: i32,
+    selected_pixel_size_26_6: isize,
+    source_identity: FileIdentity,
+    outline: bool,
+    coverage: Box<[(u32, u32)]>,
+}
+
+impl ResolvedFaceSource {
+    fn fingerprint(&self) -> FontFaceFingerprint {
+        FontFaceFingerprint {
+            family: self.family.clone(),
+            style: self.style.clone(),
+            path: self.path.clone(),
+            index: self.index.raw(),
+            weight: self.weight,
+            slant: self.slant,
+            selected_pixel_size_26_6: self.selected_pixel_size_26_6,
+            source_identity: self.source_identity,
+        }
+    }
+}
+
 const FONTCONFIG_FACE_FORMAT: &str = "%{file}\\n%{index}\\n%{family[0]}\\n%{style}\\n%{weight}\\n%{slant}\\n%{pixelsize}\\n%{outline}\\n%{charset}\\n--record--\\n";
 
 fn parse_fontconfig_charset(value: &str) -> Result<Box<[(u32, u32)]>> {
@@ -1197,7 +1386,7 @@ fn parse_fontconfig_charset(value: &str) -> Result<Box<[(u32, u32)]>> {
         .map(Vec::into_boxed_slice)
 }
 
-fn parse_fontconfig_faces(label: &'static str, stdout: &[u8]) -> Result<Vec<FontFace>> {
+fn parse_fontconfig_sources(label: &'static str, stdout: &[u8]) -> Result<Vec<ResolvedFaceSource>> {
     let stdout = std::str::from_utf8(stdout).context("fc-match output is not UTF-8")?;
     stdout
         .split("--record--\n")
@@ -1209,13 +1398,15 @@ fn parse_fontconfig_faces(label: &'static str, stdout: &[u8]) -> Result<Vec<Font
                     .next()
                     .with_context(|| format!("fc-match returned no font path for {label}"))?,
             );
-            let index = lines
-                .next()
-                .with_context(|| format!("fc-match returned no face index for {label}"))?
-                .parse::<usize>()
-                .with_context(|| {
-                    format!("fc-match returned a non-numeric face index for {label}")
-                })?;
+            let index = FontconfigFaceIndex::from_fontconfig(
+                lines
+                    .next()
+                    .with_context(|| format!("fc-match returned no face index for {label}"))?
+                    .parse::<u32>()
+                    .with_context(|| {
+                        format!("fc-match returned a non-numeric face index for {label}")
+                    })?,
+            )?;
             let family = lines
                 .next()
                 .with_context(|| format!("fc-match returned no font family for {label}"))?
@@ -1252,7 +1443,13 @@ fn parse_fontconfig_faces(label: &'static str, stdout: &[u8]) -> Result<Vec<Font
                     .next()
                     .with_context(|| format!("fc-match returned no charset for {label}"))?,
             )?;
-            Ok(FontFace {
+            let metadata = std::fs::metadata(&path)
+                .with_context(|| format!("inspect resolved {label} font {}", path.display()))?;
+            anyhow::ensure!(
+                metadata.is_file() && metadata.len() > 0,
+                "resolved font is not a non-empty regular file"
+            );
+            Ok(ResolvedFaceSource {
                 label,
                 family,
                 style,
@@ -1261,15 +1458,25 @@ fn parse_fontconfig_faces(label: &'static str, stdout: &[u8]) -> Result<Vec<Font
                 weight,
                 slant,
                 selected_pixel_size_26_6: pixel_size_26_6(selected_pixel_size)?,
+                source_identity: FileIdentity {
+                    device: metadata.dev(),
+                    inode: metadata.ino(),
+                    length: metadata.len(),
+                    modified_seconds: metadata.mtime(),
+                    modified_nanoseconds: metadata.mtime_nsec(),
+                },
                 outline,
                 coverage,
-                data: Some(OnceLock::new()),
             })
         })
         .collect()
 }
 
-fn run_fontconfig_faces(label: &'static str, pattern: &str, sorted: bool) -> Result<Vec<FontFace>> {
+fn run_fontconfig_sources(
+    label: &'static str,
+    pattern: &str,
+    sorted: bool,
+) -> Result<Vec<ResolvedFaceSource>> {
     let mut command = Command::new("fc-match");
     if sorted {
         command.arg("-s");
@@ -1284,7 +1491,97 @@ fn run_fontconfig_faces(label: &'static str, pattern: &str, sorted: bool) -> Res
             String::from_utf8_lossy(&output.stderr)
         );
     }
-    parse_fontconfig_faces(label, &output.stdout)
+    parse_fontconfig_sources(label, &output.stdout)
+}
+
+fn resolve_face_source(
+    label: &'static str,
+    pattern: &str,
+    expected_family_fragment: &str,
+) -> Result<ResolvedFaceSource> {
+    let source = run_fontconfig_sources(label, pattern, false)?
+        .into_iter()
+        .next()
+        .with_context(|| format!("fc-match returned no face for {label}"))?;
+    let normalized_family = normalize_family(&source.family);
+    let normalized_expected = normalize_family(expected_family_fragment);
+    if !normalized_expected.is_empty() && !normalized_family.contains(&normalized_expected) {
+        bail!(
+            "explicit {label} pattern {pattern:?} resolved unexpectedly to {:?}",
+            source.family
+        );
+    }
+    Ok(source)
+}
+
+fn stage_face(source: ResolvedFaceSource) -> Result<FontFace> {
+    let snapshot = ReadOnlyFileMap::immutable_snapshot(&source.path, MAX_STAGED_FONT_BYTES)
+        .with_context(|| format!("snapshot resolved {} font", source.label))?;
+    anyhow::ensure!(
+        snapshot.source_identity == source.source_identity,
+        "resolved font source changed before staging"
+    );
+    let data = Arc::new(snapshot.mapping);
+    let face = FontFace {
+        label: source.label,
+        family: source.family,
+        style: source.style,
+        path: source.path,
+        index: source.index,
+        weight: source.weight,
+        slant: source.slant,
+        generation_id: 0,
+        selected_pixel_size_26_6: source.selected_pixel_size_26_6,
+        source_identity: source.source_identity,
+        outline: source.outline,
+        coverage: source.coverage,
+        data: Some(data),
+        normalized_coords: OnceLock::new(),
+    };
+    font_ref(&face).with_context(|| format!("parse resolved {} font", face.label))?;
+    eprintln!(
+        "Resolved {}: {} {} (face {}, {})",
+        face.label,
+        face.family,
+        face.style,
+        face.index.raw(),
+        face.path.display()
+    );
+    Ok(face)
+}
+
+fn unstaged_fallback_face(source: ResolvedFaceSource) -> FontFace {
+    FontFace {
+        label: source.label,
+        family: source.family,
+        style: source.style,
+        path: source.path,
+        index: source.index,
+        weight: source.weight,
+        slant: source.slant,
+        generation_id: 0,
+        selected_pixel_size_26_6: source.selected_pixel_size_26_6,
+        source_identity: source.source_identity,
+        outline: source.outline,
+        coverage: source.coverage,
+        data: None,
+        normalized_coords: OnceLock::new(),
+    }
+}
+
+fn resolve_fallback_sources(
+    pattern: &str,
+    excluded: &HashSet<(PathBuf, FontconfigFaceIndex)>,
+) -> Result<Vec<ResolvedFaceSource>> {
+    let mut identities = excluded.clone();
+    Ok(
+        run_fontconfig_sources("fontconfig fallback", pattern, true)?
+            .into_iter()
+            .filter(|source| {
+                source.outline && identities.insert((source.path.clone(), source.index))
+            })
+            .collect(),
+    )
 }
 
 pub(super) fn resolve_face(
@@ -1292,41 +1589,11 @@ pub(super) fn resolve_face(
     pattern: &str,
     expected_family_fragment: &str,
 ) -> Result<FontFace> {
-    let face = run_fontconfig_faces(label, pattern, false)?
-        .into_iter()
-        .next()
-        .with_context(|| format!("fc-match returned no face for {label}"))?;
-    let normalized_family = normalize_family(&face.family);
-    let normalized_expected = normalize_family(expected_family_fragment);
-    if !normalized_expected.is_empty() && !normalized_family.contains(&normalized_expected) {
-        bail!(
-            "explicit {label} pattern {pattern:?} resolved unexpectedly to {:?}",
-            face.family
-        );
-    }
-    eprintln!(
-        "Resolved {label}: {} {} (face {}, {})",
-        face.family,
-        face.style,
-        face.index,
-        face.path.display()
-    );
-    Ok(face)
-}
-
-fn resolve_fallback_faces(
-    pattern: &str,
-    excluded: &HashSet<(PathBuf, usize)>,
-) -> Result<Vec<FontFace>> {
-    let mut identities = excluded.clone();
-    Ok(run_fontconfig_faces("fontconfig fallback", pattern, true)?
-        .into_iter()
-        .filter(|face| face.outline && identities.insert((face.path.clone(), face.index)))
-        .map(|mut face| {
-            face.data = None;
-            face
-        })
-        .collect())
+    stage_face(resolve_face_source(
+        label,
+        pattern,
+        expected_family_fragment,
+    )?)
 }
 
 #[derive(Clone, Copy)]
@@ -1386,10 +1653,68 @@ fn primary_style_pattern(family: &str, request: PrimaryStyleRequest) -> String {
     )
 }
 
+fn probe_primary_style_source(
+    regular: &ResolvedFaceSource,
+    request: PrimaryStyleRequest,
+) -> ResolvedFaceSource {
+    let pattern = primary_style_pattern(&regular.family, request);
+    let candidate = resolve_face_source(request.label, &pattern, &regular.family);
+    match candidate {
+        Ok(candidate)
+            if normalize_family(&candidate.family) == normalize_family(&regular.family)
+                && (candidate.path != regular.path || candidate.index != regular.index)
+                && request.bold == (candidate.weight > regular.weight)
+                && request.italic == (candidate.slant != regular.slant) =>
+        {
+            candidate
+        }
+        _ => {
+            let mut fallback = regular.clone();
+            fallback.label = request.label;
+            fallback
+        }
+    }
+}
+
+/// Probes the effective fontconfig source identities without mapping font bytes.
+///
+/// # Errors
+/// Returns an error when Fontconfig output or selected source metadata is invalid.
+#[doc(hidden)]
+pub fn probe_live_font_sources(pattern: &str, authority: FontAuthority) -> Result<FontFingerprint> {
+    let regular = resolve_face_source(
+        "primary regular",
+        pattern,
+        expected_primary_family_fragment(pattern),
+    )?;
+    let [bold_request, italic_request, bold_italic_request] = PRIMARY_STYLE_REQUESTS;
+    let mut sources = Vec::from([
+        regular.clone(),
+        probe_primary_style_source(&regular, bold_request),
+        probe_primary_style_source(&regular, italic_request),
+        probe_primary_style_source(&regular, bold_italic_request),
+        resolve_face_source("CJK fallback", CJK_FONT, "noto sans cjk")?,
+        resolve_face_source("emoji fallback", EMOJI_FONT, "noto color emoji")?,
+    ]);
+    let excluded = sources
+        .iter()
+        .map(|source| (source.path.clone(), source.index))
+        .collect::<HashSet<_>>();
+    sources.extend(resolve_fallback_sources(pattern, &excluded)?);
+    Ok(FontFingerprint {
+        pattern: pattern.to_owned(),
+        authority,
+        faces: sources
+            .iter()
+            .map(ResolvedFaceSource::fingerprint)
+            .collect(),
+    })
+}
+
 fn face_advance(face: &FontFace, font_size: f32) -> Result<f32> {
-    let font = font_ref(face)?;
+    let (font, coords) = font_ref_with_coords(face)?;
     let advance = font
-        .glyph_metrics(&[])
+        .glyph_metrics(coords)
         .scale(font_size)
         .advance_width(font.charmap().map('M'));
     anyhow::ensure!(advance.is_finite() && advance > 0.0, "invalid M advance");
@@ -1452,8 +1777,20 @@ fn resolve_primary_style(
     }
 }
 
-fn resolve_primary_faces(pattern: &str) -> Result<[FontFace; 4]> {
-    let regular = resolve_face("primary regular", pattern, "")?;
+fn expected_primary_family_fragment(pattern: &str) -> &'static str {
+    if pattern == STARTUP_FONT_FALLBACK {
+        "jetbrains mono"
+    } else {
+        ""
+    }
+}
+
+fn resolve_primary_faces_exact(pattern: &str) -> Result<[FontFace; 4]> {
+    let regular = resolve_face(
+        "primary regular",
+        pattern,
+        expected_primary_family_fragment(pattern),
+    )?;
     let regular_advance = face_advance(&regular, BASE_FONT_SIZE)
         .context("selected primary regular face is unusable")?;
     let [bold_request, italic_request, bold_italic_request] = PRIMARY_STYLE_REQUESTS;
@@ -1463,32 +1800,177 @@ fn resolve_primary_faces(pattern: &str) -> Result<[FontFace; 4]> {
     Ok([regular, bold, italic, bold_italic])
 }
 
-pub(super) fn font_data(face: &FontFace) -> Result<&[u8]> {
-    face.data
-        .as_ref()
-        .context("fallback font data requires the bounded mapping cache")?
-        .get_or_init(|| {
-            ReadOnlyFileMap::open(&face.path)
-                .with_context(|| format!("map {}", face.path.display()))
-                .map_err(|error| error.to_string())
-        })
-        .as_ref()
-        .map(|mapping| &**mapping)
-        .map_err(|error| anyhow::anyhow!(error.clone()))
+fn resolve_startup_primary_with<T>(
+    pattern: &str,
+    authority: FontAuthority,
+    mut resolve: impl FnMut(&str) -> Result<T>,
+) -> Result<T> {
+    match resolve(pattern) {
+        Ok(resolved) => Ok(resolved),
+        Err(error) if authority == FontAuthority::Explicit => Err(error).with_context(|| {
+            format!("explicit primary font pattern {pattern:?} could not be resolved")
+        }),
+        Err(native_error) => {
+            eprintln!(
+                "splinterm font warning: native system monospace resolution failed ({native_error:#}); trying the documented JetBrains Mono Nerd Font fallback"
+            );
+            resolve(STARTUP_FONT_FALLBACK).with_context(|| {
+                format!(
+                    "native primary font pattern {pattern:?} failed ({native_error:#}) and startup fallback {STARTUP_FONT_FALLBACK:?} could not be resolved"
+                )
+            })
+        }
+    }
 }
 
-pub(super) fn font_ref(face: &FontFace) -> Result<FontRef<'_>> {
-    FontRef::from_index(font_data(face)?, face.index).with_context(|| {
+fn resolve_primary_faces(pattern: &str, authority: FontAuthority) -> Result<[FontFace; 4]> {
+    resolve_startup_primary_with(pattern, authority, resolve_primary_faces_exact)
+}
+
+fn resolve_font_candidate(
+    pattern: &str,
+    authority: FontAuthority,
+    startup: bool,
+) -> Result<FontGeneration> {
+    let [regular, bold, italic, bold_italic] = if startup {
+        resolve_primary_faces(pattern, authority)?
+    } else {
+        resolve_primary_faces_exact(pattern)?
+    };
+    let id = NEXT_FONT_GENERATION_ID.fetch_add(1, Ordering::Relaxed);
+    let mut faces = Vec::from([
+        regular,
+        bold,
+        italic,
+        bold_italic,
+        resolve_face("CJK fallback", CJK_FONT, "noto sans cjk")?,
+        resolve_face("emoji fallback", EMOJI_FONT, "noto color emoji")?,
+    ]);
+    let excluded = faces
+        .iter()
+        .map(|face| (face.path.clone(), face.index))
+        .collect::<HashSet<_>>();
+    let fallback_sources = resolve_fallback_sources(pattern, &excluded)?;
+    eprintln!(
+        "Resolved {} ordered Fontconfig fallback faces",
+        fallback_sources.len()
+    );
+    faces.extend(fallback_sources.into_iter().map(unstaged_fallback_face));
+    for face in &mut faces {
+        face.generation_id = id;
+    }
+    let fingerprint = FontFingerprint {
+        pattern: pattern.to_owned(),
+        authority,
+        faces: faces.iter().map(FontFace::fingerprint).collect(),
+    };
+    Ok(FontGeneration {
+        id,
+        fingerprint,
+        faces,
+    })
+}
+
+fn stage_stable_with<F, T>(mut stage: impl FnMut() -> Result<(F, T)>) -> Result<T>
+where
+    F: std::fmt::Debug + Eq,
+{
+    let (first_fingerprint, first) = stage()?;
+    let (second_fingerprint, second) = stage()?;
+    anyhow::ensure!(
+        first_fingerprint == second_fingerprint,
+        "font resolution changed while staging: first={first_fingerprint:?}, second={second_fingerprint:?}"
+    );
+    drop(first);
+    Ok(second)
+}
+
+fn stage_font_generation(
+    pattern: &str,
+    authority: FontAuthority,
+    startup: bool,
+) -> Result<FontGeneration> {
+    stage_stable_with(|| {
+        let generation = resolve_font_candidate(pattern, authority, startup)?;
+        Ok((generation.fingerprint.clone(), generation))
+    })
+}
+
+fn stage_startup_font_generation(
+    pattern: &str,
+    authority: FontAuthority,
+) -> Result<FontGeneration> {
+    stage_font_generation(pattern, authority, true)
+}
+
+/// Stages one stable live generation without applying the startup fallback.
+///
+/// # Errors
+/// Returns an error when resolution is unstable or any complete face set is invalid.
+#[doc(hidden)]
+pub fn stage_live_font_generation(
+    pattern: &str,
+    authority: FontAuthority,
+) -> Result<FontGeneration> {
+    stage_font_generation(pattern, authority, false)
+}
+
+pub(super) fn font_data(face: &FontFace) -> Result<&[u8]> {
+    face.data
+        .as_deref()
+        .map(|mapping| &**mapping)
+        .context("fallback font data requires the bounded mapping cache")
+}
+
+fn parse_font_ref<'a>(face: &FontFace, data: &'a [u8]) -> Result<FontRef<'a>> {
+    FontRef::from_index(data, face.index.collection_index()).with_context(|| {
         format!(
-            "parse {} face {} with Swash",
+            "parse {} Fontconfig face {} (collection face {}) with Swash",
             face.path.display(),
-            face.index
+            face.index.raw(),
+            face.index.collection_index()
         )
     })
 }
 
+fn normalized_coords<'a>(face: &'a FontFace, font: FontRef<'_>) -> Result<&'a [NormalizedCoord]> {
+    face.normalized_coords
+        .get_or_init(|| {
+            let Some(instance_index) = face.index.named_instance_index() else {
+                return Ok(Box::new([]));
+            };
+            let Some(instance) = font.instances().nth(instance_index) else {
+                return Err(format!(
+                    "Fontconfig face {} selects missing named instance {} in {}",
+                    face.index.raw(),
+                    instance_index + 1,
+                    face.path.display()
+                ));
+            };
+            Ok(instance
+                .normalized_coords()
+                .collect::<Vec<_>>()
+                .into_boxed_slice())
+        })
+        .as_ref()
+        .map(Box::as_ref)
+        .map_err(|error| anyhow::anyhow!(error.clone()))
+}
+
+pub(super) fn font_ref(face: &FontFace) -> Result<FontRef<'_>> {
+    let font = parse_font_ref(face, font_data(face)?)?;
+    normalized_coords(face, font)?;
+    Ok(font)
+}
+
+fn font_ref_with_coords(face: &FontFace) -> Result<(FontRef<'_>, &[NormalizedCoord])> {
+    let font = font_ref(face)?;
+    let coords = normalized_coords(face, font)?;
+    Ok((font, coords))
+}
+
 fn fallback_font_mapping(face: &FontFace) -> Result<Arc<ReadOnlyFileMap>> {
-    let key = face.path.clone();
+    let key = (face.path.clone(), face.source_identity);
     SNAPSHOT_FALLBACK_MAPPING_CACHE.with(|cache| {
         let mut cache = cache.borrow_mut();
         if let Some(mapping) = cache.mappings.get(&key).cloned() {
@@ -1498,7 +1980,11 @@ fn fallback_font_mapping(face: &FontFace) -> Result<Arc<ReadOnlyFileMap>> {
         cache.misses = cache.misses.saturating_add(1);
         let mapping = Arc::new(
             ReadOnlyFileMap::open(&face.path)
-                .with_context(|| format!("map fallback font {}", face.path.display()))?,
+                .with_context(|| format!("map fallback {}", face.path.display()))?,
+        );
+        anyhow::ensure!(
+            mapping.identity() == face.source_identity,
+            "fallback font source changed before mapping"
         );
         Ok(cache.insert(key, mapping))
     })
@@ -1506,20 +1992,16 @@ fn fallback_font_mapping(face: &FontFace) -> Result<Arc<ReadOnlyFileMap>> {
 
 pub(super) fn with_font_ref<T>(
     face: &FontFace,
-    use_font: impl FnOnce(FontRef<'_>) -> Result<T>,
+    use_font: impl FnOnce(FontRef<'_>, &[NormalizedCoord]) -> Result<T>,
 ) -> Result<T> {
     if face.data.is_some() {
-        return use_font(font_ref(face)?);
+        let (font, coords) = font_ref_with_coords(face)?;
+        return use_font(font, coords);
     }
     let mapping = fallback_font_mapping(face)?;
-    let font = FontRef::from_index(&mapping, face.index).with_context(|| {
-        format!(
-            "parse fallback {} face {} with Swash",
-            face.path.display(),
-            face.index
-        )
-    })?;
-    use_font(font)
+    let font = parse_font_ref(face, &mapping)?;
+    let coords = normalized_coords(face, font)?;
+    use_font(font, coords)
 }
 
 pub(super) fn select_glyph(
@@ -1535,11 +2017,7 @@ pub(super) fn select_glyph(
     order
         .iter()
         .find_map(|face_index| {
-            let face = &faces[*face_index];
-            if !face.covers_text(&character.to_string()) {
-                return None;
-            }
-            let glyph = font_ref(face).ok()?.charmap().map(character);
+            let glyph = font_ref(&faces[*face_index]).ok()?.charmap().map(character);
             (glyph != 0).then_some((*face_index, glyph))
         })
         .with_context(|| format!("no explicit font covers U+{:04X}", u32::from(character)))
@@ -1624,19 +2102,135 @@ mod tests {
         weight: i32,
         slant: i32,
     ) -> FontFace {
+        static NEXT_SYNTHETIC_FACE: std::sync::atomic::AtomicU64 =
+            std::sync::atomic::AtomicU64::new(1);
+        let mapped_path = std::env::temp_dir().join(format!(
+            "splinterm-synthetic-face-{}-{}",
+            std::process::id(),
+            NEXT_SYNTHETIC_FACE.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+        ));
+        std::fs::write(&mapped_path, b"synthetic face bytes").unwrap();
+        let data = Arc::new(ReadOnlyFileMap::open(&mapped_path).unwrap());
+        std::fs::remove_file(mapped_path).unwrap();
         FontFace {
             label,
             family: family.to_owned(),
             style: label.to_owned(),
             path: PathBuf::from(path),
-            index: 0,
+            index: FontconfigFaceIndex::new(0),
             weight,
             slant,
+            generation_id: 0,
             selected_pixel_size_26_6: 12 * 64,
+            source_identity: data.identity(),
             outline: true,
-            coverage: Box::new([]),
-            data: Some(OnceLock::new()),
+            coverage: vec![(0, u32::from(char::MAX))].into_boxed_slice(),
+            data: Some(data),
+            normalized_coords: OnceLock::new(),
         }
+    }
+
+    #[test]
+    fn packed_fontconfig_face_index_separates_collection_and_named_instance() {
+        let static_face = FontconfigFaceIndex::new(7);
+        assert_eq!(static_face.raw(), 7);
+        assert_eq!(static_face.collection_index(), 7);
+        assert_eq!(static_face.named_instance_index(), None);
+
+        let victor_regular = FontconfigFaceIndex::new(0x0004_0000);
+        assert_eq!(victor_regular.raw(), 262_144);
+        assert_eq!(victor_regular.collection_index(), 0);
+        assert_eq!(victor_regular.named_instance_index(), Some(3));
+
+        let collection_instance = FontconfigFaceIndex::new(0x0003_0004);
+        assert_eq!(collection_instance.collection_index(), 4);
+        assert_eq!(collection_instance.named_instance_index(), Some(2));
+        assert!(FontconfigFaceIndex::from_fontconfig(0x8000_0000).is_err());
+    }
+
+    #[test]
+    fn fontconfig_source_parser_preserves_packed_variable_instance_index() {
+        let path = std::env::temp_dir().join(format!(
+            "splinterm-fontconfig-index-fixture-{}",
+            std::process::id()
+        ));
+        std::fs::write(&path, b"font fixture").unwrap();
+        let output = format!(
+            "{}\n262144\nVariable Mono\nRegular\n80\n0\n14\nTrue\n20-7e\n--record--\n",
+            path.display()
+        );
+        let sources = parse_fontconfig_sources("variable fixture", output.as_bytes()).unwrap();
+        std::fs::remove_file(path).unwrap();
+        assert_eq!(sources.len(), 1);
+        assert_eq!(sources[0].index.raw(), 262_144);
+        assert_eq!(sources[0].index.collection_index(), 0);
+        assert_eq!(sources[0].index.named_instance_index(), Some(3));
+    }
+
+    #[test]
+    #[ignore = "manual variable-font integration; requires SPLINTERM_VARIABLE_FONT_FIXTURE and SPLINTERM_VARIABLE_FONT_INDEX"]
+    fn variable_font_named_instance_shapes_and_rasterizes_with_freetype_identity() {
+        let path = PathBuf::from(
+            std::env::var("SPLINTERM_VARIABLE_FONT_FIXTURE")
+                .expect("SPLINTERM_VARIABLE_FONT_FIXTURE names a variable font"),
+        );
+        let raw_index = std::env::var("SPLINTERM_VARIABLE_FONT_INDEX")
+            .expect("SPLINTERM_VARIABLE_FONT_INDEX names a Fontconfig packed index")
+            .parse::<u32>()
+            .expect("packed index is numeric");
+        let snapshot = ReadOnlyFileMap::immutable_snapshot(&path, MAX_STAGED_FONT_BYTES).unwrap();
+        let mut face = synthetic_face("variable", "Variable Mono", "/fonts/variable.ttf", 80, 0);
+        face.path = path;
+        face.index = FontconfigFaceIndex::from_fontconfig(raw_index).unwrap();
+        face.source_identity = snapshot.source_identity;
+        face.data = Some(Arc::new(snapshot.mapping));
+
+        let (font, coords) = font_ref_with_coords(&face).unwrap();
+        assert!(face.index.named_instance_index().is_some());
+        assert!(!coords.is_empty());
+        let glyph_id = font.charmap().map('M');
+        assert_ne!(glyph_id, 0);
+        let swash_advance = font
+            .glyph_metrics(coords)
+            .scale(BASE_FONT_SIZE)
+            .advance_width(glyph_id);
+        assert!(swash_advance.is_finite() && swash_advance > 0.0);
+
+        let mut shape_context = ShapeContext::new();
+        let mut shaped_glyph_ids = Vec::new();
+        let mut shaper = shape_context
+            .builder(font)
+            .size(BASE_FONT_SIZE)
+            .normalized_coords(coords)
+            .build();
+        shaper.add_str("Mono");
+        shaper.shape_with(|cluster| {
+            shaped_glyph_ids.extend(cluster.glyphs.iter().map(|glyph| glyph.id));
+        });
+        assert!(!shaped_glyph_ids.is_empty());
+
+        let mut scale_context = ScaleContext::new();
+        let mut scaler = scale_context
+            .builder(font)
+            .size(BASE_FONT_SIZE)
+            .normalized_coords(coords)
+            .hint(true)
+            .build();
+        assert!(
+            Render::new(&[Source::Outline])
+                .format(Format::Alpha)
+                .render(&mut scaler, glyph_id)
+                .is_some()
+        );
+
+        let mut freetype = RasterFace::open_memory(
+            face.data.as_deref().unwrap(),
+            face.index.raw(),
+            pixel_size_26_6(BASE_FONT_SIZE).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(freetype.glyph_index('M'), u32::from(glyph_id));
+        assert!(freetype.rasterize_gray(u32::from(glyph_id)).is_ok());
     }
 
     #[test]
@@ -1651,27 +2245,22 @@ mod tests {
     }
 
     #[test]
-    fn fallback_font_mapping_cache_is_bounded_across_face_churn() {
-        reset_snapshot_cache();
-        let faces = snapshot_faces().unwrap();
-        let mapping =
-            Arc::new(ReadOnlyFileMap::open(&faces[SNAPSHOT_PRIMARY_REGULAR].path).unwrap());
-        SNAPSHOT_FALLBACK_MAPPING_CACHE.with(|cache| {
-            let mut cache = cache.borrow_mut();
-            for index in 0..=SNAPSHOT_FALLBACK_MAPPING_BUDGET {
-                cache.insert(
-                    PathBuf::from(format!("/synthetic/font-{index}.ttf")),
-                    Arc::clone(&mapping),
-                );
-            }
-        });
-        let metrics = snapshot_cache_metrics();
-        assert_eq!(
-            metrics["fallback_mappings"].as_u64(),
-            Some(SNAPSHOT_FALLBACK_MAPPING_BUDGET as u64)
-        );
-        assert_eq!(metrics["fallback_mapping_evictions"].as_u64(), Some(1));
-        reset_snapshot_cache();
+    fn fallback_font_mapping_cache_remains_bounded() {
+        let face = synthetic_face("mapping", "Chosen Mono", "/fonts/mapping.ttf", 80, 0);
+        let mapping = face.data.expect("synthetic face is mapped");
+        let identity = mapping.identity();
+        let mut cache = PersistentFontMappingCache::default();
+        for index in 0..=SNAPSHOT_FALLBACK_MAPPING_BUDGET {
+            cache.insert(
+                (
+                    PathBuf::from(format!("/fonts/fallback-{index}.ttf")),
+                    identity,
+                ),
+                Arc::clone(&mapping),
+            );
+        }
+        assert_eq!(cache.mappings.len(), SNAPSHOT_FALLBACK_MAPPING_BUDGET);
+        assert_eq!(cache.evictions, 1);
     }
 
     #[test]
@@ -1725,6 +2314,15 @@ mod tests {
             "Fontconfig oblique faces satisfy an italic slant request"
         );
 
+        let mut named_instance =
+            synthetic_face("bold italic", "Chosen Mono", "/fonts/regular.ttf", 200, 100);
+        named_instance.index = FontconfigFaceIndex::new(0x0007_0000);
+        assert_eq!(
+            style_candidate_rejection(&regular, &named_instance, request, 8.0, 8.0),
+            None,
+            "a distinct named instance in the same variable-font file is a distinct face"
+        );
+
         let foreign = synthetic_face("bold italic", "Other Mono", "/fonts/other.ttf", 200, 100);
         assert_eq!(
             style_candidate_rejection(&regular, &foreign, request, 8.0, 8.0),
@@ -1762,8 +2360,113 @@ mod tests {
     }
 
     #[test]
+    fn documented_startup_fallback_requires_the_jetbrains_family() {
+        assert_eq!(
+            expected_primary_family_fragment(STARTUP_FONT_FALLBACK),
+            "jetbrains mono"
+        );
+        assert_eq!(expected_primary_family_fragment("monospace"), "");
+    }
+
+    #[test]
+    fn native_startup_tries_the_documented_fallback_after_resolution_failure() {
+        let mut patterns = Vec::new();
+        let resolved = resolve_startup_primary_with(
+            "monospace:style=Regular",
+            FontAuthority::NativeOmarchy,
+            |pattern| {
+                patterns.push(pattern.to_owned());
+                if pattern == STARTUP_FONT_FALLBACK {
+                    Ok("fallback")
+                } else {
+                    bail!("native unavailable")
+                }
+            },
+        )
+        .unwrap();
+        assert_eq!(resolved, "fallback");
+        assert_eq!(
+            patterns,
+            [
+                "monospace:style=Regular".to_owned(),
+                STARTUP_FONT_FALLBACK.to_owned()
+            ]
+        );
+    }
+
+    #[test]
+    fn explicit_startup_never_uses_the_native_fallback() {
+        let mut patterns = Vec::new();
+        let error = resolve_startup_primary_with(
+            "monospace:style=Regular",
+            FontAuthority::Explicit,
+            |pattern| -> Result<()> {
+                patterns.push(pattern.to_owned());
+                bail!("explicit unavailable")
+            },
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("explicit primary font pattern"));
+        assert_eq!(patterns, ["monospace:style=Regular".to_owned()]);
+    }
+
+    #[test]
+    fn native_startup_fails_when_native_and_fallback_resolution_fail() {
+        let error = resolve_startup_primary_with(
+            "monospace:style=Regular",
+            FontAuthority::NativeOmarchy,
+            |_pattern| -> Result<()> { bail!("unavailable") },
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("startup fallback"));
+    }
+
+    #[test]
+    fn stable_staging_accepts_identical_fingerprints_and_returns_the_second_candidate() {
+        let mut candidates = [(7_u8, "first"), (7_u8, "second")].into_iter();
+        let staged = stage_stable_with(|| Ok(candidates.next().unwrap())).unwrap();
+        assert_eq!(staged, "second");
+    }
+
+    #[test]
+    fn stable_staging_rejects_a_mixed_resolution() {
+        let mut candidates = [(7_u8, "first"), (8_u8, "second")].into_iter();
+        let error = stage_stable_with(|| Ok(candidates.next().unwrap())).unwrap_err();
+        assert!(error.to_string().contains("changed while staging"));
+    }
+
+    #[test]
+    #[ignore = "manual host resource timing; requires fontconfig and installed fonts"]
+    fn repeated_live_staging_is_fd_bounded() {
+        let options = renderer_options();
+        let before = std::fs::read_dir("/proc/self/fd").unwrap().count();
+        let started = Instant::now();
+        for _ in 0..3 {
+            drop(stage_live_font_generation(&options.font, options.font_authority).unwrap());
+        }
+        let elapsed = started.elapsed();
+        let after = std::fs::read_dir("/proc/self/fd").unwrap().count();
+        eprintln!(
+            "live-font-stage three_generations_ms={:.3} fd_before={before} fd_after={after}",
+            elapsed.as_secs_f64() * 1_000.0
+        );
+        assert!(after <= before.saturating_add(1));
+    }
+
+    #[test]
+    #[ignore = "requires host fontconfig and installed system fonts"]
+    fn live_probe_matches_the_staged_generation_on_the_supported_host() {
+        let options = renderer_options();
+        let probe = probe_live_font_sources(&options.font, options.font_authority).unwrap();
+        let staged = stage_live_font_generation(&options.font, options.font_authority).unwrap();
+        assert_eq!(probe, staged.fingerprint);
+    }
+
+    #[test]
+    #[ignore = "requires host fontconfig and installed system fonts"]
     fn effective_system_monospace_resolves_one_coherent_primary_family() {
-        let faces = resolve_primary_faces("monospace:style=Regular").unwrap();
+        let faces =
+            resolve_primary_faces("monospace:style=Regular", FontAuthority::NativeOmarchy).unwrap();
         let regular_family = normalize_family(&faces[0].family);
         assert!(!regular_family.is_empty());
         for face in &faces[1..] {
@@ -1776,6 +2479,7 @@ mod tests {
         let mut cache = PersistentGlyphCache::default();
         for glyph in 0..=SNAPSHOT_GLYPH_CACHE_BUDGET {
             let key = (
+                1,
                 768,
                 GlyphKey {
                     face: SNAPSHOT_EMOJI,
@@ -1796,6 +2500,7 @@ mod tests {
             );
         }
         let first = (
+            1,
             768,
             GlyphKey {
                 face: SNAPSHOT_EMOJI,
@@ -1812,7 +2517,7 @@ mod tests {
         let mut byte_bounded = PersistentGlyphCache::default();
         for glyph in 0..3 {
             byte_bounded.insert_glyph_bounded(
-                (768, GlyphKey { face: 0, glyph }),
+                (1, 768, GlyphKey { face: 0, glyph }),
                 Arc::new(CachedGlyph {
                     content: Content::Mask,
                     left: 0,

--- a/crates/splinterm/src/renderer/frame.rs
+++ b/crates/splinterm/src/renderer/frame.rs
@@ -19,12 +19,12 @@ use crate::{
 };
 
 use super::{
-    BOX_DRAWING_FACE, CachedGlyph, FontFace, GlyphKey, RenderContext, SNAPSHOT_CJK, SNAPSHOT_EMOJI,
-    SNAPSHOT_FALLBACK_START, SNAPSHOT_PRIMARY_BOLD, SNAPSHOT_PRIMARY_BOLD_ITALIC,
+    BOX_DRAWING_FACE, CachedGlyph, FontFace, FontGeneration, GlyphKey, RenderContext, SNAPSHOT_CJK,
+    SNAPSHOT_EMOJI, SNAPSHOT_FALLBACK_START, SNAPSHOT_PRIMARY_BOLD, SNAPSHOT_PRIMARY_BOLD_ITALIC,
     SNAPSHOT_PRIMARY_ITALIC, SNAPSHOT_PRIMARY_REGULAR, cell_metrics, compatibility_render_context,
     decorations::{DecorationMetrics, DecorationSpan},
     images::{SnapshotImage, prepare_snapshot_images},
-    snapshot_color_advance, snapshot_faces, snapshot_glyph, u32_to_f32, with_font_ref,
+    snapshot_color_advance, snapshot_glyph, u32_to_f32, with_font_ref,
 };
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -41,6 +41,7 @@ pub(super) struct SnapshotGlyph {
 
 /// One immutable, scale-dependent rendering of an owned daemon snapshot.
 pub(crate) struct SnapshotFrame {
+    pub(super) font_generation: Arc<FontGeneration>,
     pub(super) glyphs: Vec<SnapshotGlyph>,
     pub(super) decorations: Vec<DecorationSpan>,
     pub(super) cache: HashMap<GlyphKey, Arc<CachedGlyph>>,
@@ -334,7 +335,8 @@ impl SnapshotFrame {
         }
         let scale_120 = u16::try_from(scale_120).context("scale fits u16")?;
         let font_size = context.effective_font_size(u32::from(scale_120))?;
-        let faces = snapshot_faces()?;
+        let font_generation = Arc::clone(context.font_generation()?);
+        let faces = &font_generation.faces;
         let metrics = cell_metrics(&faces[0], font_size)?;
         let cell_width = metrics.width;
         let cell_height = metrics.height;
@@ -394,6 +396,7 @@ impl SnapshotFrame {
         let cursor = snapshot_cursor(snapshot, columns, rows);
         let images = prepare_snapshot_images(snapshot, sources)?;
         let mut frame = Self {
+            font_generation,
             glyphs,
             decorations,
             cache,
@@ -448,7 +451,12 @@ impl SnapshotFrame {
         if snapshot.palette.len() != 256 {
             bail!("snapshot palette must contain exactly 256 colors");
         }
-        let faces = snapshot_faces()?;
+        let context_generation = context.font_generation()?;
+        anyhow::ensure!(
+            self.font_generation.id == context_generation.id,
+            "incremental frame font generation changed; a full rebuild is required"
+        );
+        let faces = &self.font_generation.faces;
         let font_size = context.effective_font_size(u32::from(self.scale_120))?;
         let default_foreground = packed_rgb(snapshot.default_colors[0]);
         let default_background = packed_rgb(snapshot.default_colors[1]);
@@ -778,9 +786,13 @@ pub(super) fn prepare_snapshot_row(
                 Ok(face_index) => (face_index, cell.content.as_str()),
                 Err(_) => (primary_face_index(&cell.attributes), "\u{fffd}"),
             };
-        let shaped_glyphs = with_font_ref(&faces[face_index], |font| {
+        let shaped_glyphs = with_font_ref(&faces[face_index], |font, coords| {
             let mut shaped_glyphs = Vec::new();
-            let mut shaper = shape_context.builder(font).size(font_size).build();
+            let mut shaper = shape_context
+                .builder(font)
+                .size(font_size)
+                .normalized_coords(coords)
+                .build();
             shaper.add_str(content);
             shaper.shape_with(|cluster| {
                 let advance = cluster.advance();
@@ -802,8 +814,10 @@ pub(super) fn prepare_snapshot_row(
                 .or_insert(snapshot_glyph(faces, face_index, glyph_id, font_size)?);
             let cluster_advance = if face_index == SNAPSHOT_EMOJI {
                 f32::from(
-                    i16::try_from(snapshot_color_advance(face_index, glyph_id, font_size)?)
-                        .context("color glyph advance fits i16")?,
+                    i16::try_from(snapshot_color_advance(
+                        faces, face_index, glyph_id, font_size,
+                    )?)
+                    .context("color glyph advance fits i16")?,
                 )
             } else {
                 cluster_advance.trunc()
@@ -856,7 +870,7 @@ pub(super) fn select_face_for_text(
         .find(|index| {
             let face = &faces[*index];
             face.covers_text(text)
-                && with_font_ref(face, |font| {
+                && with_font_ref(face, |font, _coords| {
                     Ok(text
                         .chars()
                         .all(|character| font.charmap().map(character) != 0))

--- a/crates/splinterm/src/renderer/settings.rs
+++ b/crates/splinterm/src/renderer/settings.rs
@@ -1,17 +1,22 @@
 //! Immutable renderer resources, explicit per-window state, and compatibility adapters.
 
-use std::sync::{Mutex, OnceLock};
+use std::sync::{Arc, Mutex, OnceLock};
 
 use anyhow::{Context, Result, bail};
 use splinterm_freetype::{MAX_PIXEL_SIZE_26_6, MIN_PIXEL_SIZE_26_6};
 
-use crate::geometry::{
-    FontSize, FontSizingPolicy, OutputDpiObservation, TerminalPadding, resolve_font_size,
-    resolve_font_size_with_output,
+use super::{FontGeneration, clear_snapshot_caches, snapshot_font_generation};
+
+use crate::{
+    config::{FontAuthority, STARTUP_FONT_FALLBACK},
+    geometry::{
+        FontSize, FontSizingPolicy, OutputDpiObservation, TerminalPadding, resolve_font_size,
+        resolve_font_size_with_output,
+    },
 };
 
 pub(super) const BASE_FONT_SIZE: f32 = 22.0;
-pub(super) const PRIMARY_FONT: &str = "JetBrains Mono Nerd Font:style=Regular";
+pub(super) const PRIMARY_FONT: &str = STARTUP_FONT_FALLBACK;
 const FONT_ZOOM_STEP_POINTS: f32 = 0.5;
 
 /// Immutable process resources shared by renderer contexts.
@@ -26,6 +31,7 @@ static COMPATIBILITY_CONTEXT: OnceLock<Mutex<RenderContext>> = OnceLock::new();
 #[derive(Clone, Debug)]
 pub struct RendererOptions {
     pub font: String,
+    pub font_authority: FontAuthority,
     pub font_size: FontSize,
     pub font_sizing_policy: FontSizingPolicy,
     pub physical_dpi: f32,
@@ -37,6 +43,7 @@ impl Default for RendererOptions {
     fn default() -> Self {
         Self {
             font: PRIMARY_FONT.to_owned(),
+            font_authority: FontAuthority::Explicit,
             font_size: FontSize::Pixels(BASE_FONT_SIZE),
             font_sizing_policy: FontSizingPolicy::OutputScale,
             physical_dpi: 96.0,
@@ -50,6 +57,7 @@ impl Default for RendererOptions {
 #[derive(Clone, Debug)]
 pub struct RenderContext {
     resources: &'static RendererResources,
+    font_generation: Result<Arc<FontGeneration>, Arc<String>>,
     output_dpi: OutputDpiObservation,
     font_zoom_steps: i16,
     background_alpha: u16,
@@ -63,13 +71,46 @@ impl RenderContext {
     #[must_use]
     pub fn new(background_alpha: u16) -> Self {
         let resources = renderer_resources();
+        let font_generation = snapshot_font_generation()
+            .map(Arc::clone)
+            .map_err(|error| Arc::new(format!("{error:#}")));
         Self {
             resources,
+            font_generation,
             output_dpi: OutputDpiObservation::provided(resources.options.physical_dpi)
                 .expect("configured physical DPI was validated"),
             font_zoom_steps: 0,
             background_alpha,
         }
+    }
+
+    pub(super) fn font_generation(&self) -> Result<&Arc<FontGeneration>> {
+        self.font_generation
+            .as_ref()
+            .map_err(|error| anyhow::anyhow!(error.to_string()))
+    }
+
+    #[must_use]
+    #[allow(dead_code, reason = "used by the next Plan 0038 delivery milestone")]
+    pub(crate) fn font_generation_id(&self) -> Option<u64> {
+        self.font_generation
+            .as_ref()
+            .ok()
+            .map(|generation| generation.id)
+    }
+
+    #[allow(dead_code, reason = "used by the next Plan 0038 delivery milestone")]
+    pub(crate) fn replace_font_generation(&mut self, next: Arc<FontGeneration>) -> bool {
+        if self
+            .font_generation
+            .as_ref()
+            .is_ok_and(|current| current.fingerprint == next.fingerprint)
+        {
+            return false;
+        }
+        self.font_generation = Ok(next);
+        clear_snapshot_caches();
+        true
     }
 
     #[must_use]
@@ -159,6 +200,7 @@ pub(super) fn compatible_renderer_options(
     next: &RendererOptions,
 ) -> bool {
     current.font == next.font
+        && current.font_authority == next.font_authority
         && current.font_size == next.font_size
         && current.font_sizing_policy == next.font_sizing_policy
         && current.physical_dpi.to_bits() == next.physical_dpi.to_bits()
@@ -281,6 +323,10 @@ mod tests {
         let mut different_font = current.clone();
         different_font.font = "different font".to_owned();
         assert!(!compatible_renderer_options(&current, &different_font));
+
+        let mut different_authority = current.clone();
+        different_authority.font_authority = FontAuthority::NativeOmarchy;
+        assert!(!compatible_renderer_options(&current, &different_authority));
 
         let mut different_padding = current.clone();
         different_padding.padding.left += 1;

--- a/crates/splinterm/src/renderer/tests.rs
+++ b/crates/splinterm/src/renderer/tests.rs
@@ -756,8 +756,7 @@ fn snapshot_decorations_use_foot_baseline_metrics_in_full_and_row_paints() {
 #[test]
 fn fontconfig_fallback_renders_the_prompt_arrow_instead_of_replacement() {
     let generation = Arc::new(
-        stage_live_font_generation("monospace", crate::config::FontAuthority::NativeOmarchy)
-            .unwrap(),
+        stage_live_font_generation(PRIMARY_FONT, crate::config::FontAuthority::Explicit).unwrap(),
     );
     let faces = &generation.faces;
     let attributes = CellAttributes::default();

--- a/crates/splinterm/src/renderer/tests.rs
+++ b/crates/splinterm/src/renderer/tests.rs
@@ -297,6 +297,26 @@ fn explicit_render_contexts_are_pixel_and_metric_isolated_when_interleaved() {
     assert_eq!(second_capture.pixels[3], alpha_u8(52_000));
 }
 
+#[test]
+fn font_generation_replacement_preserves_zoom_dpi_and_alpha() {
+    let mut context = RenderContext::new(12_345);
+    context.set_font_zoom_steps(2, 150).unwrap();
+    context
+        .update_output_dpi(OutputDpiObservation::provided(144.0).unwrap(), 150)
+        .unwrap();
+    let before = context.effective_font_resolution(150).unwrap();
+    let options = renderer_options();
+    let mut replacement =
+        stage_live_font_generation(&options.font, options.font_authority).unwrap();
+    replacement.fingerprint.pattern.push_str("#test-generation");
+    let replacement_id = replacement.id;
+
+    assert!(context.replace_font_generation(Arc::new(replacement)));
+    assert_eq!(context.font_generation_id(), Some(replacement_id));
+    assert_eq!(context.effective_font_resolution(150).unwrap(), before);
+    assert_eq!(context.background_alpha(), 12_345);
+}
+
 fn incremental_snapshot() -> TerminalSnapshot {
     let attributes = default_attributes();
     TerminalSnapshot {
@@ -735,7 +755,11 @@ fn snapshot_decorations_use_foot_baseline_metrics_in_full_and_row_paints() {
 
 #[test]
 fn fontconfig_fallback_renders_the_prompt_arrow_instead_of_replacement() {
-    let faces = snapshot_faces().unwrap();
+    let generation = Arc::new(
+        stage_live_font_generation("monospace", crate::config::FontAuthority::NativeOmarchy)
+            .unwrap(),
+    );
+    let faces = &generation.faces;
     let attributes = CellAttributes::default();
     let face_index = select_face_for_text(faces, "⇕", &attributes).unwrap();
     assert!(
@@ -746,12 +770,17 @@ fn fontconfig_fallback_renders_the_prompt_arrow_instead_of_replacement() {
         faces[face_index].data.is_none(),
         "dynamic fallbacks must use the bounded mapping cache"
     );
-    let glyph_id = with_font_ref(&faces[face_index], |font| Ok(font.charmap().map('⇕'))).unwrap();
+    let glyph_id = with_font_ref(&faces[face_index], |font, _coords| {
+        Ok(font.charmap().map('⇕'))
+    })
+    .unwrap();
     assert_ne!(glyph_id, 0);
 
     let mut snapshot = incremental_snapshot();
     snapshot.visible_rows[0].cells[0].content = "⇕".to_owned();
-    let frame = SnapshotFrame::load_scaled(&snapshot, 120).unwrap();
+    let mut context = RenderContext::new(u16::MAX);
+    context.replace_font_generation(generation);
+    let frame = SnapshotFrame::load_scaled_with_context(&snapshot, 120, &context).unwrap();
     assert!(
         frame
             .glyphs
@@ -806,14 +835,19 @@ fn color_fallback_cache_uses_fcft_fixed_strike_size_and_advance() {
     let font = font_ref(&faces[SNAPSHOT_EMOJI]).unwrap();
     let glyph_id = font.charmap().map('\u{1f642}');
     let small = snapshot_glyph(faces, SNAPSHOT_EMOJI, glyph_id, 12.0).unwrap();
-    let small_advance = snapshot_color_advance(SNAPSHOT_EMOJI, glyph_id, 12.0).unwrap();
+    let small_advance = snapshot_color_advance(faces, SNAPSHOT_EMOJI, glyph_id, 12.0).unwrap();
     let larger = snapshot_glyph(faces, SNAPSHOT_EMOJI, glyph_id, 15.0).unwrap();
-    let larger_advance = snapshot_color_advance(SNAPSHOT_EMOJI, glyph_id, 15.0).unwrap();
+    let larger_advance = snapshot_color_advance(faces, SNAPSHOT_EMOJI, glyph_id, 15.0).unwrap();
 
     assert_eq!((small.width, small.height, small_advance), (14, 14, 14));
     assert_eq!((larger.width, larger.height, larger_advance), (18, 17, 18));
     assert!(!Arc::ptr_eq(&small, &larger));
     assert_ne!(small.data, larger.data);
+    clear_snapshot_caches();
+    assert_eq!(
+        snapshot_color_advance(faces, SNAPSHOT_EMOJI, glyph_id, 15.0).unwrap(),
+        larger_advance
+    );
 }
 
 #[test]
@@ -868,12 +902,51 @@ fn underline_style_color_partial_mutation_matches_clean_full_rebuild() {
 }
 
 #[test]
-fn selected_font_bytes_are_loaded_only_when_the_face_is_used() {
-    let face = resolve_face("lazy CJK test", CJK_FONT, "noto sans cjk").unwrap();
-    let data = face.data.as_ref().expect("explicit face owns stable data");
-    assert!(data.get().is_none());
+fn selected_font_bytes_and_opened_identity_are_staged_together() {
+    let face = resolve_face("staged CJK test", CJK_FONT, "noto sans cjk").unwrap();
+    let data = face.data.as_ref().expect("explicit faces are staged");
+    assert!(!data.is_empty());
+    assert_eq!(
+        face.source_identity.length,
+        u64::try_from(data.len()).unwrap()
+    );
+    assert_ne!(face.source_identity, data.identity());
     assert_ne!(font_ref(&face).unwrap().charmap().map('界'), 0);
-    assert!(data.get().is_some_and(Result::is_ok));
+}
+
+#[test]
+#[ignore = "requires host fontconfig and installed system fonts"]
+fn memory_backed_freetype_keeps_the_staged_inode_after_path_replacement() {
+    let source = resolve_face("staged replacement test", CJK_FONT, "noto sans cjk").unwrap();
+    let path = std::env::temp_dir().join(format!(
+        "splinterm-font-generation-replacement-{}",
+        std::process::id()
+    ));
+    let retired = path.with_extension("retired");
+    fs::write(
+        &path,
+        &***source.data.as_ref().expect("explicit faces are staged"),
+    )
+    .unwrap();
+    let staged = Arc::new(
+        splinterm_filemap::ReadOnlyFileMap::immutable_snapshot(
+            &path,
+            splinterm_freetype::MAX_STAGED_FONT_BYTES,
+        )
+        .unwrap()
+        .mapping,
+    );
+    fs::rename(&path, &retired).unwrap();
+    fs::write(&path, b"not a font").unwrap();
+
+    let shaped = swash::FontRef::from_index(&staged, source.index.collection_index()).unwrap();
+    assert_ne!(shaped.charmap().map('界'), 0);
+    let mut raster =
+        splinterm_freetype::RasterFace::open_memory(&staged, source.index.raw(), 22 * 64).unwrap();
+    assert!(raster.metrics().unwrap().height > 0);
+
+    fs::remove_file(path).unwrap();
+    fs::remove_file(retired).unwrap();
 }
 
 #[test]
@@ -1208,6 +1281,48 @@ fn empty_overlays_leave_compositor_border_area_untouched() {
 }
 
 #[test]
+fn incremental_refresh_rejects_a_different_font_generation() {
+    let snapshot = incremental_snapshot();
+    let context = compatibility_render_context().unwrap();
+    let mut frame = SnapshotFrame::load_scaled_with_context(&snapshot, 120, &context).unwrap();
+    let options = renderer_options();
+    let replacement =
+        Arc::new(stage_live_font_generation(&options.font, options.font_authority).unwrap());
+    assert_ne!(frame.font_generation.id, replacement.id);
+    frame.font_generation = replacement;
+    let error = frame
+        .refresh_rows_with_context(&snapshot, &[true, true], &context)
+        .unwrap_err();
+    assert!(error.to_string().contains("full rebuild is required"));
+}
+
+#[test]
+fn prepared_frame_retains_its_font_generation_until_drop() {
+    let snapshot = incremental_snapshot();
+    let frame = SnapshotFrame::load_scaled(&snapshot, 120).unwrap();
+    let generation = Arc::clone(&frame.font_generation);
+    let retained = Arc::strong_count(&generation);
+    assert!(retained >= 3);
+    drop(frame);
+    assert_eq!(Arc::strong_count(&generation), retained - 1);
+}
+
+#[test]
+fn identical_glyph_ids_do_not_share_cache_entries_across_generations() {
+    reset_snapshot_cache();
+    let current = snapshot_font_generation().unwrap();
+    let face = &current.faces[SNAPSHOT_PRIMARY_REGULAR];
+    let glyph_id = font_ref(face).unwrap().charmap().map('M');
+    let current_glyph =
+        snapshot_glyph(&current.faces, SNAPSHOT_PRIMARY_REGULAR, glyph_id, 22.0).unwrap();
+    let options = renderer_options();
+    let replacement = stage_live_font_generation(&options.font, options.font_authority).unwrap();
+    let replacement_glyph =
+        snapshot_glyph(&replacement.faces, SNAPSHOT_PRIMARY_REGULAR, glyph_id, 22.0).unwrap();
+    assert!(!Arc::ptr_eq(&current_glyph, &replacement_glyph));
+}
+
+#[test]
 fn incremental_refresh_preserves_unchanged_prepared_rows() {
     let mut snapshot = incremental_snapshot();
     let mut frame = SnapshotFrame::load(&snapshot, 1).expect("initial frame");
@@ -1373,6 +1488,7 @@ fn default_alpha_tracks_color_source_and_uses_premultiplied_argb() {
 fn snapshot_framebuffer_paints_background_wide_composed_glyphs_and_cursor() {
     let key = GlyphKey { face: 0, glyph: 1 };
     let frame = SnapshotFrame {
+        font_generation: Arc::clone(snapshot_font_generation().unwrap()),
         glyphs: vec![
             SnapshotGlyph {
                 key,
@@ -1465,6 +1581,7 @@ fn snapshot_framebuffer_paints_background_wide_composed_glyphs_and_cursor() {
 
 fn damage_test_frame() -> SnapshotFrame {
     SnapshotFrame {
+        font_generation: Arc::clone(snapshot_font_generation().unwrap()),
         glyphs: Vec::new(),
         decorations: Vec::new(),
         cache: HashMap::new(),
@@ -2363,6 +2480,7 @@ fn scroll_copy_clips_to_undersized_framebuffers() {
 #[test]
 fn terminal_size_calculation_clamps_minimum_and_protocol_limits() {
     let frame = SnapshotFrame {
+        font_generation: Arc::clone(snapshot_font_generation().unwrap()),
         glyphs: Vec::new(),
         decorations: Vec::new(),
         cache: HashMap::new(),

--- a/crates/splinterm/src/wayland.rs
+++ b/crates/splinterm/src/wayland.rs
@@ -127,7 +127,7 @@ use crate::frontend::{
     AuthorityStatus, BINDING_HELP_PAGE_ITEMS, BindingHelpUi, BoundedTextEditor,
     BuiltInCommandDispatch, BuiltInCommandId, CommandControlAction, CommandHistoryAction,
     CommandPaletteContext, CommandPaletteUi, CommandTabMoveAvailability, CommandZoomAction,
-    DojoPromptUi, LairDirection, LairPromptKind, PerfTraceCorrelation, SelectorKind,
+    DojoPromptUi, FontUpdate, LairDirection, LairPromptKind, PerfTraceCorrelation, SelectorKind,
     SessionPickerDecision, SessionPickerItem, SessionPickerUi, TabContextMenuUi, TabMenuActionId,
     TabMenuContext, TabMenuDispatch, TabMenuRightPress, TerminalGridLimits, TerminationDecision,
     ThemeUpdate, TrustedConsentUi, WindowCommand, WindowDojoIdentity, WindowOptions,
@@ -150,14 +150,14 @@ use crate::renderer::{
     ChromeText, ChromeTextStyle, CommandPaletteLayout, CommandPaletteTextCache, CursorPresentation,
     DojoPromptLayout, HistoryOverlayStatus, PickerHitTarget, RenderContext,
     SessionPickerOverlayLayout, SessionPickerTextCache, SessionPickerTextItem, SnapshotFrame,
-    SnapshotOverlays, TabContextMenuLayout, TextRow, background_bgra, command_palette_hit_test,
-    command_palette_layout, dojo_prompt_hit_test, dojo_prompt_layout, fill_rect,
-    history_overlay_layout, paint, paint_command_palette, paint_dojo_prompt, paint_history_overlay,
-    paint_session_picker_overlay, paint_snapshot_overlays, paint_snapshot_presented,
-    paint_snapshot_region_presented, paint_snapshot_rows_presented, paint_tab_context_menu,
-    premultiplied_theme_rgba, scroll_snapshot_pixels, session_picker_hit_test,
-    session_picker_overlay_layout, session_picker_palette, snapshot_row_rect,
-    tab_context_menu_hit_test, tab_context_menu_layout, write_ppm,
+    SnapshotOverlays, TabContextMenuLayout, TextRow, background_bgra, clear_snapshot_caches,
+    command_palette_hit_test, command_palette_layout, dojo_prompt_hit_test, dojo_prompt_layout,
+    fill_rect, history_overlay_layout, paint, paint_command_palette, paint_dojo_prompt,
+    paint_history_overlay, paint_session_picker_overlay, paint_snapshot_overlays,
+    paint_snapshot_presented, paint_snapshot_region_presented, paint_snapshot_rows_presented,
+    paint_tab_context_menu, premultiplied_theme_rgba, scroll_snapshot_pixels,
+    session_picker_hit_test, session_picker_overlay_layout, session_picker_palette,
+    snapshot_row_rect, tab_context_menu_hit_test, tab_context_menu_layout, write_ppm,
 };
 use crate::{
     keymap::{ActionId, KeymapPress, PrefixState, ResolvedKeymap},
@@ -834,6 +834,7 @@ pub fn run(mut options: WindowOptions) -> Result<()> {
             text_row,
             renderer_generation: 0,
             theme_generation: 0,
+            pending_font_update: None,
             cursor_style: options.cursor_style,
             cursor_blink: options.cursor_blink,
             title_override: options.title,
@@ -1186,6 +1187,29 @@ fn rebuild_pane_scaled_frame(pane: &mut PaneView, scale_120: u32) -> Result<bool
     )?);
     finish_rebuilt_pane_frame(pane);
     Ok(true)
+}
+
+fn prepare_pane_scaled_frame_with_context(
+    pane: &PaneView,
+    scale_120: u32,
+    context: &RenderContext,
+) -> Result<Option<SnapshotFrame>> {
+    let Some(display) = pane.display_snapshot() else {
+        return Ok(None);
+    };
+    Ok(Some(SnapshotFrame::load_scaled_with_sources_and_context(
+        &display,
+        scale_120,
+        Some(&pane.image_sources),
+        context,
+    )?))
+}
+
+fn install_prepared_pane_frame(pane: &mut PaneView, frame: Option<SnapshotFrame>) {
+    if let Some(frame) = frame {
+        pane.snapshot_frame = Some(frame);
+        finish_rebuilt_pane_frame(pane);
+    }
 }
 
 fn rebuild_pane_scaled_frame_with_context(
@@ -1677,7 +1701,7 @@ impl PaneView {
             } else {
                 BackgroundUpdateImpact::NONE
             }),
-            WindowUpdate::Theme(_) => Ok(BackgroundUpdateImpact::NONE),
+            WindowUpdate::Theme(_) | WindowUpdate::Font(_) => Ok(BackgroundUpdateImpact::NONE),
             WindowUpdate::Exited { .. } | WindowUpdate::Shutdown => {
                 self.controller_active = false;
                 self.commands = None;
@@ -1751,6 +1775,11 @@ fn rebuild_inactive_frames_with_context(
     Ok(rebuilt)
 }
 
+struct PreparedTabFontFrames {
+    focused: Option<SnapshotFrame>,
+    inactive: Vec<Option<SnapshotFrame>>,
+}
+
 struct CachedFrameTitle {
     source: String,
     maximum_cells: u32,
@@ -1811,6 +1840,7 @@ struct PresentationState {
     text_row: Option<TextRow>,
     renderer_generation: u64,
     theme_generation: u64,
+    pending_font_update: Option<FontUpdate>,
     cursor_style: CursorStyle,
     cursor_blink: bool,
     title_override: Option<String>,
@@ -2584,6 +2614,15 @@ fn update_graphical_focus_watch(
                 true
             }
         });
+    }
+}
+
+fn retain_newest_font(slot: &mut Option<FontUpdate>, update: FontUpdate) {
+    if slot
+        .as_ref()
+        .is_none_or(|current| current.generation.id() < update.generation.id())
+    {
+        *slot = Some(update);
     }
 }
 
@@ -5594,6 +5633,106 @@ impl App {
         Ok(rebuilt)
     }
 
+    fn reconcile_font_generation(&mut self, update: FontUpdate) -> Result<bool> {
+        let mut candidate_context = self.presentation.render_context.clone();
+        if !candidate_context.replace_font_generation(update.generation) {
+            return Ok(false);
+        }
+
+        let focused = if let Some(mut display) = self.panes.display_snapshot() {
+            apply_ime_preedit(&mut display, self.input.ime.visible_preedit.as_deref());
+            Some(SnapshotFrame::load_scaled_with_sources_and_context(
+                &display,
+                self.surface.scale_120,
+                Some(&self.panes.pane.image_sources),
+                &candidate_context,
+            )?)
+        } else {
+            None
+        };
+        let inactive = self
+            .panes
+            .inactive_panes
+            .iter()
+            .map(|pane| {
+                prepare_pane_scaled_frame_with_context(
+                    pane,
+                    self.surface.scale_120,
+                    &candidate_context,
+                )
+            })
+            .collect::<Result<Vec<_>>>()?;
+        let hidden = self
+            .tab_state
+            .tabs
+            .iter()
+            .map(|tab| {
+                let Some(view) = tab.value.as_ref() else {
+                    return Ok(None);
+                };
+                let focused = prepare_pane_scaled_frame_with_context(
+                    &view.pane,
+                    self.surface.scale_120,
+                    &candidate_context,
+                )?;
+                let inactive = view
+                    .inactive_panes
+                    .iter()
+                    .map(|pane| {
+                        prepare_pane_scaled_frame_with_context(
+                            pane,
+                            self.surface.scale_120,
+                            &candidate_context,
+                        )
+                    })
+                    .collect::<Result<Vec<_>>>()?;
+                Ok(Some(PreparedTabFontFrames { focused, inactive }))
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        self.presentation.render_context = candidate_context;
+        install_prepared_pane_frame(&mut self.panes.pane, focused);
+        for (pane, frame) in self.panes.inactive_panes.iter_mut().zip(inactive) {
+            install_prepared_pane_frame(pane, frame);
+        }
+        for (tab, prepared) in self.tab_state.tabs.iter_mut().zip(hidden) {
+            let (Some(view), Some(prepared)) = (tab.value.as_mut(), prepared) else {
+                continue;
+            };
+            install_prepared_pane_frame(&mut view.pane, prepared.focused);
+            for (pane, frame) in view.inactive_panes.iter_mut().zip(prepared.inactive) {
+                install_prepared_pane_frame(pane, frame);
+            }
+            view.frame_titles.clear();
+            view.dirty_inactive_panes.clear();
+        }
+        clear_snapshot_caches();
+        self.presentation.renderer_generation =
+            self.presentation.renderer_generation.saturating_add(1);
+        self.presentation.frame_titles.clear();
+        self.modal.session_picker_text_cache.clear();
+        self.modal.command_palette_text_cache.clear();
+        self.modal.dojo_prompt_text_cache.clear();
+        self.modal.tab_context_menu_text_cache.clear();
+        self.tab_state.tab_label_cache.clear();
+        self.tab_state.tab_close_text = None;
+        self.tab_state.tab_new_text = None;
+        self.modal.session_picker_layout = None;
+        self.modal.command_palette_layout = None;
+        self.modal.dojo_prompt_layout = None;
+        self.modal.tab_context_menu_layout = None;
+        self.surface.buffers.clear();
+        self.surface.backing.clear();
+        self.presentation.full_redraw = true;
+        self.input.cursor_blink_visible = true;
+        self.input.last_cursor_blink = Instant::now();
+        self.update_ime_cursor_rectangle();
+        if self.surface.configured {
+            self.emit_font_resize()?;
+        }
+        Ok(true)
+    }
+
     fn toggle_tab_strip(&mut self) -> Result<bool> {
         if !self.tab_state.managed_tabs {
             return Ok(false);
@@ -6731,6 +6870,44 @@ impl App {
         Ok(())
     }
 
+    fn emit_font_resize(&mut self) -> Result<()> {
+        let layout = self.computed_pane_layout()?;
+        let active_rect = self
+            .panes
+            .focused_splint()
+            .and_then(|splint_id| layout.as_ref().and_then(|layout| layout.rect(splint_id)));
+        let content = self.content_rect();
+        let (active_width, active_height) = active_rect
+            .map_or((content.width, content.height), |rect| {
+                (rect.width, rect.height)
+            });
+        let active = self.panes.pane.controller_active;
+        Self::emit_pane_resize(
+            &mut self.panes.pane,
+            active_width,
+            active_height,
+            self.surface.scale_120,
+            active,
+        )?;
+        for pane in &mut self.panes.inactive_panes {
+            let Some(splint_id) = pane.snapshot.as_ref().map(|snapshot| snapshot.splint_id) else {
+                continue;
+            };
+            let Some(rect) = layout.as_ref().and_then(|layout| layout.rect(splint_id)) else {
+                continue;
+            };
+            let active = pane.controller_active;
+            Self::emit_pane_resize(
+                pane,
+                rect.width,
+                rect.height,
+                self.surface.scale_120,
+                active,
+            )?;
+        }
+        Ok(())
+    }
+
     fn emit_active_pane_resize(
         pane: &mut PaneView,
         logical_width: u32,
@@ -7278,6 +7455,9 @@ impl App {
                         retain_newest_theme(&mut next_theme, update);
                     }
                 }
+                WindowTopologyUpdate::Font(update) => {
+                    retain_newest_font(&mut self.presentation.pending_font_update, update);
+                }
                 WindowTopologyUpdate::Closed => self
                     .scheduling
                     .request_exit(ExitClass::CleanFinalTabRemoved),
@@ -7495,6 +7675,7 @@ impl App {
         let mut full_frame_reload = false;
         let mut rebuild_all_inactive = false;
         let mut effect_desired_changed = false;
+        let mut font_reconciled = false;
         if let Some(update) = next_theme {
             if inline_picker_open {
                 retain_newest_theme(&mut self.modal.deferred_picker_theme, update);
@@ -7874,6 +8055,9 @@ impl App {
                         effect_desired_changed |= impact.reconcile_effect;
                     }
                 }
+                WindowUpdate::Font(update) => {
+                    retain_newest_font(&mut self.presentation.pending_font_update, update);
+                }
                 WindowUpdate::Exited { splint_id } => {
                     anyhow::ensure!(
                         self.panes.focused_splint() == Some(splint_id),
@@ -7907,6 +8091,22 @@ impl App {
                         self.scheduling.request_exit(ExitClass::ErrorPaneStream);
                         return Ok(());
                     }
+                }
+            }
+        }
+        if let Some(update) = self.presentation.pending_font_update.take() {
+            match self.reconcile_font_generation(update) {
+                Ok(true) => {
+                    font_reconciled = true;
+                    visual_changed = true;
+                    focused_visual_changed = true;
+                    self.presentation.full_redraw = true;
+                }
+                Ok(false) => {}
+                Err(error) => {
+                    eprintln!(
+                        "splinterm live font update rejected during frame reconciliation: {error:#}"
+                    );
                 }
             }
         }
@@ -8071,7 +8271,8 @@ impl App {
             }
             self.refresh_ime_preedit()?;
             self.update_ime_cursor_rectangle();
-            if !self.modal.inline_picker_open()
+            if !font_reconciled
+                && !self.modal.inline_picker_open()
                 && !self.modal.session_picker_reconcile_pending
                 && terminal_resize_allowed(
                     TerminalResizeCause::SnapshotAvailable,
@@ -11256,6 +11457,33 @@ mod tests {
         let first = command_receiver.try_recv().unwrap();
         assert!(matches!(first, WindowCommand::Resize { .. }));
         App::emit_pane_resize(&mut pane, 320, 240, SCALE_DENOMINATOR, true).unwrap();
+        assert!(command_receiver.try_recv().is_err());
+    }
+
+    #[test]
+    fn observer_font_resize_prepares_without_claiming_control() {
+        let splint_id = SplintId::new();
+        let (_updates, update_receiver) = tokio::sync::mpsc::channel(1);
+        let (commands, mut command_receiver) = tokio::sync::mpsc::channel(2);
+        let mut pane = PaneView::from_options(
+            WindowPaneOptions {
+                snapshot: valid_snapshot(splint_id),
+                terminal_grid_limits: TerminalGridLimits::default(),
+                updates: update_receiver,
+                commands,
+                authority: AuthorityStatus::default(),
+                controlled: false,
+                image_sources: ImageContentLeaseSet::default(),
+            },
+            SCALE_DENOMINATOR,
+        )
+        .unwrap();
+        App::emit_pane_resize(&mut pane, 320, 240, SCALE_DENOMINATOR, false).unwrap();
+        assert!(matches!(
+            command_receiver.try_recv().unwrap(),
+            WindowCommand::PrepareResize { .. }
+        ));
+        App::emit_pane_resize(&mut pane, 320, 240, SCALE_DENOMINATOR, false).unwrap();
         assert!(command_receiver.try_recv().is_err());
     }
 

--- a/crates/splinterm/src/wayland.rs
+++ b/crates/splinterm/src/wayland.rs
@@ -914,6 +914,7 @@ pub fn run(mut options: WindowOptions) -> Result<()> {
                 search: SearchUiState::default(),
                 authority: options.authority,
                 last_resize: None,
+                pending_resize: None,
                 prepare_dirty_rows: Vec::new(),
                 raster_dirty_rows: Vec::new(),
                 surface_dirty_rows: Vec::new(),
@@ -1002,6 +1003,7 @@ pub fn run(mut options: WindowOptions) -> Result<()> {
             app.apply_updates(&queue_handle)?;
             if !app.scheduling.exit {
                 app.flush_pending_terminal_input();
+                app.retry_pending_pane_resizes()?;
             }
             if app.scheduling.redraw_pending
                 && !pending_draw_waits_for_frame(
@@ -1117,6 +1119,12 @@ fn new_search_editor() -> BoundedTextEditor {
     )
 }
 
+#[derive(Debug)]
+struct PendingPaneResize {
+    size: (u16, u16, u16, u16),
+    command: WindowCommand,
+}
+
 #[allow(
     clippy::struct_excessive_bools,
     reason = "independent pane rendering, history, and input flags are not one state machine"
@@ -1143,6 +1151,7 @@ struct PaneView {
     search: SearchUiState,
     authority: AuthorityStatus,
     last_resize: Option<(u16, u16, u16, u16)>,
+    pending_resize: Option<PendingPaneResize>,
     prepare_dirty_rows: Vec<bool>,
     raster_dirty_rows: Vec<bool>,
     surface_dirty_rows: Vec<bool>,
@@ -1394,6 +1403,7 @@ impl PaneView {
             search: SearchUiState::default(),
             authority: options.authority,
             last_resize: None,
+            pending_resize: None,
             prepare_dirty_rows: Vec::new(),
             raster_dirty_rows: Vec::new(),
             surface_dirty_rows: Vec::new(),
@@ -2408,7 +2418,9 @@ fn event_loop_timeout(
 }
 
 fn pane_command_retry_pending(pane: &PaneView) -> bool {
-    pane.control_release_pending || pane.pending_focus_report.is_some()
+    pane.control_release_pending
+        || pane.pending_focus_report.is_some()
+        || pane.pending_resize.is_some()
 }
 
 fn command_retry_dispatch_timeout(
@@ -6935,9 +6947,12 @@ impl App {
         scale_120: u32,
         activate: bool,
     ) -> Result<()> {
-        let (Some(frame), Some(commands)) = (&pane.snapshot_frame, &pane.commands) else {
+        let Some(frame) = &pane.snapshot_frame else {
             return Ok(());
         };
+        if pane.commands.is_none() {
+            return Ok(());
+        }
         let (resize, column_capped, row_capped) = match frame.terminal_size_with_limit_status(
             logical_width,
             logical_height,
@@ -6963,6 +6978,7 @@ impl App {
             );
         }
         if !resize_changed(pane.last_resize, resize) {
+            pane.pending_resize = None;
             return Ok(());
         }
         let resize_command = if activate {
@@ -6980,13 +6996,30 @@ impl App {
                 pixel_height: resize.3,
             }
         };
-        match commands.try_send(resize_command) {
-            Ok(()) => pane.last_resize = Some(resize),
-            Err(TrySendError::Full(_)) => {
-                // Layout and scale reconciliation can briefly outpace the
-                // one-pane command worker. Keep the previous dimensions so a
-                // later update retries the newest resize instead of treating
-                // ordinary backpressure as a fatal Wayland failure.
+        pane.pending_resize = Some(PendingPaneResize {
+            size: resize,
+            command: resize_command,
+        });
+        Self::retry_pending_pane_resize(pane)
+    }
+
+    fn retry_pending_pane_resize(pane: &mut PaneView) -> Result<()> {
+        let Some(pending) = pane.pending_resize.take() else {
+            return Ok(());
+        };
+        let Some(commands) = &pane.commands else {
+            return Ok(());
+        };
+        match commands.try_send(pending.command) {
+            Ok(()) => pane.last_resize = Some(pending.size),
+            Err(TrySendError::Full(command)) => {
+                // Preserve the exact newest resize across ordinary queue
+                // backpressure. The event loop retries deferred pane commands
+                // after pending terminal input, without changing authority.
+                pane.pending_resize = Some(PendingPaneResize {
+                    size: pending.size,
+                    command,
+                });
             }
             Err(TrySendError::Closed(_)) => {
                 anyhow::bail!("Wayland command receiver disconnected");
@@ -8445,6 +8478,22 @@ impl App {
                     snapshot.input_modes,
                 )
             })
+    }
+
+    fn retry_pending_pane_resizes(&mut self) -> Result<()> {
+        for pane in
+            std::iter::once(&mut self.panes.pane).chain(self.panes.inactive_panes.iter_mut())
+        {
+            Self::retry_pending_pane_resize(pane)?;
+        }
+        for tab in self.tab_state.tabs.iter_mut() {
+            if let Some(view) = tab.value.as_mut() {
+                for pane in std::iter::once(&mut view.pane).chain(view.inactive_panes.iter_mut()) {
+                    Self::retry_pending_pane_resize(pane)?;
+                }
+            }
+        }
+        Ok(())
     }
 
     fn has_deferred_pane_command(&self) -> bool {
@@ -11574,30 +11623,48 @@ mod tests {
             SCALE_DENOMINATOR,
         )
         .unwrap();
+        App::emit_pane_resize(&mut pane, 320, 240, SCALE_DENOMINATOR, true).unwrap();
+        assert!(matches!(
+            command_receiver.try_recv().unwrap(),
+            WindowCommand::Resize { .. }
+        ));
+        let previous = pane.last_resize;
         commands
             .try_send(WindowCommand::Input(vec![1]))
             .expect("fill pane command queue");
 
-        App::emit_pane_resize(&mut pane, 320, 240, SCALE_DENOMINATOR, true)
+        App::emit_pane_resize(&mut pane, 640, 480, SCALE_DENOMINATOR, false)
             .expect("queue saturation defers resize");
-        assert_eq!(pane.last_resize, None);
+        assert_eq!(pane.last_resize, previous);
+        assert!(pane.pending_resize.is_some());
+        assert!(pane_command_retry_pending(&pane));
         assert_eq!(
             command_receiver.try_recv().unwrap(),
             WindowCommand::Input(vec![1])
         );
 
-        App::emit_pane_resize(&mut pane, 320, 240, SCALE_DENOMINATOR, true)
-            .expect("deferred resize retries");
+        App::retry_pending_pane_resize(&mut pane).expect("deferred resize retries");
         let retried = command_receiver.try_recv().unwrap();
-        assert!(matches!(retried, WindowCommand::Resize { .. }));
-        assert!(pane.last_resize.is_some());
+        assert!(matches!(retried, WindowCommand::PrepareResize { .. }));
+        assert_ne!(pane.last_resize, previous);
+        assert!(pane.pending_resize.is_none());
+        assert!(!pane_command_retry_pending(&pane));
 
+        commands
+            .try_send(WindowCommand::Input(vec![2]))
+            .expect("refill pane command queue");
+        App::emit_pane_resize(&mut pane, 800, 600, SCALE_DENOMINATOR, true)
+            .expect("second resize defers");
+        assert!(pane.pending_resize.is_some());
+        assert_eq!(
+            command_receiver.try_recv().unwrap(),
+            WindowCommand::Input(vec![2])
+        );
         drop(command_receiver);
-        pane.last_resize = None;
-        let error = App::emit_pane_resize(&mut pane, 640, 480, SCALE_DENOMINATOR, true)
-            .expect_err("disconnected resize receiver");
+        let error = App::retry_pending_pane_resize(&mut pane)
+            .expect_err("disconnected deferred resize receiver");
         assert!(error.to_string().contains("disconnected"));
-        assert_eq!(pane.last_resize, None);
+        assert!(pane.pending_resize.is_none());
     }
 
     #[test]

--- a/crates/splinterm/src/wayland/tabs.rs
+++ b/crates/splinterm/src/wayland/tabs.rs
@@ -350,7 +350,7 @@ impl DojoTabView {
                     }
                     continue;
                 }
-                if matches!(update, WindowUpdate::Theme(_)) {
+                if matches!(update, WindowUpdate::Theme(_) | WindowUpdate::Font(_)) {
                     continue;
                 }
                 let splint_id = pane.snapshot.as_ref().map(|snapshot| snapshot.splint_id);

--- a/docs/adr/0004-font-and-cpu-renderer.md
+++ b/docs/adr/0004-font-and-cpu-renderer.md
@@ -1,7 +1,8 @@
 # ADR 0004: Use narrow fontconfig discovery with Swash and CPU SHM rendering
 
-- **Status:** Accepted — Phase 8.1 renderer and oracle policy closed
+- **Status:** Accepted — Phase 8.1 renderer and oracle policy closed; live font-generation amendment accepted
 - **Date:** 2026-07-18
+- **Amended:** 2026-08-29
 
 ## Context
 
@@ -45,11 +46,15 @@ Use a client-owned CPU renderer backed by:
 The current discovery adapter invokes `fc-match` for explicit patterns and once
 for the ordered fallback set. It validates resolved family/style and records
 Fontconfig charset coverage before opening only candidate files whose metadata
-covers a rendered cell. Primary, CJK, and emoji mappings remain immutable;
-dynamic fallback mappings use an evictable 24-entry cache. Fontconfig discovery
-must not run repeatedly on the Wayland dispatch path. Production configuration
-supplies the requested primary pattern; generic `fontdb` monospace selection is
-not authoritative.
+covers a rendered cell. Fontconfig's face index retains FreeType's packed
+identity: the low 16 bits select a collection face and bits 16–30 select a
+one-based named variable instance. FreeType receives that complete identity;
+Swash receives the collection face plus the named instance's normalized
+variation coordinates for metrics, shaping, and outline rasterization. Primary,
+CJK, and emoji mappings remain immutable; dynamic fallback mappings use an
+evictable 24-entry cache. Fontconfig discovery must not run repeatedly on the
+Wayland dispatch path. Production configuration supplies the requested primary
+pattern; generic `fontdb` monospace selection is not authoritative.
 
 Regular, Bold, Italic, and Bold Italic faces must resolve to distinct identities
 and preserve the terminal advance contract. Combining sequences are shaped as
@@ -121,15 +126,33 @@ cache keys or invalidation; cold/warm and full/damage/scroll-copy paths must
 produce identical pixels.
 
 Renderer ownership is explicit. `RendererResources` holds immutable
-process-wide renderer options and font configuration. Every graphical Window
-owns one mutable `RenderContext` containing its output DPI, font zoom, and
-background alpha. Prepared frames capture their context-dependent metrics and
-alpha, so composition and deterministic capture do not consult ambient mutable
-state. Existing public configuration and capture signatures retain a separate
+process-wide sizing, padding, and renderer options. Every graphical Window owns
+one mutable `RenderContext` containing its output DPI, font zoom, background
+alpha, and an `Arc` to one immutable `FontGeneration`. A generation owns the
+complete resolved regular/bold/italic/bold-italic and ordered fallback metadata,
+source fingerprints, and bounded sealed byte snapshots for the primary, CJK,
+and emoji faces used by both Swash and the safe FreeType wrapper. Dynamic
+fallback mappings remain lazy and bounded to 24 entries; their cache identity
+includes the resolved source identity so a same-path font replacement cannot
+reuse bytes from an older generation. Prepared frames retain their generation
+and capture their context-dependent metrics and alpha, so composition and
+deterministic capture do not consult ambient mutable state. Glyph and
+raster-face cache keys include the generation identity; incremental refresh
+rejects a generation mismatch.
+Existing public configuration and capture signatures retain a separate
 compatibility context, but production Wayland rendering uses explicit context
-paths. Immutable resolved font faces remain process-wide; bounded glyph and
-raster-face caches remain renderer-thread-local so native FreeType handles are
-not made `Send` or `Sync`.
+paths. Bounded native FreeType handles remain renderer-thread-local and are
+cleared at successful generation publication; old bytes remain alive only while
+an old prepared frame still retains its generation.
+
+When `main.font` is unset, the client treats fontconfig `monospace` as native
+Omarchy family authority and probes complete effective source identities on a
+bounded interval. Resolution, immutable snapshotting, parsing, metric checks,
+and stable double-resolution run off Tokio and Wayland dispatch paths. A valid
+candidate is fully prepared for active, inactive, and hidden panes before one
+callback-boundary publication. Failure leaves the active generation in place.
+Explicit `main.font` disables this watcher. The startup-only documented
+JetBrains fallback is not available during live updates.
 
 Release budgets are enforced by `tools/performance/phase9-thresholds.json`.
 Notable limits are 10/300 ms full-paint p95 at 80×24/240×80, 1/10 ms one-row
@@ -172,7 +195,11 @@ focus-safe history, and application-keypad text input.
 - CPU SHM rendering remains the baseline; a future GPU renderer must preserve
   the same cell, fallback, shaping, and damage semantics.
 - Glyph caches are invalidated and rerasterized when physical scale or font
-  identity changes.
+  identity changes; generation-keyed entries cannot cross a live family swap.
+- A live family swap preserves Window size, configured font size and policy,
+  padding, output DPI, runtime zoom, modal and IME state, topology, focus, and
+  history. Existing controller authority may emit one final changed PTY size;
+  observers do not acquire control for font reconciliation.
 - Full-window blend is fast for the current evidence row, but terminal rendering
   must consume semantic damage rather than repaint large windows continuously.
 - Fontconfig process startup is acceptable for the first client slice but may be

--- a/docs/adr/0004-font-and-cpu-renderer.md
+++ b/docs/adr/0004-font-and-cpu-renderer.md
@@ -146,13 +146,15 @@ cleared at successful generation publication; old bytes remain alive only while
 an old prepared frame still retains its generation.
 
 When `main.font` is unset, the client treats fontconfig `monospace` as native
-Omarchy family authority and probes complete effective source identities on a
-bounded interval. Resolution, immutable snapshotting, parsing, metric checks,
-and stable double-resolution run off Tokio and Wayland dispatch paths. A valid
-candidate is fully prepared for active, inactive, and hidden panes before one
-callback-boundary publication. Failure leaves the active generation in place.
-Explicit `main.font` disables this watcher. The startup-only documented
-JetBrains fallback is not available during live updates.
+Omarchy family authority and probes complete effective source identities every
+ten seconds after an initial ten-second delay. This bounds idle Fontconfig
+subprocess churn while retaining live following. Resolution, immutable
+snapshotting, parsing, metric checks, and stable double-resolution run off Tokio
+and Wayland dispatch paths. A valid candidate is fully prepared for active,
+inactive, and hidden panes before one callback-boundary publication. Failure
+leaves the active generation in place. Explicit `main.font` disables this
+watcher. The startup-only documented JetBrains fallback is not available during
+live updates.
 
 Release budgets are enforced by `tools/performance/phase9-thresholds.json`.
 Notable limits are 10/300 ms full-paint p95 at 80×24/240×80, 1/10 ms one-row

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -9,7 +9,7 @@ default path is `${XDG_CONFIG_HOME:-~/.config}/splinterm/config.ini`; set
 
 | Section/key | Meaning | Range/default |
 | --- | --- | --- |
-| `main.font` | fontconfig pattern; regular/bold/italic variants stay within its resolved family | Fontconfig `monospace` Regular |
+| `main.font` | explicit fontconfig pattern; when unset, follow Omarchy's effective `monospace` family | unset |
 | `main.font-pixelsize` | configured pixel font size | 6–96; 14 |
 | `main.font-point-size` | mutually exclusive point-size alternative | 6–96; unset |
 | `main.font-size` | deprecated alias for `main.font-pixelsize` | unset |
@@ -41,13 +41,32 @@ outside terminal hit-testing, and emits one bounded `grid_capped` diagnostic for
 the pane instead of silently treating the residual as terminal cells.
 
 Malformed supported values fail startup. Unknown sections and keys print
-line-numbered diagnostics. The default `monospace` pattern follows Omarchy's
-effective Fontconfig terminal-family selection for each newly launched client.
-An explicit `main.font` pattern remains the client-local authority. Splinterm
-resolves regular, bold, italic, and bold-italic from the selected regular
-family; when a styled face is missing, substituted to another family, or has
-incompatible terminal-cell metrics, Splinterm warns and deliberately reuses the
-regular face instead of refusing to open a Window.
+line-numbered diagnostics. When `main.font` is unset, each graphical client
+follows Fontconfig's effective `monospace` family and watches that complete
+regular/bold/italic/bold-italic plus CJK/emoji generation for live changes. An
+explicit `main.font` remains authoritative and disables native live family
+following, including when its literal value is `monospace`. Native startup tries
+the documented JetBrains Mono Nerd Font pattern only if initial `monospace`
+resolution fails, then fails startup if that fallback is also unavailable; a
+live-update failure never switches to the fallback and retains the complete last
+valid generation.
+
+Splinterm resolves regular, bold, italic, and bold-italic from the selected
+regular family. Fontconfig-selected named instances in variable fonts are
+preserved across FreeType metrics and rasterization and Swash shaping, metrics,
+and outline rasterization. When a styled face is missing, substituted to another
+family, or has incompatible terminal-cell metrics, Splinterm warns and
+reuses the regular face.
+
+A valid native family change preserves configured size and sizing policy,
+padding, output DPI, runtime zoom, topology, focus, history and copy-mode
+anchors, modal input, visible IME preedit, and running processes. Splinterm
+stages immutable bounded primary, CJK, and emoji font bytes plus ordered
+fallback metadata off the Wayland dispatch path, publishes the generation
+atomically, rebuilds active and hidden pane frames, and lets only an
+existing pane controller issue the final PTY resize. Observer panes prepare a
+future size without acquiring control. Font changes do not imply live reload of
+font size, padding, shell, scrollback, cursor, or keymap settings.
 
 By default, palette roles come directly from the
 active Omarchy theme's `colors.toml` and effective `foot.ini`; `[colors] alpha`
@@ -448,6 +467,14 @@ daemon, shell, or Wayland window. A transiently incomplete replacement or
 malformed live theme retains the last valid palette and reports one bounded
 diagnostic. If Omarchy state is absent at startup, Splinterm uses its bundled
 safe fallback.
+
+For each new Splint, the persistent daemon also reads the active theme's
+`gum_env.lua`, removes inherited values in Omarchy's bounded Gum palette
+namespace, and supplies the current rendered values to the new PTY. Theme
+changes therefore affect Gum in newly created shells without restarting the
+daemon or existing sessions. Existing shells retain their original environment.
+If the Gum palette is absent or malformed, the daemon preserves its inherited
+environment instead of applying a partial update.
 
 No theme hook, generated file, or manual integration step is required. Setting
 `main.theme=/path/to/theme.json` explicitly opts out of Omarchy discovery for

--- a/docs/images.md
+++ b/docs/images.md
@@ -9,7 +9,7 @@ SSH relay metadata.
 
 | Protocol/operation | Status | Notes |
 | --- | --- | --- |
-| Sixel DCS `q` | supported | Foot 1.27.0-compatible streaming decode, palette modes, raster attributes, repeat, carriage return, graphical newline, cursor/scroller modes, overlap, resize, and reflow |
+| Sixel DCS `q` | supported | When enabled, advertised through primary device attribute `4`; Foot 1.27.0-compatible streaming decode, palette modes, raster attributes, repeat, carriage return, graphical newline, cursor/scroller modes, overlap, resize, and reflow |
 | Kitty direct RGB/RGBA | supported | direct and chunked static transmission; optional zlib |
 | Kitty direct PNG | supported | bounded PNG decode; `kitten icat` 0.48.0 and Chafa 1.18.2 streams are pinned fixtures |
 | Kitty transmit/display/query | supported subset | IDs, placements, crop, aspect-preserving extents, cell offsets, cursor policy, and signed z tiers |

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -3,11 +3,11 @@
 Release authority, candidate construction, approval boundaries, and the future
 n8n notification role are defined in [Release automation](release-automation.md).
 
-Splinterm's `packaging/PKGBUILD` prepares the `0.1.0beta3` split packages for
+Splinterm's `packaging/PKGBUILD` prepares the `0.1.0rc.1` split packages for
 reviewed local and CI candidate builds. Its local source archive and `SKIP` checksum are
 valid only in that workflow. The current public versioned release is
-[`v0.1.0-beta2`](https://github.com/OldJobobo/splinterm/releases/tag/v0.1.0-beta2),
-and both AUR package bases publish `0.1.0beta2-1`. The closed
+[`v0.1.0-beta3`](https://github.com/OldJobobo/splinterm/releases/tag/v0.1.0-beta3),
+and both AUR package bases publish `0.1.0beta3-1`. The closed
 `packaging/release-state.json` record is the machine-readable authority for that
 current public predecessor; candidate construction and promotion both reject a
 different supplied tag even when it exists. `docs/status.md` carries the same
@@ -106,8 +106,8 @@ complete package test suite. This is the mode used by `./install.sh --source`;
 Its equivalent manual build from a clean checkout is:
 
 ```bash
-git archive --format=tar.gz --prefix=splinterm-0.1.0beta3/ \
-  -o packaging/splinterm-0.1.0beta3.tar.gz HEAD
+git archive --format=tar.gz --prefix=splinterm-0.1.0rc.1/ \
+  -o packaging/splinterm-0.1.0rc.1.tar.gz HEAD
 ```
 
 The archive honors `.gitattributes` `export-ignore` entries; website source and
@@ -126,8 +126,8 @@ creates the main package plus the explicitly optional `splinterm-mcp` split
 package without installing either. Inspect them with:
 
 ```bash
-pacman -Qlp packaging/splinterm-0.1.0beta3-1-x86_64.pkg.tar.zst
-pacman -Qlp packaging/splinterm-mcp-0.1.0beta3-1-x86_64.pkg.tar.zst
+pacman -Qlp packaging/splinterm-0.1.0rc.1-1-x86_64.pkg.tar.zst
+pacman -Qlp packaging/splinterm-mcp-0.1.0rc.1-1-x86_64.pkg.tar.zst
 namcap packaging/PKGBUILD packaging/*.pkg.tar.zst   # optional
 ```
 
@@ -239,7 +239,7 @@ The equivalent manual lifecycle is:
 
 ```bash
 systemctl --user stop splinterd.service
-sudo pacman -U packaging/splinterm-0.1.0beta3-1-x86_64.pkg.tar.zst
+sudo pacman -U packaging/splinterm-0.1.0rc.1-1-x86_64.pkg.tar.zst
 systemctl --user daemon-reload
 systemctl --user start splinterd.service
 ```
@@ -247,7 +247,7 @@ systemctl --user start splinterd.service
 Install the adapter only when an MCP host will be configured:
 
 ```bash
-sudo pacman -U packaging/splinterm-mcp-0.1.0beta3-1-x86_64.pkg.tar.zst
+sudo pacman -U packaging/splinterm-mcp-0.1.0rc.1-1-x86_64.pkg.tar.zst
 ```
 
 The guarded upgrade script upgrades `splinterm-mcp` only when that optional

--- a/docs/product-roadmap.md
+++ b/docs/product-roadmap.md
@@ -97,7 +97,8 @@ work only through explicit bounded authority.
 - Make Lair and Dojo lifecycle intentional: named, pinned, disposable,
   restorable, and expired work should be recognizable and manageable.
 - Finish the fit-and-finish gaps that make the terminal feel native to Omarchy,
-  including exact theme fidelity and supported desktop integration.
+  including exact theme fidelity, live native system-font following, and
+  supported desktop integration.
 - Build on delivered bounded local-file path insertion with separately designed
   saved-image paths and other desktop workflows that preserve terminal input
   and privacy boundaries.

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,6 +1,6 @@
 # Current product status
 
-- **Current public version tag:** `v0.1.0-beta2`
+- **Current public version tag:** `v0.1.0-beta3`
 
 This document is the repository authority for Splinterm's current maturity,
 validated product scope, availability, and release gates. The [product roadmap](product-roadmap.md)
@@ -33,37 +33,85 @@ The current product target is:
 - native Wayland under the documented Hyprland environment;
 - Foot 1.27.0 commit `3c5b584b0eafa772eb4376fb6eaf6643399e190e`
   as the terminal-behavior oracle;
-- public Beta 2 `0.1.0beta2-1` Arch packages built from clean committed
+- public Beta 3 `0.1.0beta3-1` Arch packages built from clean committed
   source; and
 - guarded installed-package evidence for the Alpha3 command, scrollback,
   saved-Lair, Wayland file-drop, and Omarchy screensaver workflows; isolated
   exact-package acceptance for the Alpha3.1 transient-tab hotfixes; accepted
   Beta 1 graphical, package, provenance, wide-grid, sparse-publication, and
-  active-tab contrast evidence; and accepted Beta 2 terminal-lifetime,
-  font-family, workload-isolation, package, and release evidence.
+  active-tab contrast evidence; accepted Beta 2 terminal-lifetime, font-family,
+  workload-isolation, package, and release evidence; and accepted Beta 3
+  workload-policy, tab-strip, compatibility-label, package, and release evidence.
 
 Other Linux distributions, compositors, architectures, and package formats are
 not current compatibility promises. Headless `splinterd` does not require a
 graphical environment, but its packaged and remote workflows remain beta
 interfaces on the documented platform.
 
-## Beta 3 candidate preparation
+## Unreleased 0.1.0 stabilization
 
-The `0.1.0-beta3` maintenance candidate removes Splinterm's provisional
-512/1024/2048 task ceilings from terminal workload scopes and slices so ordinary
-Chromium, Node, editor, build, and agent workloads inherit the surrounding
-systemd user manager's `DefaultTasksMax`. The daemon retains its independent
-`TasksMax=2048` control-plane guard and the existing nested workload and
-memory-pressure boundaries remain intact.
+This source branch implements live native Omarchy system-font synchronization.
+When `main.font` is unset, a graphical client follows the effective Fontconfig
+`monospace` family, stages complete immutable face generations off dispatch
+paths, and atomically rebuilds active and hidden presentation state while
+preserving configured size and policy, padding, DPI, runtime zoom, topology,
+focus, history, modal input, and IME preedit. Explicit `main.font` disables
+native following. Invalid live candidates retain the last valid generation, and
+observer panes do not acquire control solely to resize.
 
-The candidate also places the New Dojo control immediately after the final
-visible tab, gives inactive tabs exact semantic dividers, and presents the strict
-historical initial Dojo `terminal` under Lair `terminal-<epoch-seconds>-<pid>`
-as `Dojo 1` without changing ordinary explicit names or daemon-owned topology.
-Focused implementation tests have passed; complete non-graphical release
-validation, independent review, candidate construction,
-protected publication, installation, and AUR updates remain pending. Beta 2
-remains the current public release.
+Focused and complete non-graphical validation, independent review, packaged
+graphical acceptance, and publication remain separate release boundaries.
+
+## 0.1.0 RC1 candidate preparation
+
+The `0.1.0-rc.1` maintenance candidate freezes the 0.1 feature line for
+stabilization on top of the complete public Beta 3 baseline. It refreshes the
+bounded Omarchy Gum palette environment for each newly created Splint so a
+persistent daemon does not give later PTYs stale theme colors. Existing PTYs
+remain unchanged, unrelated environment variables remain untouched, and
+missing, malformed, oversized, symlinked, or non-regular palette state preserves
+the daemon's inherited values instead of applying a partial update.
+
+Focused and complete non-graphical source validation and independent maintenance
+review are required before candidate construction. Protected publication,
+installation evidence, and the RC soak remain separate release boundaries. Beta
+3 remains the current public release until those boundaries complete.
+
+## Beta 3 release
+
+[`v0.1.0-beta3`](https://github.com/OldJobobo/splinterm/releases/tag/v0.1.0-beta3)
+was published as a GitHub prerelease on 2026-08-28 and distributed through both
+AUR package bases as `0.1.0beta3-1`. Beta 3 removes provisional fixed task
+ceilings from terminal workload scopes and slices so ordinary applications
+inherit the surrounding systemd user manager's task policy while the daemon
+retains its independent `TasksMax=2048` control-plane guard. It also places the
+New Dojo control after the final visible tab, gives inactive tabs semantic
+dividers, and presents the strict historical unnamed initial Dojo form as
+`Dojo 1` without changing daemon-owned topology.
+
+- Release commit `f7e695df13e6595256ef9bfa6a702449a66bf674` passed exact-SHA CI
+  run `33150750026`. Candidate run `33151111255` built the release once, and
+  protected promotion run `33151651368` published and reverified the exact
+  five public assets; publication receipt artifact `9685613482` remains the
+  release record.
+- Source archive SHA-256:
+  `a2da767287f339919f4254a48d422c0dbe38e0bee3c9b507c55f85f3454b93a8`.
+  Main package SHA-256:
+  `690c4771125fb7ccca22a1ad5c49d73e58e8b565038da5cd6a0ef4ec2eaad26d`.
+  MCP package SHA-256:
+  `cf4518591c75c9c827abedaa15fa1f97d295b2699ab2d534c83b6f54b0653bb3`.
+- AUR source package commit: `2edc58f2335b41819e7da71cd5578ef58ca7809f`.
+  AUR prebuilt package commit: `1fb1472bf3d06764dde5bb886a79dfbe2a008848`.
+  Both visible recipes identify `0.1.0beta3-1` and pin the immutable GitHub
+  source or package assets to the release hashes above.
+- Exact-SHA CI, closed candidate construction, protected promotion, public
+  asset redownload and hash verification, and live AUR recipe verification
+  passed before this status was recorded.
+
+Upgrading Beta 2 to Beta 3 recreates the `0.1` daemon and workload hierarchy and
+therefore ends active Dojos. The [packaging guide](packaging.md) documents the
+required external-terminal upgrade and rollback workflow; package installation
+does not restart the user service automatically.
 
 ## Beta 2 release
 
@@ -273,7 +321,7 @@ post-alpha3, pre-1.0 roadmap milestone.
 | MCP adapter | Implemented and validated | Optional, separately packaged, exact-identity adapter over the supported automation surface. See [MCP](mcp.md). |
 | Terminal images | Supported documented subset | Sixel, practical static Kitty, and inline iTerm2 PNG subsets are bounded; full Kitty graphics is not claimed. See [Images](images.md). |
 | Arch/Omarchy packaging | Public beta packages validated | Immutable versioned GitHub and AUR split packages, service, desktop metadata, upgrade checks, trusted-client identity, and rollback guidance. See [Packaging](packaging.md). |
-| AUR packages | Available | Recommended prebuilt [`splinterm-bin` `0.1.0beta1-1`](https://aur.archlinux.org/packages/splinterm-bin) publishes `splinterm-bin` and optional `splinterm-mcp-bin` from checksummed immutable versioned-release assets without local compilation. Source-built [`splinterm` `0.1.0beta1-1`](https://aur.archlinux.org/packages/splinterm) and `splinterm-mcp` remain available. |
+| AUR packages | Available | Recommended prebuilt [`splinterm-bin` `0.1.0beta3-1`](https://aur.archlinux.org/packages/splinterm-bin) publishes `splinterm-bin` and optional `splinterm-mcp-bin` from checksummed immutable versioned-release assets without local compilation. Source-built [`splinterm` `0.1.0beta3-1`](https://aur.archlinux.org/packages/splinterm) and `splinterm-mcp` remain available. |
 | Public source and versioned releases | Available | The repository, documentation, protected GitHub prereleases, and AUR packages are public. The retired rolling edge channel is no longer produced or consumed. |
 | Stable support | Unreleased | No compatibility window, support duration, or formal support/security-reporting process is promised yet. |
 | Nix and broader distribution | Planned | Not current product behavior or support. |

--- a/packaging/PKGBUILD
+++ b/packaging/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: OldJobobo
 pkgbase=splinterm
 pkgname=('splinterm' 'splinterm-mcp')
-pkgver=0.1.0beta3
+pkgver=0.1.0rc.1
 pkgrel=1
 arch=('x86_64')
 url='https://github.com/oldjobobo/splinterm'

--- a/packaging/aur-bin/.SRCINFO
+++ b/packaging/aur-bin/.SRCINFO
@@ -1,15 +1,15 @@
 pkgbase = splinterm-bin
-	pkgver = 0.1.0beta3
+	pkgver = 0.1.0rc.1
 	pkgrel = 1
 	url = https://github.com/oldjobobo/splinterm
 	arch = x86_64
 	license = MIT
-	noextract = splinterm-0.1.0beta3-x86_64.pkg.tar.zst
-	noextract = splinterm-mcp-0.1.0beta3-x86_64.pkg.tar.zst
+	noextract = splinterm-0.1.0rc.1-x86_64.pkg.tar.zst
+	noextract = splinterm-mcp-0.1.0rc.1-x86_64.pkg.tar.zst
 	options = !strip
 	options = !debug
-	source = splinterm-0.1.0beta3-x86_64.pkg.tar.zst::https://github.com/OldJobobo/splinterm/releases/download/v0.1.0-beta3/splinterm-11742b60cb5b502cdadb60a582b9c3c838120d2b-x86_64.pkg.tar.zst
-	source = splinterm-mcp-0.1.0beta3-x86_64.pkg.tar.zst::https://github.com/OldJobobo/splinterm/releases/download/v0.1.0-beta3/splinterm-mcp-11742b60cb5b502cdadb60a582b9c3c838120d2b-x86_64.pkg.tar.zst
+	source = splinterm-0.1.0rc.1-x86_64.pkg.tar.zst::https://github.com/OldJobobo/splinterm/releases/download/v0.1.0-rc.1/splinterm-11742b60cb5b502cdadb60a582b9c3c838120d2b-x86_64.pkg.tar.zst
+	source = splinterm-mcp-0.1.0rc.1-x86_64.pkg.tar.zst::https://github.com/OldJobobo/splinterm/releases/download/v0.1.0-rc.1/splinterm-mcp-11742b60cb5b502cdadb60a582b9c3c838120d2b-x86_64.pkg.tar.zst
 	sha256sums = 1a7f2a31c04dfc87495740938a3e8410f2a464f99c382a0f5d563045d8798cfb
 	sha256sums = e53a2b567619d6d8058522c4e18ef077e3b575cc99889d26cc1a18d65647ead0
 
@@ -31,13 +31,13 @@ pkgname = splinterm-bin
 	depends = xdg-terminal-exec
 	optdepends = fcitx5: Wayland text-input support
 	optdepends = splinterm-mcp-bin: explicitly configured MCP stdio adapter
-	provides = splinterm=0.1.0beta3-1
+	provides = splinterm=0.1.0rc.1-1
 	conflicts = splinterm
 
 pkgname = splinterm-mcp-bin
 	pkgdesc = Policy-scoped MCP stdio adapter for Splinterm (prebuilt binary)
-	depends = splinterm=0.1.0beta3-1
+	depends = splinterm=0.1.0rc.1-1
 	depends = gcc-libs
 	depends = glibc
-	provides = splinterm-mcp=0.1.0beta3-1
+	provides = splinterm-mcp=0.1.0rc.1-1
 	conflicts = splinterm-mcp

--- a/packaging/aur-bin/PKGBUILD
+++ b/packaging/aur-bin/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: OldJobobo
 pkgbase=splinterm-bin
 pkgname=('splinterm-bin' 'splinterm-mcp-bin')
-pkgver=0.1.0beta3
+pkgver=0.1.0rc.1
 pkgrel=1
 _commit=11742b60cb5b502cdadb60a582b9c3c838120d2b
 arch=('x86_64')
@@ -9,8 +9,8 @@ url='https://github.com/oldjobobo/splinterm'
 license=('MIT')
 options=('!strip' '!debug')
 source=(
-  "splinterm-$pkgver-$CARCH.pkg.tar.zst::https://github.com/OldJobobo/splinterm/releases/download/v0.1.0-beta3/splinterm-$_commit-$CARCH.pkg.tar.zst"
-  "splinterm-mcp-$pkgver-$CARCH.pkg.tar.zst::https://github.com/OldJobobo/splinterm/releases/download/v0.1.0-beta3/splinterm-mcp-$_commit-$CARCH.pkg.tar.zst"
+  "splinterm-$pkgver-$CARCH.pkg.tar.zst::https://github.com/OldJobobo/splinterm/releases/download/v0.1.0-rc.1/splinterm-$_commit-$CARCH.pkg.tar.zst"
+  "splinterm-mcp-$pkgver-$CARCH.pkg.tar.zst::https://github.com/OldJobobo/splinterm/releases/download/v0.1.0-rc.1/splinterm-mcp-$_commit-$CARCH.pkg.tar.zst"
 )
 noextract=(
   "splinterm-$pkgver-$CARCH.pkg.tar.zst"

--- a/packaging/aur/.SRCINFO
+++ b/packaging/aur/.SRCINFO
@@ -1,5 +1,5 @@
 pkgbase = splinterm
-	pkgver = 0.1.0beta3
+	pkgver = 0.1.0rc.1
 	pkgrel = 1
 	url = https://github.com/oldjobobo/splinterm
 	arch = x86_64
@@ -19,7 +19,7 @@ pkgbase = splinterm
 	makedepends = ttf-jetbrains-mono-nerd
 	makedepends = wayland
 	makedepends = xdg-terminal-exec
-	source = https://github.com/OldJobobo/splinterm/releases/download/v0.1.0-beta3/splinterm-0.1.0-beta3.tar.gz
+	source = https://github.com/OldJobobo/splinterm/releases/download/v0.1.0-rc.1/splinterm-0.1.0-rc.1.tar.gz
 	sha256sums = d59bf82a5e2218112613d4a69adb20ce2b6cd8c133cc9b14da8fbfa1de4d0644
 
 pkgname = splinterm
@@ -43,6 +43,6 @@ pkgname = splinterm
 
 pkgname = splinterm-mcp
 	pkgdesc = Policy-scoped MCP stdio adapter for Splinterm
-	depends = splinterm=0.1.0beta3-1
+	depends = splinterm=0.1.0rc.1-1
 	depends = gcc-libs
 	depends = glibc

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -1,8 +1,8 @@
 # Maintainer: OldJobobo
 pkgbase=splinterm
 pkgname=('splinterm' 'splinterm-mcp')
-pkgver=0.1.0beta3
-_upstream_ver=0.1.0-beta3
+pkgver=0.1.0rc.1
+_upstream_ver=0.1.0-rc.1
 pkgrel=1
 arch=('x86_64')
 url='https://github.com/oldjobobo/splinterm'

--- a/packaging/release-state.json
+++ b/packaging/release-state.json
@@ -1,4 +1,4 @@
 {
   "schema": 1,
-  "current_version_tag": "v0.1.0-beta2"
+  "current_version_tag": "v0.1.0-beta3"
 }

--- a/site/src/content/docs/docs/status.md
+++ b/site/src/content/docs/docs/status.md
@@ -5,9 +5,9 @@ description: What is implemented, validated, limited, planned, and unreleased in
 
 Splinterm is a **public beta**. Source, documentation, and immutable versioned GitHub and AUR packages are public. Substantial core behavior is implemented and validated, while the validated target remains narrow and stable compatibility guarantees have not been released.
 
-[`v0.1.0-beta2`](https://github.com/OldJobobo/splinterm/releases/tag/v0.1.0-beta2) is the current public prerelease. It adds configurable Window-owned terminal lifetimes, corrected startup font-family and glyph fallback resolution, and verified nested systemd workload isolation.
+[`v0.1.0-beta3`](https://github.com/OldJobobo/splinterm/releases/tag/v0.1.0-beta3) is the current public prerelease. It lets terminal workloads inherit the user manager's normal task policy while retaining the daemon guard, and it polishes the Dojo tab strip and legacy unnamed-Dojo label.
 
-Beta 3 candidate preparation is in progress. It removes provisional per-workload task ceilings so terminal applications inherit the user manager's normal task policy while the daemon retains its independent guard. It also places the New Dojo control beside the final tab, separates inactive tabs with semantic dividers, and gives legacy unnamed Dojos a stable `Dojo 1` tab label. Focused tests pass; complete release validation, review, publication, installation, and AUR updates remain pending.
+`0.1.0-rc.1` candidate preparation is in progress as the stabilization boundary for the final `0.1.0` release. It adds current Omarchy Gum palette inheritance for newly created Splints without changing existing PTYs. Complete candidate construction, protected publication, installation, and soak evidence remain pending.
 
 ## What that means
 
@@ -37,7 +37,7 @@ Beta 3 candidate preparation is in progress. It removes provisional per-workload
 | Sixel, practical Kitty static images, inline iTerm2 PNG | Documented supported subsets |
 | Arch/Omarchy package | Versioned GitHub release and AUR packages validated |
 | Public source and versioned builds | Available |
-| [AUR packages](https://aur.archlinux.org/packages/splinterm-bin) | Recommended prebuilt `splinterm-bin`; source-built `splinterm` also available, both `0.1.0beta2-1` |
+| [AUR packages](https://aur.archlinux.org/packages/splinterm-bin) | Recommended prebuilt `splinterm-bin`; source-built `splinterm` also available, both `0.1.0beta3-1` |
 | Stable support and broader compatibility | Not released |
 | Nix and broader distributions | Planned |
 

--- a/tools/foot-oracle/provenance.json
+++ b/tools/foot-oracle/provenance.json
@@ -59,7 +59,7 @@
   "rust": {
     "rustc": "1.91.0",
     "cargo": "1.91.0",
-    "cargo_lock_sha256": "c6f97db22c022a2283ef44022bf1f2e08f56aec7860b991860ae11cb4c4dec0f",
+    "cargo_lock_sha256": "ba02518751a081095bf95b762b9077f6e3c3df810e4a2e6d8df70ff216c5cc62",
     "dependencies": {
       "fontdb": "0.23.0",
       "freetype-rs": "0.38.0",
@@ -112,7 +112,7 @@
     },
     "foreground": "ebebeb",
     "background": "0e1216",
-    "cargo_lock_sha256": "c6f97db22c022a2283ef44022bf1f2e08f56aec7860b991860ae11cb4c4dec0f"
+    "cargo_lock_sha256": "ba02518751a081095bf95b762b9077f6e3c3df810e4a2e6d8df70ff216c5cc62"
   },
   "semantic_fixture_schema": "fixtures/terminal/v1/schema.md",
   "final_buffer_schema": "tools/foot-oracle/final-buffer-schema.md",

--- a/tools/release/test_prepare_candidate.py
+++ b/tools/release/test_prepare_candidate.py
@@ -140,7 +140,7 @@ class PrepareCandidateTests(unittest.TestCase):
         commit = MODULE.run(["git", "rev-parse", "HEAD"])
         with self.assertRaisesRegex(ValueError, "release tag already exists"):
             MODULE.validate_candidate(
-                "OldJobobo/splinterm", commit, version, "v0.1.0-beta1"
+                "OldJobobo/splinterm", commit, version, "v0.1.0-beta3"
             )
 
     def test_mismatched_version_fails_before_build(self) -> None:
@@ -150,30 +150,30 @@ class PrepareCandidateTests(unittest.TestCase):
                 "OldJobobo/splinterm",
                 commit,
                 "9.9.9-alpha9",
-                "v0.1.0-beta2",
+                "v0.1.0-beta3",
             )
 
     def test_previous_release_is_explicit_existing_and_distinct(self) -> None:
-        release_tag = "v9.9.9-beta3"
+        release_tag = "v9.9.9-rc.1"
         with mock.patch.object(MODULE, "run", return_value="a" * 40):
             self.assertEqual(
-                MODULE.validate_previous_version_tag("v0.1.0-beta2", release_tag),
-                "v0.1.0-beta2",
+                MODULE.validate_previous_version_tag("v0.1.0-beta3", release_tag),
+                "v0.1.0-beta3",
             )
         with self.assertRaisesRegex(ValueError, "v-prefixed SemVer"):
-            MODULE.validate_previous_version_tag("0.1.0-beta2", release_tag)
+            MODULE.validate_previous_version_tag("0.1.0-beta3", release_tag)
         with self.assertRaisesRegex(ValueError, "must differ"):
             MODULE.validate_previous_version_tag(release_tag, release_tag)
         with self.assertRaisesRegex(ValueError, "current public release"):
-            MODULE.validate_previous_version_tag("v0.1.0-beta1", release_tag)
+            MODULE.validate_previous_version_tag("v0.1.0-beta2", release_tag)
         with (
             mock.patch.object(MODULE, "run", side_effect=ValueError("missing tag")),
             self.assertRaisesRegex(ValueError, "missing tag"),
         ):
-            MODULE.validate_previous_version_tag("v0.1.0-beta2", release_tag)
+            MODULE.validate_previous_version_tag("v0.1.0-beta3", release_tag)
 
     def test_public_release_state_is_closed_and_versioned(self) -> None:
-        self.assertEqual(MODULE.current_public_release_tag(), "v0.1.0-beta2")
+        self.assertEqual(MODULE.current_public_release_tag(), "v0.1.0-beta3")
         state = json.loads(
             (ROOT / "packaging/release-state.json").read_text(encoding="utf-8")
         )
@@ -181,7 +181,7 @@ class PrepareCandidateTests(unittest.TestCase):
         self.assertEqual(state["schema"], 1)
         status = (ROOT / "docs/status.md").read_text(encoding="utf-8")
         self.assertEqual(
-            status.count("**Current public version tag:** `v0.1.0-beta2`"), 1
+            status.count("**Current public version tag:** `v0.1.0-beta3`"), 1
         )
 
     def test_release_notes_are_read_from_the_exact_candidate_commit(self) -> None:
@@ -193,7 +193,7 @@ class PrepareCandidateTests(unittest.TestCase):
                 output.read_text(encoding="utf-8"),
                 MODULE.run(["git", "show", f"{commit}:RELEASE_NOTES.md"]) + "\n",
             )
-            self.assertIn("Room to Work", output.read_text(encoding="utf-8"))
+            self.assertIn("Stable Ground", output.read_text(encoding="utf-8"))
 
     def test_manifest_example_is_json_serializable(self) -> None:
         manifest = {

--- a/tools/release/test_promote_release.py
+++ b/tools/release/test_promote_release.py
@@ -22,7 +22,7 @@ RUN_ID = 12345
 
 class CandidateFixture:
     def __init__(
-        self, root: Path, previous_version_tag: str = "v0.1.0-beta2"
+        self, root: Path, previous_version_tag: str = "v0.1.0-beta3"
     ) -> None:
         self.root = root
         self.assets = MODULE.expected_assets(COMMIT, VERSION)


### PR DESCRIPTION
## Summary

- advance the 0.1 maintenance line from Beta 3 to RC1
- include bounded Gum environment refresh, Yazi Sixel capability, live Omarchy font synchronization with variable-font support, and legacy Dojo restore-name migration
- finalize RC1 release notes and package/release metadata

## Authority

This one-commit linear release branch has tree `676169d5be773bd5e62807a1be8851d9b0ee51df`, byte-identical to reviewed local RC authority `e02c4f3e9804b156dd65d2a2c916a296d4f6a8a2`. It exists to satisfy the protected `maint/0.1` no-merge-commit rule without rewriting the reviewed local integration history.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- portable Foot provenance
- all-target/all-feature Clippy with warnings denied
- full serial workspace tests, excluding only the pre-existing independently reproduced subscription-race test
- complete CI Python automation, contract, Foot fixture, and benchmark suites
- exact clean Arch split-package build and package validation
- packaged live installation on the persistent Omarchy VM
- live Wintermute installation with Pacman integrity, trusted sibling identity, daemon `ping`, human `list`, and configuration verification
- independent exact-tree release review: OK

Strict local raster provenance remains host-classified only: workstation Fontconfig 2.18.3 differs from the pinned 2.18.2 reference environment; portable provenance passes.
