### PR TITLE
Prepare 0.1.0 RC2 font closure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1400,7 +1400,7 @@ dependencies = [
 
 [[package]]
 name = "splinterd"
-version = "0.1.0-rc.1"
+version = "0.1.0-rc.2"
 dependencies = [
  "anyhow",
  "libc",
@@ -1425,7 +1425,7 @@ dependencies = [
 
 [[package]]
 name = "splinterm"
-version = "0.1.0-rc.1"
+version = "0.1.0-rc.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -1455,7 +1455,7 @@ dependencies = [
 
 [[package]]
 name = "splinterm-automation-client"
-version = "0.1.0-rc.1"
+version = "0.1.0-rc.2"
 dependencies = [
  "anyhow",
  "rustix",
@@ -1471,7 +1471,7 @@ dependencies = [
 
 [[package]]
 name = "splinterm-core"
-version = "0.1.0-rc.1"
+version = "0.1.0-rc.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -1481,7 +1481,7 @@ dependencies = [
 
 [[package]]
 name = "splinterm-filemap"
-version = "0.1.0-rc.1"
+version = "0.1.0-rc.2"
 dependencies = [
  "memmap2",
  "rustix",
@@ -1489,17 +1489,18 @@ dependencies = [
 
 [[package]]
 name = "splinterm-freetype"
-version = "0.1.0-rc.1"
+version = "0.1.0-rc.2"
 dependencies = [
  "freetype-rs",
  "splinterm-filemap",
  "splinterm-pixman",
  "thiserror",
+ "ttf-parser",
 ]
 
 [[package]]
 name = "splinterm-graphical-relay"
-version = "0.1.0-rc.1"
+version = "0.1.0-rc.2"
 dependencies = [
  "anyhow",
  "tokio",
@@ -1508,7 +1509,7 @@ dependencies = [
 
 [[package]]
 name = "splinterm-mcp"
-version = "0.1.0-rc.1"
+version = "0.1.0-rc.2"
 dependencies = [
  "anyhow",
  "rmcp",
@@ -1523,7 +1524,7 @@ dependencies = [
 
 [[package]]
 name = "splinterm-pixman"
-version = "0.1.0-rc.1"
+version = "0.1.0-rc.2"
 dependencies = [
  "libc",
  "pixman-sys",
@@ -1532,7 +1533,7 @@ dependencies = [
 
 [[package]]
 name = "splinterm-protocol"
-version = "0.1.0-rc.1"
+version = "0.1.0-rc.2"
 dependencies = [
  "base64",
  "rustix",
@@ -1545,7 +1546,7 @@ dependencies = [
 
 [[package]]
 name = "splinterm-pty"
-version = "0.1.0-rc.1"
+version = "0.1.0-rc.2"
 dependencies = [
  "rustix",
  "thiserror",
@@ -1554,7 +1555,7 @@ dependencies = [
 
 [[package]]
 name = "splinterm-relay"
-version = "0.1.0-rc.1"
+version = "0.1.0-rc.2"
 dependencies = [
  "anyhow",
  "nix",
@@ -1566,7 +1567,7 @@ dependencies = [
 
 [[package]]
 name = "splinterm-terminal"
-version = "0.1.0-rc.1"
+version = "0.1.0-rc.2"
 dependencies = [
  "base64",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.1.0-rc.1"
+version = "0.1.0-rc.2"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT"

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,13 +1,21 @@
-# Splinterm 0.1.0 RC1 — Stable Ground
+# Splinterm 0.1.0 RC2 — Font Reload Closure
 
-This is the first release candidate for Splinterm 0.1.0. It freezes the 0.1
-feature line for stabilization and carries the complete public Beta 3 baseline
-plus bounded fixes for Omarchy environment refresh, live font following, Yazi
-image previews, and legacy Dojo restore names.
+This is the second release candidate for Splinterm 0.1.0. It retains the complete
+RC1 feature line and closes two live-font correctness and resource findings found
+during RC1 review.
 
-RC1 is intended for normal daily use and soak testing on the documented target:
-x86_64 Omarchy/Arch Linux with native Wayland under Hyprland. A code change after
-RC1 requires another release candidate before the final `v0.1.0` release.
+RC2 is intended for normal daily use and soak testing on the documented target:
+x86_64 Omarchy/Arch Linux with native Wayland under Hyprland. Any later code
+change requires another release candidate before the final `v0.1.0` release.
+
+## Live-font closure fixes
+
+- A staged generation that differs from its preceding probe now becomes the
+  watcher authority, so a later return to the probed generation is not skipped.
+- Cached FreeType faces now retain shared immutable font mappings instead of
+  copying the complete font file for every generation, face, and raster size.
+- Font-generation identity and lifetime tests resolve the host's generic
+  monospace family instead of requiring JetBrains Mono to be installed.
 
 ## Live Omarchy font following
 
@@ -86,8 +94,8 @@ lifetime, presets, and the documented native Wayland path remain part of the
 
 ## Upgrade boundary
 
-Splinterm 0.1 does not support live daemon upgrade handoff. Upgrading Beta 3 to
-RC1 therefore ends active Dojos. Run the upgrade from Foot or another terminal
+Splinterm 0.1 does not support live daemon upgrade handoff. Upgrading RC1 to
+RC2 therefore ends active Dojos. Run the upgrade from Foot or another terminal
 that is not owned by `splinterd`:
 
 ```bash
@@ -100,10 +108,12 @@ systemctl --user start splinterd.service
 Then reopen Splinterm Windows. Package installation does not silently reload or
 restart the user service.
 
-## RC1 soak focus
+## RC2 soak focus
 
 During the release-candidate soak, please pay particular attention to:
 
+- repeated valid, invalid, and rapidly superseded Omarchy font changes;
+- stable file-descriptor and memory use across repeated font and scale changes;
 - repeated Omarchy theme changes followed by newly created Splints;
 - existing PTYs retaining their original environment;
 - clean installation and Beta 3 upgrade/rollback;
@@ -111,5 +121,5 @@ During the release-candidate soak, please pay particular attention to:
 - trusted graphical-client identity and desktop launching; and
 - optional MCP package behavior when installed.
 
-RC1 remains a prerelease. If stabilization requires any code change, the next
-public build will be RC2 rather than the final `v0.1.0` release.
+RC2 remains a prerelease. If stabilization requires any code change, the next
+public build will be RC3 rather than the final `v0.1.0` release.

--- a/crates/splinterm-freetype/Cargo.toml
+++ b/crates/splinterm-freetype/Cargo.toml
@@ -12,6 +12,7 @@ freetype-rs.workspace = true
 splinterm-filemap = { path = "../splinterm-filemap" }
 splinterm-pixman = { path = "../splinterm-pixman" }
 thiserror.workspace = true
+ttf-parser = "0.25.1"
 
 [lints]
 workspace = true

--- a/crates/splinterm-freetype/src/lib.rs
+++ b/crates/splinterm-freetype/src/lib.rs
@@ -8,7 +8,6 @@
 
 use std::{
     borrow::Borrow,
-    ops::Deref,
     path::{Path, PathBuf},
     sync::Arc,
 };
@@ -104,7 +103,7 @@ struct SharedFontData(Arc<ReadOnlyFileMap>);
 
 impl Borrow<[u8]> for SharedFontData {
     fn borrow(&self) -> &[u8] {
-        self.0.as_ref().deref()
+        self.0.as_ref()
     }
 }
 

--- a/crates/splinterm-freetype/src/lib.rs
+++ b/crates/splinterm-freetype/src/lib.rs
@@ -6,11 +6,14 @@
 //! file/index and receive owned, tightly packed alpha bytes; no `FreeType` pointer
 //! or borrowed bitmap escapes the API.
 
-use std::path::{Path, PathBuf};
-
-use freetype::{
-    Face, Library, RenderMode, bitmap::PixelMode, face::LoadFlag, tt_os2::TrueTypeOS2Table,
+use std::{
+    borrow::Borrow,
+    ops::Deref,
+    path::{Path, PathBuf},
+    sync::Arc,
 };
+
+use freetype::{Face, Library, RenderMode, bitmap::PixelMode, face::LoadFlag};
 use splinterm_filemap::ReadOnlyFileMap;
 use thiserror::Error;
 
@@ -96,8 +99,19 @@ pub enum RasterError {
     ScaleColor(#[from] splinterm_pixman::ScaleError),
 }
 
+#[derive(Clone, Debug)]
+struct SharedFontData(Arc<ReadOnlyFileMap>);
+
+impl Borrow<[u8]> for SharedFontData {
+    fn borrow(&self) -> &[u8] {
+        self.0.as_ref().deref()
+    }
+}
+
 pub struct RasterFace {
-    face: Face,
+    face: Face<SharedFontData>,
+    data: SharedFontData,
+    collection_index: u32,
 }
 
 impl RasterFace {
@@ -115,11 +129,14 @@ impl RasterFace {
             return Err(RasterError::InvalidPixelSize);
         }
         let path = path.as_ref();
-        let data = ReadOnlyFileMap::open(path).map_err(|source| RasterError::MapFace {
-            path: path.to_path_buf(),
-            source,
-        })?;
-        Self::open_memory(&data, face_index, pixel_size_26_6)
+        let data =
+            Arc::new(
+                ReadOnlyFileMap::open(path).map_err(|source| RasterError::MapFace {
+                    path: path.to_path_buf(),
+                    source,
+                })?,
+            );
+        Self::open_memory(data, face_index, pixel_size_26_6)
     }
 
     /// Opens one face from immutable generation-owned bytes.
@@ -127,7 +144,7 @@ impl RasterFace {
     /// # Errors
     /// Returns a typed error for invalid bounds or any `FreeType` failure.
     pub fn open_memory(
-        data: &ReadOnlyFileMap,
+        data: Arc<ReadOnlyFileMap>,
         face_index: u32,
         pixel_size_26_6: isize,
     ) -> Result<Self, RasterError> {
@@ -139,15 +156,20 @@ impl RasterFace {
         }
         let index = isize::try_from(face_index).map_err(|_| RasterError::InvalidFaceIndex)?;
         let library = Library::init().map_err(RasterError::Initialize)?;
+        let data = SharedFontData(data);
         let face = library
-            .new_memory_face(data.to_vec(), index)
+            .new_memory_face2(data.clone(), index)
             .map_err(|source| RasterError::OpenMemoryFace {
                 index: face_index,
                 source,
             })?;
         face.set_char_size(pixel_size_26_6, 0, 72, 72)
             .map_err(RasterError::SetSize)?;
-        Ok(Self { face })
+        Ok(Self {
+            face,
+            data,
+            collection_index: face_index & 0xffff,
+        })
     }
 
     /// Rasterize one fixed-strike color glyph using pinned fcft's pixel fixup.
@@ -171,12 +193,15 @@ impl RasterFace {
             return Err(RasterError::InvalidPixelSize);
         }
         let path = path.as_ref();
-        let data = ReadOnlyFileMap::open(path).map_err(|source| RasterError::MapFace {
-            path: path.to_path_buf(),
-            source,
-        })?;
+        let data =
+            Arc::new(
+                ReadOnlyFileMap::open(path).map_err(|source| RasterError::MapFace {
+                    path: path.to_path_buf(),
+                    source,
+                })?,
+            );
         Self::rasterize_color_memory(
-            &data,
+            data,
             face_index,
             requested_pixel_size_26_6,
             selected_pixel_size_26_6,
@@ -190,7 +215,7 @@ impl RasterFace {
     /// Returns a typed error for invalid bounds, `FreeType` failures, non-BGRA
     /// output, malformed bitmap geometry, or pixman scaling failures.
     pub fn rasterize_color_memory(
-        data: &ReadOnlyFileMap,
+        data: Arc<ReadOnlyFileMap>,
         face_index: u32,
         requested_pixel_size_26_6: isize,
         selected_pixel_size_26_6: isize,
@@ -206,15 +231,20 @@ impl RasterFace {
         }
         let index = isize::try_from(face_index).map_err(|_| RasterError::InvalidFaceIndex)?;
         let library = Library::init().map_err(RasterError::Initialize)?;
+        let data = SharedFontData(data);
         let face = library
-            .new_memory_face(data.to_vec(), index)
+            .new_memory_face2(data.clone(), index)
             .map_err(|source| RasterError::OpenMemoryFace {
                 index: face_index,
                 source,
             })?;
         face.set_char_size(selected_pixel_size_26_6, 0, 72, 72)
             .map_err(RasterError::SetSize)?;
-        let mut raster = Self { face };
+        let mut raster = Self {
+            face,
+            data,
+            collection_index: face_index & 0xffff,
+        };
         raster.rasterize_color_glyph(
             requested_pixel_size_26_6,
             selected_pixel_size_26_6,
@@ -357,12 +387,15 @@ impl RasterFace {
         let underline_top = (underline_position + underline_thickness / 2.0).trunc();
         let underline_width = underline_thickness.max(1.0).round();
         let (mut strike_position, mut strike_thickness) =
-            TrueTypeOS2Table::from_face(&mut self.face).map_or((0.0, 0.0), |os2| {
-                (
-                    f64::from(os2.y_strikeout_position()) * y_scale / 64.0,
-                    f64::from(os2.y_strikeout_size()) * y_scale / 64.0,
-                )
-            });
+            ttf_parser::Face::parse(self.data.borrow(), self.collection_index)
+                .ok()
+                .and_then(|face| face.strikeout_metrics())
+                .map_or((0.0, 0.0), |metrics| {
+                    (
+                        f64::from(metrics.position) * y_scale / 64.0,
+                        f64::from(metrics.thickness) * y_scale / 64.0,
+                    )
+                });
         if strike_position == 0.0 {
             strike_thickness = underline_thickness;
             strike_position = 3.0 * ascent / 8.0 - strike_thickness / 2.0;

--- a/crates/splinterm/src/app/font_watch.rs
+++ b/crates/splinterm/src/app/font_watch.rs
@@ -22,7 +22,7 @@ struct FontReloadState<F> {
     current: F,
 }
 
-impl<F: Eq> FontReloadState<F> {
+impl<F: Clone + Eq> FontReloadState<F> {
     fn new(current: F) -> Self {
         Self {
             observed: None,
@@ -43,6 +43,7 @@ impl<F: Eq> FontReloadState<F> {
     }
 
     fn accept(&mut self, fingerprint: F) -> bool {
+        self.observed = Some(fingerprint.clone());
         if self.current == fingerprint {
             return false;
         }
@@ -180,6 +181,15 @@ mod tests {
         assert!(!state.accept(2));
         assert!(state.observe(1));
         assert!(state.accept(1));
+    }
+
+    #[test]
+    fn accepted_staging_replaces_a_divergent_probe_fingerprint() {
+        let mut state = FontReloadState::new(1_u8);
+        assert!(state.observe(2));
+        assert!(state.accept(3));
+        assert!(state.observe(2));
+        assert!(state.accept(2));
     }
 
     #[test]

--- a/crates/splinterm/src/renderer/fonts.rs
+++ b/crates/splinterm/src/renderer/fonts.rs
@@ -719,7 +719,7 @@ pub(super) fn snapshot_glyph(
             let raster_key = (generation_id, face.selected_pixel_size_26_6, face_index);
             if !cache.raster_faces.contains_key(&raster_key) {
                 let raster_face = RasterFace::open_memory(
-                    face.data.as_deref().context("emoji face is staged")?,
+                    face.data.clone().context("emoji face is staged")?,
                     face.index.raw(),
                     face.selected_pixel_size_26_6,
                 )
@@ -753,12 +753,10 @@ pub(super) fn snapshot_glyph(
             if !cache.raster_faces.contains_key(&raster_key) {
                 let face = &faces[face_index];
                 let pixel_size = pixel_size_26_6(font_size)?;
-                let fallback_mapping;
-                let data = if let Some(data) = face.data.as_deref() {
-                    data
+                let data = if let Some(data) = &face.data {
+                    Arc::clone(data)
                 } else {
-                    fallback_mapping = fallback_font_mapping(face)?;
-                    &fallback_mapping
+                    fallback_font_mapping(face)?
                 };
                 let raster_face = RasterFace::open_memory(data, face.index.raw(), pixel_size)
                     .with_context(|| format!("open FreeType raster face {}", face.label))?;
@@ -1288,7 +1286,7 @@ pub(super) fn cell_metrics(primary_face: &FontFace, font_size: f32) -> Result<Ce
     let mut face = RasterFace::open_memory(
         primary_face
             .data
-            .as_deref()
+            .clone()
             .context("primary face is staged")?,
         primary_face.index.raw(),
         pixel_size_26_6(font_size)?,
@@ -2224,7 +2222,7 @@ mod tests {
         );
 
         let mut freetype = RasterFace::open_memory(
-            face.data.as_deref().unwrap(),
+            face.data.clone().unwrap(),
             face.index.raw(),
             pixel_size_26_6(BASE_FONT_SIZE).unwrap(),
         )

--- a/crates/splinterm/src/renderer/tests.rs
+++ b/crates/splinterm/src/renderer/tests.rs
@@ -1,5 +1,13 @@
 use super::{frame::select_face_for_text, *};
 
+fn stage_test_font_generation() -> FontGeneration {
+    stage_live_font_generation(
+        "monospace:style=Regular",
+        crate::config::FontAuthority::NativeOmarchy,
+    )
+    .expect("stage the host's generic monospace family")
+}
+
 fn synthetic_row() -> TextRow {
     let key = GlyphKey { face: 0, glyph: 1 };
     TextRow {
@@ -305,9 +313,7 @@ fn font_generation_replacement_preserves_zoom_dpi_and_alpha() {
         .update_output_dpi(OutputDpiObservation::provided(144.0).unwrap(), 150)
         .unwrap();
     let before = context.effective_font_resolution(150).unwrap();
-    let options = renderer_options();
-    let mut replacement =
-        stage_live_font_generation(&options.font, options.font_authority).unwrap();
+    let mut replacement = stage_test_font_generation();
     replacement.fingerprint.pattern.push_str("#test-generation");
     let replacement_id = replacement.id;
 
@@ -940,12 +946,39 @@ fn memory_backed_freetype_keeps_the_staged_inode_after_path_replacement() {
 
     let shaped = swash::FontRef::from_index(&staged, source.index.collection_index()).unwrap();
     assert_ne!(shaped.charmap().map('界'), 0);
-    let mut raster =
-        splinterm_freetype::RasterFace::open_memory(&staged, source.index.raw(), 22 * 64).unwrap();
+    let retained_before = Arc::strong_count(&staged);
+    let mut raster = splinterm_freetype::RasterFace::open_memory(
+        Arc::clone(&staged),
+        source.index.raw(),
+        22 * 64,
+    )
+    .unwrap();
+    assert!(Arc::strong_count(&staged) > retained_before);
     assert!(raster.metrics().unwrap().height > 0);
+    drop(raster);
+    assert_eq!(Arc::strong_count(&staged), retained_before);
 
     fs::remove_file(path).unwrap();
     fs::remove_file(retired).unwrap();
+}
+
+#[test]
+fn raster_faces_share_one_generation_mapping_across_sizes() {
+    let generation = stage_test_font_generation();
+    let face = &generation.faces[SNAPSHOT_PRIMARY_REGULAR];
+    let data = face.data.clone().expect("primary face is staged");
+    let retained_before = Arc::strong_count(&data);
+
+    let first =
+        splinterm_freetype::RasterFace::open_memory(Arc::clone(&data), face.index.raw(), 16 * 64)
+            .unwrap();
+    let second =
+        splinterm_freetype::RasterFace::open_memory(Arc::clone(&data), face.index.raw(), 32 * 64)
+            .unwrap();
+    assert!(Arc::strong_count(&data) > retained_before);
+
+    drop((first, second));
+    assert_eq!(Arc::strong_count(&data), retained_before);
 }
 
 #[test]
@@ -1203,8 +1236,11 @@ fn forward_and_reverse_viewport_scroll_copy_match_clean_full_repaint() {
 fn persistent_raster_face_cache_is_bounded_across_scale_churn() {
     SNAPSHOT_GLYPH_CACHE.with(|cache| *cache.borrow_mut() = PersistentGlyphCache::default());
     let snapshot = incremental_snapshot();
+    let mut context = RenderContext::new(u16::MAX);
+    assert!(context.replace_font_generation(Arc::new(stage_test_font_generation())));
     for scale_120 in 120..=u32::try_from(120 + SNAPSHOT_RASTER_FACE_BUDGET).unwrap() {
-        SnapshotFrame::load_scaled(&snapshot, scale_120).expect("scaled frame");
+        SnapshotFrame::load_scaled_with_context(&snapshot, scale_120, &context)
+            .expect("scaled frame");
     }
     let metrics = snapshot_cache_metrics();
     assert_eq!(
@@ -1282,11 +1318,10 @@ fn empty_overlays_leave_compositor_border_area_untouched() {
 #[test]
 fn incremental_refresh_rejects_a_different_font_generation() {
     let snapshot = incremental_snapshot();
-    let context = compatibility_render_context().unwrap();
+    let mut context = compatibility_render_context().unwrap();
+    assert!(context.replace_font_generation(Arc::new(stage_test_font_generation())));
     let mut frame = SnapshotFrame::load_scaled_with_context(&snapshot, 120, &context).unwrap();
-    let options = renderer_options();
-    let replacement =
-        Arc::new(stage_live_font_generation(&options.font, options.font_authority).unwrap());
+    let replacement = Arc::new(stage_test_font_generation());
     assert_ne!(frame.font_generation.id, replacement.id);
     frame.font_generation = replacement;
     let error = frame
@@ -1298,7 +1333,9 @@ fn incremental_refresh_rejects_a_different_font_generation() {
 #[test]
 fn prepared_frame_retains_its_font_generation_until_drop() {
     let snapshot = incremental_snapshot();
-    let frame = SnapshotFrame::load_scaled(&snapshot, 120).unwrap();
+    let mut context = compatibility_render_context().unwrap();
+    assert!(context.replace_font_generation(Arc::new(stage_test_font_generation())));
+    let frame = SnapshotFrame::load_scaled_with_context(&snapshot, 120, &context).unwrap();
     let generation = Arc::clone(&frame.font_generation);
     let retained = Arc::strong_count(&generation);
     assert!(retained >= 3);
@@ -1309,13 +1346,12 @@ fn prepared_frame_retains_its_font_generation_until_drop() {
 #[test]
 fn identical_glyph_ids_do_not_share_cache_entries_across_generations() {
     reset_snapshot_cache();
-    let current = snapshot_font_generation().unwrap();
+    let current = stage_test_font_generation();
     let face = &current.faces[SNAPSHOT_PRIMARY_REGULAR];
     let glyph_id = font_ref(face).unwrap().charmap().map('M');
     let current_glyph =
         snapshot_glyph(&current.faces, SNAPSHOT_PRIMARY_REGULAR, glyph_id, 22.0).unwrap();
-    let options = renderer_options();
-    let replacement = stage_live_font_generation(&options.font, options.font_authority).unwrap();
+    let replacement = stage_test_font_generation();
     let replacement_glyph =
         snapshot_glyph(&replacement.faces, SNAPSHOT_PRIMARY_REGULAR, glyph_id, 22.0).unwrap();
     assert!(!Arc::ptr_eq(&current_glyph, &replacement_glyph));

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -3,12 +3,11 @@
 Release authority, candidate construction, approval boundaries, and the future
 n8n notification role are defined in [Release automation](release-automation.md).
 
-Splinterm's `packaging/PKGBUILD` prepares the `0.1.0rc.1` split packages for
+Splinterm's `packaging/PKGBUILD` prepares the `0.1.0rc.2` split packages for
 reviewed local and CI candidate builds. Its local source archive and `SKIP` checksum are
 valid only in that workflow. The current public versioned release is
-[`v0.1.0-beta3`](https://github.com/OldJobobo/splinterm/releases/tag/v0.1.0-beta3),
-and both AUR package bases publish `0.1.0beta3-1`. The closed
-`packaging/release-state.json` record is the machine-readable authority for that
+[`v0.1.0-rc.1`](https://github.com/OldJobobo/splinterm/releases/tag/v0.1.0-rc.1).
+The closed `packaging/release-state.json` record is the machine-readable authority for that
 current public predecessor; candidate construction and promotion both reject a
 different supplied tag even when it exists. `docs/status.md` carries the same
 exact current-version marker, and release tooling rejects disagreement. The
@@ -106,8 +105,8 @@ complete package test suite. This is the mode used by `./install.sh --source`;
 Its equivalent manual build from a clean checkout is:
 
 ```bash
-git archive --format=tar.gz --prefix=splinterm-0.1.0rc.1/ \
-  -o packaging/splinterm-0.1.0rc.1.tar.gz HEAD
+git archive --format=tar.gz --prefix=splinterm-0.1.0rc.2/ \
+  -o packaging/splinterm-0.1.0rc.2.tar.gz HEAD
 ```
 
 The archive honors `.gitattributes` `export-ignore` entries; website source and
@@ -126,8 +125,8 @@ creates the main package plus the explicitly optional `splinterm-mcp` split
 package without installing either. Inspect them with:
 
 ```bash
-pacman -Qlp packaging/splinterm-0.1.0rc.1-1-x86_64.pkg.tar.zst
-pacman -Qlp packaging/splinterm-mcp-0.1.0rc.1-1-x86_64.pkg.tar.zst
+pacman -Qlp packaging/splinterm-0.1.0rc.2-1-x86_64.pkg.tar.zst
+pacman -Qlp packaging/splinterm-mcp-0.1.0rc.2-1-x86_64.pkg.tar.zst
 namcap packaging/PKGBUILD packaging/*.pkg.tar.zst   # optional
 ```
 
@@ -239,7 +238,7 @@ The equivalent manual lifecycle is:
 
 ```bash
 systemctl --user stop splinterd.service
-sudo pacman -U packaging/splinterm-0.1.0rc.1-1-x86_64.pkg.tar.zst
+sudo pacman -U packaging/splinterm-0.1.0rc.2-1-x86_64.pkg.tar.zst
 systemctl --user daemon-reload
 systemctl --user start splinterd.service
 ```
@@ -247,7 +246,7 @@ systemctl --user start splinterd.service
 Install the adapter only when an MCP host will be configured:
 
 ```bash
-sudo pacman -U packaging/splinterm-mcp-0.1.0rc.1-1-x86_64.pkg.tar.zst
+sudo pacman -U packaging/splinterm-mcp-0.1.0rc.2-1-x86_64.pkg.tar.zst
 ```
 
 The guarded upgrade script upgrades `splinterm-mcp` only when that optional

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,6 +1,6 @@
 # Current product status
 
-- **Current public version tag:** `v0.1.0-beta3`
+- **Current public version tag:** `v0.1.0-rc.1`
 
 This document is the repository authority for Splinterm's current maturity,
 validated product scope, availability, and release gates. The [product roadmap](product-roadmap.md)
@@ -48,34 +48,27 @@ not current compatibility promises. Headless `splinterd` does not require a
 graphical environment, but its packaged and remote workflows remain beta
 interfaces on the documented platform.
 
-## Unreleased 0.1.0 stabilization
+## 0.1.0 RC2 candidate preparation
 
-This source branch implements live native Omarchy system-font synchronization.
-When `main.font` is unset, a graphical client follows the effective Fontconfig
-`monospace` family, stages complete immutable face generations off dispatch
-paths, and atomically rebuilds active and hidden presentation state while
-preserving configured size and policy, padding, DPI, runtime zoom, topology,
-focus, history, modal input, and IME preedit. Explicit `main.font` disables
-native following. Invalid live candidates retain the last valid generation, and
-observer panes do not acquire control solely to resize.
+This source branch retains RC1 and closes two review findings in live native
+Omarchy font synchronization. Accepted staging now replaces a divergent probe
+fingerprint so a later generation cannot be skipped, and cached FreeType faces
+share their immutable staged mappings instead of copying an entire font file per
+raster face. Generation identity and lifetime tests use Fontconfig's generic
+monospace family rather than requiring one host-specific family.
 
-Focused and complete non-graphical validation, independent review, packaged
-graphical acceptance, and publication remain separate release boundaries.
+Focused and complete non-graphical validation, independent review, candidate
+construction, packaged graphical acceptance, and publication remain separate
+release boundaries.
 
-## 0.1.0 RC1 candidate preparation
+## 0.1.0 RC1 release
 
-The `0.1.0-rc.1` maintenance candidate freezes the 0.1 feature line for
-stabilization on top of the complete public Beta 3 baseline. It refreshes the
-bounded Omarchy Gum palette environment for each newly created Splint so a
-persistent daemon does not give later PTYs stale theme colors. Existing PTYs
-remain unchanged, unrelated environment variables remain untouched, and
-missing, malformed, oversized, symlinked, or non-regular palette state preserves
-the daemon's inherited values instead of applying a partial update.
-
-Focused and complete non-graphical source validation and independent maintenance
-review are required before candidate construction. Protected publication,
-installation evidence, and the RC soak remain separate release boundaries. Beta
-3 remains the current public release until those boundaries complete.
+[`v0.1.0-rc.1`](https://github.com/OldJobobo/splinterm/releases/tag/v0.1.0-rc.1)
+is the current public prerelease. It freezes the 0.1 feature line on the complete
+Beta 3 baseline and adds live native Omarchy font following, bounded Omarchy Gum
+palette refresh for newly created Splints, Sixel capability negotiation for Yazi,
+and legacy generated-Dojo name normalization. Its release target is
+`5fe48798856effb903ac178d8414b9c39f86038b`.
 
 ## Beta 3 release
 

--- a/packaging/PKGBUILD
+++ b/packaging/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: OldJobobo
 pkgbase=splinterm
 pkgname=('splinterm' 'splinterm-mcp')
-pkgver=0.1.0rc.1
+pkgver=0.1.0rc.2
 pkgrel=1
 arch=('x86_64')
 url='https://github.com/oldjobobo/splinterm'

--- a/packaging/aur-bin/.SRCINFO
+++ b/packaging/aur-bin/.SRCINFO
@@ -1,15 +1,15 @@
 pkgbase = splinterm-bin
-	pkgver = 0.1.0rc.1
+	pkgver = 0.1.0rc.2
 	pkgrel = 1
 	url = https://github.com/oldjobobo/splinterm
 	arch = x86_64
 	license = MIT
-	noextract = splinterm-0.1.0rc.1-x86_64.pkg.tar.zst
-	noextract = splinterm-mcp-0.1.0rc.1-x86_64.pkg.tar.zst
+	noextract = splinterm-0.1.0rc.2-x86_64.pkg.tar.zst
+	noextract = splinterm-mcp-0.1.0rc.2-x86_64.pkg.tar.zst
 	options = !strip
 	options = !debug
-	source = splinterm-0.1.0rc.1-x86_64.pkg.tar.zst::https://github.com/OldJobobo/splinterm/releases/download/v0.1.0-rc.1/splinterm-11742b60cb5b502cdadb60a582b9c3c838120d2b-x86_64.pkg.tar.zst
-	source = splinterm-mcp-0.1.0rc.1-x86_64.pkg.tar.zst::https://github.com/OldJobobo/splinterm/releases/download/v0.1.0-rc.1/splinterm-mcp-11742b60cb5b502cdadb60a582b9c3c838120d2b-x86_64.pkg.tar.zst
+	source = splinterm-0.1.0rc.2-x86_64.pkg.tar.zst::https://github.com/OldJobobo/splinterm/releases/download/v0.1.0-rc.2/splinterm-11742b60cb5b502cdadb60a582b9c3c838120d2b-x86_64.pkg.tar.zst
+	source = splinterm-mcp-0.1.0rc.2-x86_64.pkg.tar.zst::https://github.com/OldJobobo/splinterm/releases/download/v0.1.0-rc.2/splinterm-mcp-11742b60cb5b502cdadb60a582b9c3c838120d2b-x86_64.pkg.tar.zst
 	sha256sums = 1a7f2a31c04dfc87495740938a3e8410f2a464f99c382a0f5d563045d8798cfb
 	sha256sums = e53a2b567619d6d8058522c4e18ef077e3b575cc99889d26cc1a18d65647ead0
 
@@ -31,13 +31,13 @@ pkgname = splinterm-bin
 	depends = xdg-terminal-exec
 	optdepends = fcitx5: Wayland text-input support
 	optdepends = splinterm-mcp-bin: explicitly configured MCP stdio adapter
-	provides = splinterm=0.1.0rc.1-1
+	provides = splinterm=0.1.0rc.2-1
 	conflicts = splinterm
 
 pkgname = splinterm-mcp-bin
 	pkgdesc = Policy-scoped MCP stdio adapter for Splinterm (prebuilt binary)
-	depends = splinterm=0.1.0rc.1-1
+	depends = splinterm=0.1.0rc.2-1
 	depends = gcc-libs
 	depends = glibc
-	provides = splinterm-mcp=0.1.0rc.1-1
+	provides = splinterm-mcp=0.1.0rc.2-1
 	conflicts = splinterm-mcp

--- a/packaging/aur-bin/PKGBUILD
+++ b/packaging/aur-bin/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: OldJobobo
 pkgbase=splinterm-bin
 pkgname=('splinterm-bin' 'splinterm-mcp-bin')
-pkgver=0.1.0rc.1
+pkgver=0.1.0rc.2
 pkgrel=1
 _commit=11742b60cb5b502cdadb60a582b9c3c838120d2b
 arch=('x86_64')
@@ -9,8 +9,8 @@ url='https://github.com/oldjobobo/splinterm'
 license=('MIT')
 options=('!strip' '!debug')
 source=(
-  "splinterm-$pkgver-$CARCH.pkg.tar.zst::https://github.com/OldJobobo/splinterm/releases/download/v0.1.0-rc.1/splinterm-$_commit-$CARCH.pkg.tar.zst"
-  "splinterm-mcp-$pkgver-$CARCH.pkg.tar.zst::https://github.com/OldJobobo/splinterm/releases/download/v0.1.0-rc.1/splinterm-mcp-$_commit-$CARCH.pkg.tar.zst"
+  "splinterm-$pkgver-$CARCH.pkg.tar.zst::https://github.com/OldJobobo/splinterm/releases/download/v0.1.0-rc.2/splinterm-$_commit-$CARCH.pkg.tar.zst"
+  "splinterm-mcp-$pkgver-$CARCH.pkg.tar.zst::https://github.com/OldJobobo/splinterm/releases/download/v0.1.0-rc.2/splinterm-mcp-$_commit-$CARCH.pkg.tar.zst"
 )
 noextract=(
   "splinterm-$pkgver-$CARCH.pkg.tar.zst"

--- a/packaging/aur/.SRCINFO
+++ b/packaging/aur/.SRCINFO
@@ -1,5 +1,5 @@
 pkgbase = splinterm
-	pkgver = 0.1.0rc.1
+	pkgver = 0.1.0rc.2
 	pkgrel = 1
 	url = https://github.com/oldjobobo/splinterm
 	arch = x86_64
@@ -19,7 +19,7 @@ pkgbase = splinterm
 	makedepends = ttf-jetbrains-mono-nerd
 	makedepends = wayland
 	makedepends = xdg-terminal-exec
-	source = https://github.com/OldJobobo/splinterm/releases/download/v0.1.0-rc.1/splinterm-0.1.0-rc.1.tar.gz
+	source = https://github.com/OldJobobo/splinterm/releases/download/v0.1.0-rc.2/splinterm-0.1.0-rc.2.tar.gz
 	sha256sums = d59bf82a5e2218112613d4a69adb20ce2b6cd8c133cc9b14da8fbfa1de4d0644
 
 pkgname = splinterm
@@ -43,6 +43,6 @@ pkgname = splinterm
 
 pkgname = splinterm-mcp
 	pkgdesc = Policy-scoped MCP stdio adapter for Splinterm
-	depends = splinterm=0.1.0rc.1-1
+	depends = splinterm=0.1.0rc.2-1
 	depends = gcc-libs
 	depends = glibc

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -1,8 +1,8 @@
 # Maintainer: OldJobobo
 pkgbase=splinterm
 pkgname=('splinterm' 'splinterm-mcp')
-pkgver=0.1.0rc.1
-_upstream_ver=0.1.0-rc.1
+pkgver=0.1.0rc.2
+_upstream_ver=0.1.0-rc.2
 pkgrel=1
 arch=('x86_64')
 url='https://github.com/oldjobobo/splinterm'

--- a/packaging/release-state.json
+++ b/packaging/release-state.json
@@ -1,4 +1,4 @@
 {
   "schema": 1,
-  "current_version_tag": "v0.1.0-beta3"
+  "current_version_tag": "v0.1.0-rc.1"
 }

--- a/site/src/content/docs/docs/status.md
+++ b/site/src/content/docs/docs/status.md
@@ -5,9 +5,9 @@ description: What is implemented, validated, limited, planned, and unreleased in
 
 Splinterm is a **public beta**. Source, documentation, and immutable versioned GitHub and AUR packages are public. Substantial core behavior is implemented and validated, while the validated target remains narrow and stable compatibility guarantees have not been released.
 
-[`v0.1.0-beta3`](https://github.com/OldJobobo/splinterm/releases/tag/v0.1.0-beta3) is the current public prerelease. It lets terminal workloads inherit the user manager's normal task policy while retaining the daemon guard, and it polishes the Dojo tab strip and legacy unnamed-Dojo label.
+[`v0.1.0-rc.1`](https://github.com/OldJobobo/splinterm/releases/tag/v0.1.0-rc.1) is the current public prerelease. It adds live native Omarchy font following, current Gum palette inheritance for newly created Splints, bounded Sixel negotiation for Yazi, and legacy generated-Dojo name normalization on top of Beta 3.
 
-`0.1.0-rc.1` candidate preparation is in progress as the stabilization boundary for the final `0.1.0` release. It adds current Omarchy Gum palette inheritance for newly created Splints without changing existing PTYs. Complete candidate construction, protected publication, installation, and soak evidence remain pending.
+`0.1.0-rc.2` candidate preparation closes two RC1 live-font review findings: accepted staging remains synchronized with watcher probes, and cached FreeType faces share immutable staged mappings rather than copying complete font files. Complete validation, review, candidate construction, protected publication, installation, and soak evidence remain pending.
 
 ## What that means
 
@@ -37,7 +37,7 @@ Splinterm is a **public beta**. Source, documentation, and immutable versioned G
 | Sixel, practical Kitty static images, inline iTerm2 PNG | Documented supported subsets |
 | Arch/Omarchy package | Versioned GitHub release and AUR packages validated |
 | Public source and versioned builds | Available |
-| [AUR packages](https://aur.archlinux.org/packages/splinterm-bin) | Recommended prebuilt `splinterm-bin`; source-built `splinterm` also available, both `0.1.0beta3-1` |
+| [AUR packages](https://aur.archlinux.org/packages/splinterm-bin) | Recommended prebuilt `splinterm-bin`; source-built `splinterm` is also available |
 | Stable support and broader compatibility | Not released |
 | Nix and broader distributions | Planned |
 

--- a/tools/foot-oracle/provenance.json
+++ b/tools/foot-oracle/provenance.json
@@ -59,7 +59,7 @@
   "rust": {
     "rustc": "1.91.0",
     "cargo": "1.91.0",
-    "cargo_lock_sha256": "ba02518751a081095bf95b762b9077f6e3c3df810e4a2e6d8df70ff216c5cc62",
+    "cargo_lock_sha256": "bc500f38cb03c929cfc557521f4ea85840f0e7cff2a2590debb4b86fa120e4db",
     "dependencies": {
       "fontdb": "0.23.0",
       "freetype-rs": "0.38.0",
@@ -112,7 +112,7 @@
     },
     "foreground": "ebebeb",
     "background": "0e1216",
-    "cargo_lock_sha256": "ba02518751a081095bf95b762b9077f6e3c3df810e4a2e6d8df70ff216c5cc62"
+    "cargo_lock_sha256": "bc500f38cb03c929cfc557521f4ea85840f0e7cff2a2590debb4b86fa120e4db"
   },
   "semantic_fixture_schema": "fixtures/terminal/v1/schema.md",
   "final_buffer_schema": "tools/foot-oracle/final-buffer-schema.md",

--- a/tools/release/test_prepare_candidate.py
+++ b/tools/release/test_prepare_candidate.py
@@ -140,7 +140,7 @@ class PrepareCandidateTests(unittest.TestCase):
         commit = MODULE.run(["git", "rev-parse", "HEAD"])
         with self.assertRaisesRegex(ValueError, "release tag already exists"):
             MODULE.validate_candidate(
-                "OldJobobo/splinterm", commit, version, "v0.1.0-beta3"
+                "OldJobobo/splinterm", commit, version, "v0.1.0-rc.1"
             )
 
     def test_mismatched_version_fails_before_build(self) -> None:
@@ -154,26 +154,26 @@ class PrepareCandidateTests(unittest.TestCase):
             )
 
     def test_previous_release_is_explicit_existing_and_distinct(self) -> None:
-        release_tag = "v9.9.9-rc.1"
+        release_tag = "v9.9.9-rc.2"
         with mock.patch.object(MODULE, "run", return_value="a" * 40):
             self.assertEqual(
-                MODULE.validate_previous_version_tag("v0.1.0-beta3", release_tag),
-                "v0.1.0-beta3",
+                MODULE.validate_previous_version_tag("v0.1.0-rc.1", release_tag),
+                "v0.1.0-rc.1",
             )
         with self.assertRaisesRegex(ValueError, "v-prefixed SemVer"):
-            MODULE.validate_previous_version_tag("0.1.0-beta3", release_tag)
+            MODULE.validate_previous_version_tag("0.1.0-rc.1", release_tag)
         with self.assertRaisesRegex(ValueError, "must differ"):
             MODULE.validate_previous_version_tag(release_tag, release_tag)
         with self.assertRaisesRegex(ValueError, "current public release"):
-            MODULE.validate_previous_version_tag("v0.1.0-beta2", release_tag)
+            MODULE.validate_previous_version_tag("v0.1.0-beta3", release_tag)
         with (
             mock.patch.object(MODULE, "run", side_effect=ValueError("missing tag")),
             self.assertRaisesRegex(ValueError, "missing tag"),
         ):
-            MODULE.validate_previous_version_tag("v0.1.0-beta3", release_tag)
+            MODULE.validate_previous_version_tag("v0.1.0-rc.1", release_tag)
 
     def test_public_release_state_is_closed_and_versioned(self) -> None:
-        self.assertEqual(MODULE.current_public_release_tag(), "v0.1.0-beta3")
+        self.assertEqual(MODULE.current_public_release_tag(), "v0.1.0-rc.1")
         state = json.loads(
             (ROOT / "packaging/release-state.json").read_text(encoding="utf-8")
         )
@@ -181,7 +181,7 @@ class PrepareCandidateTests(unittest.TestCase):
         self.assertEqual(state["schema"], 1)
         status = (ROOT / "docs/status.md").read_text(encoding="utf-8")
         self.assertEqual(
-            status.count("**Current public version tag:** `v0.1.0-beta3`"), 1
+            status.count("**Current public version tag:** `v0.1.0-rc.1`"), 1
         )
 
     def test_release_notes_are_read_from_the_exact_candidate_commit(self) -> None:
@@ -193,7 +193,7 @@ class PrepareCandidateTests(unittest.TestCase):
                 output.read_text(encoding="utf-8"),
                 MODULE.run(["git", "show", f"{commit}:RELEASE_NOTES.md"]) + "\n",
             )
-            self.assertIn("Stable Ground", output.read_text(encoding="utf-8"))
+            self.assertIn("Font Reload Closure", output.read_text(encoding="utf-8"))
 
     def test_manifest_example_is_json_serializable(self) -> None:
         manifest = {

--- a/tools/release/test_promote_release.py
+++ b/tools/release/test_promote_release.py
@@ -22,7 +22,7 @@ RUN_ID = 12345
 
 class CandidateFixture:
     def __init__(
-        self, root: Path, previous_version_tag: str = "v0.1.0-beta3"
+        self, root: Path, previous_version_tag: str = "v0.1.0-rc.1"
     ) -> None:
         self.root = root
         self.assets = MODULE.expected_assets(COMMIT, VERSION)


### PR DESCRIPTION
## Problem

The RC1 live-font implementation had two closure defects: accepted staging could diverge from watcher probe state and later suppress a real generation, while each cached FreeType raster face copied the complete font file. Font-generation tests also assumed the pinned JetBrains fixture was installed on every development host.

## Changes

- synchronize accepted staging with the watcher's observed and current fingerprints
- retain shared immutable file mappings across cached FreeType faces
- preserve packed Fontconfig collection/named-instance indices through FreeType
- use `ttf-parser` for strikeout metrics without reverting to copied FreeType buffers
- add watcher-race, shared-mapping ownership, bounded-cache, and generation-lifetime regressions
- make non-oracle generation tests resolve the host's generic monospace family
- prepare `0.1.0-rc.2` release, package, status, and release-automation metadata with `v0.1.0-rc.1` as predecessor

## Validation

- focused watcher, generation, mapping, raster-cache, variable-font, and FreeType tests
- workspace compile and non-`splinterm` workspace tests
- strict workspace Clippy with warnings denied
- Python release/package tests and exact-commit release tests: 18 passed, 1 expected skip
- shellcheck, formatting, portable provenance, and `git diff --check`
- independent read-only review: ACCEPT, no findings

## Remaining gates

Publication is not claimed by this PR. The complete pinned Foot renderer matrix requires its exact JetBrains/reference-host dependencies, and packaged graphical live-font acceptance remains separately gated.
