### PR TITLE
Complete live Omarchy font synchronization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1508,6 +1508,7 @@ dependencies = [
  "splinterm-filemap",
  "splinterm-pixman",
  "thiserror",
+ "ttf-parser",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1505,6 +1505,7 @@ name = "splinterm-freetype"
 version = "0.1.0-beta1"
 dependencies = [
  "freetype-rs",
+ "splinterm-filemap",
  "splinterm-pixman",
  "thiserror",
 ]

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ Authoritative references:
 
 Splinterm uses `${XDG_CONFIG_HOME:-~/.config}/splinterm/config.ini` for its focused configuration surface. It supports fonts and sizing, shell behavior, scrollback, cursor settings, pane chrome, keymap overlays, and explicit theme overrides.
 
-On Omarchy, Splinterm can read the active theme's effective `foot.ini` and `colors.toml` directly and safely reload valid palette changes without restarting the daemon or shell.
+On Omarchy, Splinterm reads the active theme's effective `foot.ini` and `colors.toml` and safely reloads valid palette changes without restarting the daemon or shell. When `main.font` is unset, graphical clients also follow fontconfig's effective `monospace` family live; explicit font patterns remain user-owned, and invalid live generations retain the last valid font without restarting the Window or its processes.
 
 See the [configuration guide](https://splinterm.com/docs/configure/configuration/) for supported keys, keymap inspection, Omarchy integration, and Foot migration.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,7 +7,11 @@
   the last valid family; the documented JetBrains fallback is startup-only.
 - Family changes preserve configured size/policy, padding, DPI, runtime zoom,
   topology, focus, history, modal and IME state, and controller authority.
-  Observer panes never acquire control solely to resize after a font change.
+  Observer panes never acquire control solely to resize after a font change;
+  deferred resizes retry and ambient probes use a bounded ten-second cadence.
+- Fontconfig named variable-font instances survive shaping and rasterization.
+  Accepted staging remains synchronized with watcher probes, and cached
+  FreeType faces share immutable font mappings across raster sizes.
 - Non-graphical implementation checks are recorded; packaged graphical
   acceptance and publication remain separate unreleased gates.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,16 @@
+# Unreleased
+
+- Native Omarchy font following is now live when `main.font` is unset. Valid
+  fontconfig `monospace` family changes replace one complete immutable renderer
+  generation without restarting the Window, daemon, shell, or applications.
+- Explicit font patterns remain authoritative. Invalid live generations retain
+  the last valid family; the documented JetBrains fallback is startup-only.
+- Family changes preserve configured size/policy, padding, DPI, runtime zoom,
+  topology, focus, history, modal and IME state, and controller authority.
+  Observer panes never acquire control solely to resize after a font change.
+- Non-graphical implementation checks are recorded; packaged graphical
+  acceptance and publication remain separate unreleased gates.
+
 # Splinterm 0.1.0 Beta 1 — The Foundation Holds
 
 Splinterm has reached public beta.

--- a/config/splinterm/config.ini
+++ b/config/splinterm/config.ini
@@ -1,7 +1,9 @@
 # Splinterm Phase 8 supported configuration subset.
 # Install as ${XDG_CONFIG_HOME:-~/.config}/splinterm/config.ini.
 [main]
-font=JetBrains Mono Nerd Font:style=Regular
+# Leave font unset to follow Omarchy's fontconfig monospace family. Setting
+# font makes that pattern explicitly authoritative for this client.
+# font=JetBrains Mono Nerd Font:style=Regular
 font-pixelsize=14
 font-sizing-policy=output-scale
 padding-left=12

--- a/crates/splinterm-filemap/src/lib.rs
+++ b/crates/splinterm-filemap/src/lib.rs
@@ -7,24 +7,57 @@
 
 use std::{
     fs::File,
-    io,
+    io::{self, Read, Write},
     ops::Deref,
-    os::fd::{BorrowedFd, OwnedFd},
+    os::{
+        fd::{BorrowedFd, OwnedFd},
+        unix::fs::MetadataExt,
+    },
     path::Path,
 };
 
 use memmap2::{Mmap, MmapOptions};
-use rustix::fs::{SealFlags, fcntl_get_seals, fstat};
+use rustix::fs::{MemfdFlags, SealFlags, fcntl_add_seals, fcntl_get_seals, fstat, memfd_create};
 
 const REQUIRED_IMMUTABLE_SEALS: SealFlags = SealFlags::WRITE
     .union(SealFlags::GROW)
     .union(SealFlags::SHRINK)
     .union(SealFlags::SEAL);
 
+/// Identity captured from the exact opened file backing a mapping.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct FileIdentity {
+    pub device: u64,
+    pub inode: u64,
+    pub length: u64,
+    pub modified_seconds: i64,
+    pub modified_nanoseconds: i64,
+}
+
+impl FileIdentity {
+    fn from_metadata(metadata: &std::fs::Metadata) -> Self {
+        Self {
+            device: metadata.dev(),
+            inode: metadata.ino(),
+            length: metadata.len(),
+            modified_seconds: metadata.mtime(),
+            modified_nanoseconds: metadata.mtime_nsec(),
+        }
+    }
+}
+
+/// Immutable snapshot plus the identity of the exact source file that was copied.
+#[derive(Debug)]
+pub struct ImmutableFileSnapshot {
+    pub mapping: ReadOnlyFileMap,
+    pub source_identity: FileIdentity,
+}
+
 /// An owned, read-only mapping of one non-empty regular file.
 #[derive(Debug)]
 pub struct ReadOnlyFileMap {
     mapping: Mmap,
+    identity: FileIdentity,
 }
 
 impl ReadOnlyFileMap {
@@ -38,7 +71,10 @@ impl ReadOnlyFileMap {
     /// # Errors
     /// Returns an I/O error for missing, empty, non-regular, or unmappable files.
     pub fn open(path: impl AsRef<Path>) -> io::Result<Self> {
-        let file = File::open(path)?;
+        Self::map_file(&File::open(path)?)
+    }
+
+    fn map_file(file: &File) -> io::Result<Self> {
         let metadata = file.metadata()?;
         if !metadata.is_file() || metadata.len() == 0 {
             return Err(io::Error::new(
@@ -46,12 +82,91 @@ impl ReadOnlyFileMap {
                 "mapped asset must be a non-empty regular file",
             ));
         }
-        // SAFETY: This leaf API is restricted to package-managed immutable assets.
-        // Splinterm opens system font files read-only; Arch package upgrades replace
-        // those paths with new inodes rather than mutating an active inode. `Mmap`
-        // owns the mapping for as long as the returned slice can be borrowed.
-        let mapping = unsafe { MmapOptions::new().map(&file)? };
-        Ok(Self { mapping })
+        let identity = FileIdentity::from_metadata(&metadata);
+        // SAFETY: Callers provide either a read-only package-managed asset or a
+        // descriptor whose immutable seals were verified before this helper. The
+        // private mapping owns the opened file's pages and exposes only immutable bytes.
+        let mapping = unsafe { MmapOptions::new().map(file)? };
+        Ok(Self { mapping, identity })
+    }
+
+    /// Returns metadata captured from the exact file descriptor that was mapped.
+    #[must_use]
+    pub const fn identity(&self) -> FileIdentity {
+        self.identity
+    }
+
+    /// Copies one regular file into a bounded sealed anonymous snapshot.
+    ///
+    /// Source identity is checked before and after copying. The returned mapping
+    /// is backed by a sealed memfd, so later source replacement, mutation, or
+    /// truncation cannot change or fault the staged bytes.
+    ///
+    /// # Errors
+    /// Returns an I/O error for an invalid source, an exceeded bound, source
+    /// identity drift during copying, sealing failure, or mapping failure.
+    pub fn immutable_snapshot(
+        path: impl AsRef<Path>,
+        maximum_len: usize,
+    ) -> io::Result<ImmutableFileSnapshot> {
+        if maximum_len == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "immutable snapshot bound must be positive",
+            ));
+        }
+        let mut source = File::open(path)?;
+        let before = source.metadata()?;
+        if !before.is_file() || before.len() == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "snapshot source must be a non-empty regular file",
+            ));
+        }
+        let maximum_len_u64 = u64::try_from(maximum_len).map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "snapshot bound does not fit u64",
+            )
+        })?;
+        if before.len() > maximum_len_u64 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "snapshot source exceeds its byte bound",
+            ));
+        }
+        let source_identity = FileIdentity::from_metadata(&before);
+        let expected_len = usize::try_from(before.len()).map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "snapshot length does not fit usize",
+            )
+        })?;
+        let mut bytes = Vec::with_capacity(expected_len);
+        (&mut source)
+            .take(maximum_len_u64.saturating_add(1))
+            .read_to_end(&mut bytes)?;
+        let after_identity = FileIdentity::from_metadata(&source.metadata()?);
+        if after_identity != source_identity || bytes.len() != expected_len {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "snapshot source changed while it was copied",
+            ));
+        }
+
+        let descriptor = memfd_create(
+            "splinterm-immutable-snapshot",
+            MemfdFlags::CLOEXEC | MemfdFlags::ALLOW_SEALING,
+        )?;
+        let mut sealed_file = File::from(descriptor);
+        sealed_file.write_all(&bytes)?;
+        let descriptor: OwnedFd = sealed_file.into();
+        fcntl_add_seals(&descriptor, REQUIRED_IMMUTABLE_SEALS)?;
+        let mapping = Self::from_sealed_fd(descriptor, bytes.len())?;
+        Ok(ImmutableFileSnapshot {
+            mapping,
+            source_identity,
+        })
     }
 
     /// Verifies and maps an exactly-sized sealed descriptor read-only.
@@ -76,11 +191,7 @@ impl ReadOnlyFileMap {
             ));
         }
         let file = File::from(fd);
-        // SAFETY: All mutations and size changes are prohibited by verified
-        // kernel-enforced seals before mapping. The mapping owns its file-backed
-        // pages and exposes only immutable bytes.
-        let mapping = unsafe { MmapOptions::new().map(&file)? };
-        Ok(Self { mapping })
+        Self::map_file(&file)
     }
 }
 
@@ -164,9 +275,40 @@ mod tests {
         let path = temporary_path("bytes");
         fs::write(&path, b"mapped font bytes").unwrap();
         let mapping = ReadOnlyFileMap::open(&path).unwrap();
+        let first_identity = mapping.identity();
+        assert_eq!(&*mapping, b"mapped font bytes");
+        fs::remove_file(&path).unwrap();
+        fs::write(&path, b"replacement font bytes are different").unwrap();
+        let replacement = ReadOnlyFileMap::open(&path).unwrap();
+        assert_ne!(replacement.identity(), first_identity);
         assert_eq!(&*mapping, b"mapped font bytes");
         fs::remove_file(path).unwrap();
-        assert_eq!(&*mapping, b"mapped font bytes");
+    }
+
+    #[test]
+    fn immutable_snapshot_is_bounded_and_detached_from_source_mutation() {
+        let path = temporary_path("immutable-snapshot");
+        fs::write(&path, b"original font bytes").unwrap();
+        let snapshot = ReadOnlyFileMap::immutable_snapshot(&path, 64).unwrap();
+        assert_eq!(snapshot.source_identity.length, 19);
+        assert_eq!(&*snapshot.mapping, b"original font bytes");
+
+        fs::write(&path, b"x").unwrap();
+        assert_eq!(&*snapshot.mapping, b"original font bytes");
+        assert_eq!(
+            ReadOnlyFileMap::immutable_snapshot(&path, 0)
+                .unwrap_err()
+                .kind(),
+            io::ErrorKind::InvalidInput
+        );
+        fs::write(&path, b"too large").unwrap();
+        assert_eq!(
+            ReadOnlyFileMap::immutable_snapshot(&path, 4)
+                .unwrap_err()
+                .kind(),
+            io::ErrorKind::InvalidData
+        );
+        fs::remove_file(path).unwrap();
     }
 
     #[test]

--- a/crates/splinterm-filemap/src/lib.rs
+++ b/crates/splinterm-filemap/src/lib.rs
@@ -9,10 +9,7 @@ use std::{
     fs::File,
     io::{self, Read, Write},
     ops::Deref,
-    os::{
-        fd::{BorrowedFd, OwnedFd},
-        unix::fs::MetadataExt,
-    },
+    os::{fd::OwnedFd, unix::fs::MetadataExt},
     path::Path,
 };
 

--- a/crates/splinterm-filemap/src/lib.rs
+++ b/crates/splinterm-filemap/src/lib.rs
@@ -9,7 +9,10 @@ use std::{
     fs::File,
     io::{self, Read, Write},
     ops::Deref,
-    os::{fd::OwnedFd, unix::fs::MetadataExt},
+    os::{
+        fd::{BorrowedFd, OwnedFd},
+        unix::fs::MetadataExt,
+    },
     path::Path,
 };
 

--- a/crates/splinterm-freetype/Cargo.toml
+++ b/crates/splinterm-freetype/Cargo.toml
@@ -12,6 +12,7 @@ freetype-rs.workspace = true
 splinterm-filemap = { path = "../splinterm-filemap" }
 splinterm-pixman = { path = "../splinterm-pixman" }
 thiserror.workspace = true
+ttf-parser = "0.25.1"
 
 [lints]
 workspace = true

--- a/crates/splinterm-freetype/Cargo.toml
+++ b/crates/splinterm-freetype/Cargo.toml
@@ -9,6 +9,7 @@ repository.workspace = true
 
 [dependencies]
 freetype-rs.workspace = true
+splinterm-filemap = { path = "../splinterm-filemap" }
 splinterm-pixman = { path = "../splinterm-pixman" }
 thiserror.workspace = true
 

--- a/crates/splinterm-freetype/src/lib.rs
+++ b/crates/splinterm-freetype/src/lib.rs
@@ -8,7 +8,6 @@
 
 use std::{
     borrow::Borrow,
-    ops::Deref,
     path::{Path, PathBuf},
     sync::Arc,
 };
@@ -104,7 +103,7 @@ struct SharedFontData(Arc<ReadOnlyFileMap>);
 
 impl Borrow<[u8]> for SharedFontData {
     fn borrow(&self) -> &[u8] {
-        self.0.as_ref().deref()
+        self.0.as_ref()
     }
 }
 

--- a/crates/splinterm-freetype/src/lib.rs
+++ b/crates/splinterm-freetype/src/lib.rs
@@ -11,12 +11,14 @@ use std::path::{Path, PathBuf};
 use freetype::{
     Face, Library, RenderMode, bitmap::PixelMode, face::LoadFlag, tt_os2::TrueTypeOS2Table,
 };
+use splinterm_filemap::ReadOnlyFileMap;
 use thiserror::Error;
 
 pub const MIN_PIXEL_SIZE_26_6: isize = 6 * 64;
 pub const MAX_PIXEL_SIZE_26_6: isize = 768 * 64;
 pub const MAX_GLYPH_DIMENSION: u32 = 4_096;
 pub const MAX_GLYPH_PIXELS: usize = 16 * 1024 * 1024;
+pub const MAX_STAGED_FONT_BYTES: usize = 64 * 1024 * 1024;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct FontMetrics {
@@ -57,14 +59,17 @@ pub enum RasterError {
     InvalidPixelSize,
     #[error("font face index does not fit FreeType's signed index")]
     InvalidFaceIndex,
+    #[error("staged font exceeds the 64 MiB per-face byte bound")]
+    FontTooLarge,
     #[error("initialize FreeType: {0}")]
     Initialize(freetype::Error),
-    #[error("open font face {path} index {index}: {source}")]
-    OpenFace {
+    #[error("map font face {path}: {source}")]
+    MapFace {
         path: PathBuf,
-        index: u32,
-        source: freetype::Error,
+        source: std::io::Error,
     },
+    #[error("open owned font face index {index}: {source}")]
+    OpenMemoryFace { index: u32, source: freetype::Error },
     #[error("set FreeType character size: {0}")]
     SetSize(freetype::Error),
     #[error("load glyph {glyph_id}: {source}")]
@@ -109,13 +114,34 @@ impl RasterFace {
         if !(MIN_PIXEL_SIZE_26_6..=MAX_PIXEL_SIZE_26_6).contains(&pixel_size_26_6) {
             return Err(RasterError::InvalidPixelSize);
         }
+        let path = path.as_ref();
+        let data = ReadOnlyFileMap::open(path).map_err(|source| RasterError::MapFace {
+            path: path.to_path_buf(),
+            source,
+        })?;
+        Self::open_memory(&data, face_index, pixel_size_26_6)
+    }
+
+    /// Opens one face from immutable generation-owned bytes.
+    ///
+    /// # Errors
+    /// Returns a typed error for invalid bounds or any `FreeType` failure.
+    pub fn open_memory(
+        data: &ReadOnlyFileMap,
+        face_index: u32,
+        pixel_size_26_6: isize,
+    ) -> Result<Self, RasterError> {
+        if !(MIN_PIXEL_SIZE_26_6..=MAX_PIXEL_SIZE_26_6).contains(&pixel_size_26_6) {
+            return Err(RasterError::InvalidPixelSize);
+        }
+        if data.len() > MAX_STAGED_FONT_BYTES {
+            return Err(RasterError::FontTooLarge);
+        }
         let index = isize::try_from(face_index).map_err(|_| RasterError::InvalidFaceIndex)?;
         let library = Library::init().map_err(RasterError::Initialize)?;
-        let path = path.as_ref();
         let face = library
-            .new_face(path, index)
-            .map_err(|source| RasterError::OpenFace {
-                path: path.to_path_buf(),
+            .new_memory_face(data.to_vec(), index)
+            .map_err(|source| RasterError::OpenMemoryFace {
                 index: face_index,
                 source,
             })?;
@@ -144,29 +170,87 @@ impl RasterFace {
         {
             return Err(RasterError::InvalidPixelSize);
         }
+        let path = path.as_ref();
+        let data = ReadOnlyFileMap::open(path).map_err(|source| RasterError::MapFace {
+            path: path.to_path_buf(),
+            source,
+        })?;
+        Self::rasterize_color_memory(
+            &data,
+            face_index,
+            requested_pixel_size_26_6,
+            selected_pixel_size_26_6,
+            glyph_id,
+        )
+    }
+
+    /// Rasterizes one fixed-strike color glyph from immutable generation-owned bytes.
+    ///
+    /// # Errors
+    /// Returns a typed error for invalid bounds, `FreeType` failures, non-BGRA
+    /// output, malformed bitmap geometry, or pixman scaling failures.
+    pub fn rasterize_color_memory(
+        data: &ReadOnlyFileMap,
+        face_index: u32,
+        requested_pixel_size_26_6: isize,
+        selected_pixel_size_26_6: isize,
+        glyph_id: u32,
+    ) -> Result<RasterizedColorGlyph, RasterError> {
+        if !(MIN_PIXEL_SIZE_26_6..=MAX_PIXEL_SIZE_26_6).contains(&requested_pixel_size_26_6)
+            || !(MIN_PIXEL_SIZE_26_6..=MAX_PIXEL_SIZE_26_6).contains(&selected_pixel_size_26_6)
+        {
+            return Err(RasterError::InvalidPixelSize);
+        }
+        if data.len() > MAX_STAGED_FONT_BYTES {
+            return Err(RasterError::FontTooLarge);
+        }
         let index = isize::try_from(face_index).map_err(|_| RasterError::InvalidFaceIndex)?;
         let library = Library::init().map_err(RasterError::Initialize)?;
-        let path = path.as_ref();
         let face = library
-            .new_face(path, index)
-            .map_err(|source| RasterError::OpenFace {
-                path: path.to_path_buf(),
+            .new_memory_face(data.to_vec(), index)
+            .map_err(|source| RasterError::OpenMemoryFace {
                 index: face_index,
                 source,
             })?;
         face.set_char_size(selected_pixel_size_26_6, 0, 72, 72)
             .map_err(RasterError::SetSize)?;
-        face.load_glyph(
+        let mut raster = Self { face };
+        raster.rasterize_color_glyph(
+            requested_pixel_size_26_6,
+            selected_pixel_size_26_6,
             glyph_id,
-            LoadFlag::DEFAULT | LoadFlag::TARGET_LIGHT | LoadFlag::COLOR,
         )
-        .map_err(|source| RasterError::LoadGlyph { glyph_id, source })?;
-        if face.glyph().raw().format != freetype::ffi::FT_GLYPH_FORMAT_BITMAP {
-            face.glyph()
+    }
+
+    /// Rasterizes one color glyph through an already opened fixed-strike face.
+    ///
+    /// # Errors
+    /// Returns a typed error for invalid bounds, `FreeType` failures, non-BGRA
+    /// output, malformed bitmap geometry, or pixman scaling failures.
+    pub fn rasterize_color_glyph(
+        &mut self,
+        requested_pixel_size_26_6: isize,
+        selected_pixel_size_26_6: isize,
+        glyph_id: u32,
+    ) -> Result<RasterizedColorGlyph, RasterError> {
+        if !(MIN_PIXEL_SIZE_26_6..=MAX_PIXEL_SIZE_26_6).contains(&requested_pixel_size_26_6)
+            || !(MIN_PIXEL_SIZE_26_6..=MAX_PIXEL_SIZE_26_6).contains(&selected_pixel_size_26_6)
+        {
+            return Err(RasterError::InvalidPixelSize);
+        }
+        self.face
+            .load_glyph(
+                glyph_id,
+                LoadFlag::DEFAULT | LoadFlag::TARGET_LIGHT | LoadFlag::COLOR,
+            )
+            .map_err(|source| RasterError::LoadGlyph { glyph_id, source })?;
+        if self.face.glyph().raw().format != freetype::ffi::FT_GLYPH_FORMAT_BITMAP {
+            self.face
+                .glyph()
                 .render_glyph(RenderMode::Normal)
                 .map_err(|source| RasterError::RenderGlyph { glyph_id, source })?;
         }
-        let slot = face.glyph();
+        let slot = self.face.glyph();
         let bitmap = slot.bitmap();
         let mode = bitmap
             .pixel_mode()

--- a/crates/splinterm-freetype/src/lib.rs
+++ b/crates/splinterm-freetype/src/lib.rs
@@ -6,11 +6,14 @@
 //! file/index and receive owned, tightly packed alpha bytes; no `FreeType` pointer
 //! or borrowed bitmap escapes the API.
 
-use std::path::{Path, PathBuf};
-
-use freetype::{
-    Face, Library, RenderMode, bitmap::PixelMode, face::LoadFlag, tt_os2::TrueTypeOS2Table,
+use std::{
+    borrow::Borrow,
+    ops::Deref,
+    path::{Path, PathBuf},
+    sync::Arc,
 };
+
+use freetype::{Face, Library, RenderMode, bitmap::PixelMode, face::LoadFlag};
 use splinterm_filemap::ReadOnlyFileMap;
 use thiserror::Error;
 
@@ -96,8 +99,19 @@ pub enum RasterError {
     ScaleColor(#[from] splinterm_pixman::ScaleError),
 }
 
+#[derive(Clone, Debug)]
+struct SharedFontData(Arc<ReadOnlyFileMap>);
+
+impl Borrow<[u8]> for SharedFontData {
+    fn borrow(&self) -> &[u8] {
+        self.0.as_ref().deref()
+    }
+}
+
 pub struct RasterFace {
-    face: Face,
+    face: Face<SharedFontData>,
+    data: SharedFontData,
+    collection_index: u32,
 }
 
 impl RasterFace {
@@ -115,11 +129,14 @@ impl RasterFace {
             return Err(RasterError::InvalidPixelSize);
         }
         let path = path.as_ref();
-        let data = ReadOnlyFileMap::open(path).map_err(|source| RasterError::MapFace {
-            path: path.to_path_buf(),
-            source,
-        })?;
-        Self::open_memory(&data, face_index, pixel_size_26_6)
+        let data =
+            Arc::new(
+                ReadOnlyFileMap::open(path).map_err(|source| RasterError::MapFace {
+                    path: path.to_path_buf(),
+                    source,
+                })?,
+            );
+        Self::open_memory(data, face_index, pixel_size_26_6)
     }
 
     /// Opens one face from immutable generation-owned bytes.
@@ -127,7 +144,7 @@ impl RasterFace {
     /// # Errors
     /// Returns a typed error for invalid bounds or any `FreeType` failure.
     pub fn open_memory(
-        data: &ReadOnlyFileMap,
+        data: Arc<ReadOnlyFileMap>,
         face_index: u32,
         pixel_size_26_6: isize,
     ) -> Result<Self, RasterError> {
@@ -139,15 +156,20 @@ impl RasterFace {
         }
         let index = isize::try_from(face_index).map_err(|_| RasterError::InvalidFaceIndex)?;
         let library = Library::init().map_err(RasterError::Initialize)?;
+        let data = SharedFontData(data);
         let face = library
-            .new_memory_face(data.to_vec(), index)
+            .new_memory_face2(data.clone(), index)
             .map_err(|source| RasterError::OpenMemoryFace {
                 index: face_index,
                 source,
             })?;
         face.set_char_size(pixel_size_26_6, 0, 72, 72)
             .map_err(RasterError::SetSize)?;
-        Ok(Self { face })
+        Ok(Self {
+            face,
+            data,
+            collection_index: face_index & 0xffff,
+        })
     }
 
     /// Rasterize one fixed-strike color glyph using pinned fcft's pixel fixup.
@@ -171,12 +193,15 @@ impl RasterFace {
             return Err(RasterError::InvalidPixelSize);
         }
         let path = path.as_ref();
-        let data = ReadOnlyFileMap::open(path).map_err(|source| RasterError::MapFace {
-            path: path.to_path_buf(),
-            source,
-        })?;
+        let data =
+            Arc::new(
+                ReadOnlyFileMap::open(path).map_err(|source| RasterError::MapFace {
+                    path: path.to_path_buf(),
+                    source,
+                })?,
+            );
         Self::rasterize_color_memory(
-            &data,
+            data,
             face_index,
             requested_pixel_size_26_6,
             selected_pixel_size_26_6,
@@ -190,7 +215,7 @@ impl RasterFace {
     /// Returns a typed error for invalid bounds, `FreeType` failures, non-BGRA
     /// output, malformed bitmap geometry, or pixman scaling failures.
     pub fn rasterize_color_memory(
-        data: &ReadOnlyFileMap,
+        data: Arc<ReadOnlyFileMap>,
         face_index: u32,
         requested_pixel_size_26_6: isize,
         selected_pixel_size_26_6: isize,
@@ -206,15 +231,20 @@ impl RasterFace {
         }
         let index = isize::try_from(face_index).map_err(|_| RasterError::InvalidFaceIndex)?;
         let library = Library::init().map_err(RasterError::Initialize)?;
+        let data = SharedFontData(data);
         let face = library
-            .new_memory_face(data.to_vec(), index)
+            .new_memory_face2(data.clone(), index)
             .map_err(|source| RasterError::OpenMemoryFace {
                 index: face_index,
                 source,
             })?;
         face.set_char_size(selected_pixel_size_26_6, 0, 72, 72)
             .map_err(RasterError::SetSize)?;
-        let mut raster = Self { face };
+        let mut raster = Self {
+            face,
+            data,
+            collection_index: face_index & 0xffff,
+        };
         raster.rasterize_color_glyph(
             requested_pixel_size_26_6,
             selected_pixel_size_26_6,
@@ -357,12 +387,15 @@ impl RasterFace {
         let underline_top = (underline_position + underline_thickness / 2.0).trunc();
         let underline_width = underline_thickness.max(1.0).round();
         let (mut strike_position, mut strike_thickness) =
-            TrueTypeOS2Table::from_face(&mut self.face).map_or((0.0, 0.0), |os2| {
-                (
-                    f64::from(os2.y_strikeout_position()) * y_scale / 64.0,
-                    f64::from(os2.y_strikeout_size()) * y_scale / 64.0,
-                )
-            });
+            ttf_parser::Face::parse(self.data.borrow(), self.collection_index)
+                .ok()
+                .and_then(|face| face.strikeout_metrics())
+                .map_or((0.0, 0.0), |metrics| {
+                    (
+                        f64::from(metrics.position) * y_scale / 64.0,
+                        f64::from(metrics.thickness) * y_scale / 64.0,
+                    )
+                });
         if strike_position == 0.0 {
             strike_thickness = underline_thickness;
             strike_position = 3.0 * ascent / 8.0 - strike_thickness / 2.0;

--- a/crates/splinterm/src/app/font_watch.rs
+++ b/crates/splinterm/src/app/font_watch.rs
@@ -1,0 +1,173 @@
+use std::sync::Arc;
+
+use splinterm::{
+    FontUpdate, WindowTopologyUpdate, WindowUpdate,
+    config::FontAuthority,
+    renderer::{
+        FontFingerprint, FontGeneration, probe_live_font_sources, stage_live_font_generation,
+    },
+};
+use tokio::sync::mpsc;
+
+pub(in crate::app) enum FontUpdateSink {
+    Panes(Vec<mpsc::Sender<WindowUpdate>>),
+    Topology(mpsc::Sender<WindowTopologyUpdate>),
+}
+
+#[derive(Debug)]
+struct FontReloadState<F> {
+    observed: Option<F>,
+    current: F,
+}
+
+impl<F: Eq> FontReloadState<F> {
+    fn new(current: F) -> Self {
+        Self {
+            observed: None,
+            current,
+        }
+    }
+
+    fn observe(&mut self, fingerprint: F) -> bool {
+        if self.observed.as_ref() == Some(&fingerprint) {
+            return false;
+        }
+        self.observed = Some(fingerprint);
+        true
+    }
+
+    fn accept(&mut self, fingerprint: F) -> bool {
+        if self.current == fingerprint {
+            return false;
+        }
+        self.current = fingerprint;
+        true
+    }
+}
+
+#[derive(Default)]
+struct FontReloadDiagnostics {
+    rejection_reported: bool,
+}
+
+impl FontReloadDiagnostics {
+    fn accepted(&mut self) {
+        self.rejection_reported = false;
+    }
+
+    fn rejected(&mut self, error: &anyhow::Error) -> Option<String> {
+        if self.rejection_reported {
+            return None;
+        }
+        self.rejection_reported = true;
+        Some(format!("splinterm live font update rejected: {error:#}"))
+    }
+}
+
+async fn probe(pattern: String, authority: FontAuthority) -> anyhow::Result<FontFingerprint> {
+    tokio::task::spawn_blocking(move || probe_live_font_sources(&pattern, authority))
+        .await
+        .map_err(|error| anyhow::anyhow!("font probe worker failed: {error}"))?
+}
+
+async fn stage(pattern: String, authority: FontAuthority) -> anyhow::Result<FontGeneration> {
+    tokio::task::spawn_blocking(move || stage_live_font_generation(&pattern, authority))
+        .await
+        .map_err(|error| anyhow::anyhow!("font staging worker failed: {error}"))?
+}
+
+async fn deliver(sink: &FontUpdateSink, generation: Arc<FontGeneration>) -> bool {
+    let update = FontUpdate { generation };
+    match sink {
+        FontUpdateSink::Panes(updates) => {
+            let mut delivered = false;
+            for updates in updates {
+                delivered |= updates
+                    .send(WindowUpdate::Font(update.clone()))
+                    .await
+                    .is_ok();
+            }
+            delivered
+        }
+        FontUpdateSink::Topology(updates) => updates
+            .send(WindowTopologyUpdate::Font(update))
+            .await
+            .is_ok(),
+    }
+}
+
+pub(in crate::app) async fn watch_font(
+    pattern: String,
+    authority: FontAuthority,
+    current: Arc<FontGeneration>,
+    sink: FontUpdateSink,
+) {
+    if authority != FontAuthority::NativeOmarchy {
+        return;
+    }
+    let mut state = FontReloadState::new(current.fingerprint().clone());
+    let mut diagnostics = FontReloadDiagnostics::default();
+    let mut poll = tokio::time::interval(std::time::Duration::from_secs(1));
+    poll.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    loop {
+        poll.tick().await;
+        let fingerprint = match probe(pattern.clone(), authority).await {
+            Ok(fingerprint) => fingerprint,
+            Err(error) => {
+                if let Some(diagnostic) = diagnostics.rejected(&error) {
+                    eprintln!("{diagnostic}");
+                }
+                continue;
+            }
+        };
+        if !state.observe(fingerprint) {
+            continue;
+        }
+        match stage(pattern.clone(), authority).await {
+            Ok(generation) => {
+                let generation = Arc::new(generation);
+                if !state.accept(generation.fingerprint().clone()) {
+                    diagnostics.accepted();
+                    continue;
+                }
+                diagnostics.accepted();
+                if !deliver(&sink, generation).await {
+                    break;
+                }
+            }
+            Err(error) => {
+                if let Some(diagnostic) = diagnostics.rejected(&error) {
+                    eprintln!("{diagnostic}");
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reload_state_coalesces_probes_and_publishes_only_changed_candidates() {
+        let mut state = FontReloadState::new(1_u8);
+        assert!(state.observe(1));
+        assert!(!state.accept(1));
+        assert!(!state.observe(1));
+        assert!(state.observe(2));
+        assert!(state.accept(2));
+        assert!(!state.accept(2));
+        assert!(state.observe(1));
+        assert!(state.accept(1));
+    }
+
+    #[test]
+    fn reload_rejection_diagnostics_are_bounded_until_acceptance() {
+        let mut diagnostics = FontReloadDiagnostics::default();
+        let error = anyhow::anyhow!("invalid candidate");
+        assert!(diagnostics.rejected(&error).is_some());
+        assert!(diagnostics.rejected(&error).is_none());
+        diagnostics.accepted();
+        assert!(diagnostics.rejected(&error).is_some());
+    }
+}

--- a/crates/splinterm/src/app/font_watch.rs
+++ b/crates/splinterm/src/app/font_watch.rs
@@ -36,6 +36,10 @@ impl<F: Eq> FontReloadState<F> {
         true
     }
 
+    fn reject_observed(&mut self) {
+        self.observed = None;
+    }
+
     fn accept(&mut self, fingerprint: F) -> bool {
         if self.current == fingerprint {
             return false;
@@ -107,10 +111,15 @@ pub(in crate::app) async fn watch_font(
     }
     let mut state = FontReloadState::new(current.fingerprint().clone());
     let mut diagnostics = FontReloadDiagnostics::default();
+    let mut retry_after = None;
     let mut poll = tokio::time::interval(std::time::Duration::from_secs(1));
     poll.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
     loop {
         poll.tick().await;
+        if retry_after.is_some_and(|deadline| tokio::time::Instant::now() < deadline) {
+            continue;
+        }
+        retry_after = None;
         let fingerprint = match probe(pattern.clone(), authority).await {
             Ok(fingerprint) => fingerprint,
             Err(error) => {
@@ -136,6 +145,8 @@ pub(in crate::app) async fn watch_font(
                 }
             }
             Err(error) => {
+                state.reject_observed();
+                retry_after = Some(tokio::time::Instant::now() + std::time::Duration::from_secs(5));
                 if let Some(diagnostic) = diagnostics.rejected(&error) {
                     eprintln!("{diagnostic}");
                 }
@@ -159,6 +170,15 @@ mod tests {
         assert!(!state.accept(2));
         assert!(state.observe(1));
         assert!(state.accept(1));
+    }
+
+    #[test]
+    fn failed_staging_retries_the_same_observed_fingerprint() {
+        let mut state = FontReloadState::new(1_u8);
+        assert!(state.observe(2));
+        state.reject_observed();
+        assert!(state.observe(2));
+        assert!(state.accept(2));
     }
 
     #[test]

--- a/crates/splinterm/src/app/font_watch.rs
+++ b/crates/splinterm/src/app/font_watch.rs
@@ -22,7 +22,7 @@ struct FontReloadState<F> {
     current: F,
 }
 
-impl<F: Eq> FontReloadState<F> {
+impl<F: Clone + Eq> FontReloadState<F> {
     fn new(current: F) -> Self {
         Self {
             observed: None,
@@ -43,6 +43,7 @@ impl<F: Eq> FontReloadState<F> {
     }
 
     fn accept(&mut self, fingerprint: F) -> bool {
+        self.observed = Some(fingerprint.clone());
         if self.current == fingerprint {
             return false;
         }
@@ -180,6 +181,15 @@ mod tests {
         assert!(!state.accept(2));
         assert!(state.observe(1));
         assert!(state.accept(1));
+    }
+
+    #[test]
+    fn accepted_staging_replaces_a_divergent_probe_fingerprint() {
+        let mut state = FontReloadState::new(1_u8);
+        assert!(state.observe(2));
+        assert!(state.accept(3));
+        assert!(state.observe(2));
+        assert!(state.accept(2));
     }
 
     #[test]

--- a/crates/splinterm/src/app/font_watch.rs
+++ b/crates/splinterm/src/app/font_watch.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use splinterm::{
     FontUpdate, WindowTopologyUpdate, WindowUpdate,
@@ -8,6 +8,8 @@ use splinterm::{
     },
 };
 use tokio::sync::mpsc;
+
+const FONT_PROBE_INTERVAL: Duration = Duration::from_secs(10);
 
 pub(in crate::app) enum FontUpdateSink {
     Panes(Vec<mpsc::Sender<WindowUpdate>>),
@@ -112,7 +114,10 @@ pub(in crate::app) async fn watch_font(
     let mut state = FontReloadState::new(current.fingerprint().clone());
     let mut diagnostics = FontReloadDiagnostics::default();
     let mut retry_after = None;
-    let mut poll = tokio::time::interval(std::time::Duration::from_secs(1));
+    // Startup already staged `current`; defer the first ambient Fontconfig
+    // resolution and keep idle subprocess churn bounded thereafter.
+    let first_probe = tokio::time::Instant::now() + FONT_PROBE_INTERVAL;
+    let mut poll = tokio::time::interval_at(first_probe, FONT_PROBE_INTERVAL);
     poll.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
     loop {
         poll.tick().await;
@@ -158,6 +163,11 @@ pub(in crate::app) async fn watch_font(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn ambient_font_probes_keep_a_coarse_idle_cadence() {
+        assert!(FONT_PROBE_INTERVAL >= Duration::from_secs(10));
+    }
 
     #[test]
     fn reload_state_coalesces_probes_and_publishes_only_changed_candidates() {

--- a/crates/splinterm/src/app/mod.rs
+++ b/crates/splinterm/src/app/mod.rs
@@ -4,6 +4,7 @@ mod cli;
 mod commands;
 mod consent;
 mod diagnostics_cli;
+mod font_watch;
 mod human_output;
 mod integrations;
 mod keymap_cli;

--- a/crates/splinterm/src/app/sessions.rs
+++ b/crates/splinterm/src/app/sessions.rs
@@ -131,6 +131,7 @@ pub(in crate::app) async fn select_dojo(
 fn configure_picker_renderer(config: &AppConfig, theme: ResolvedTheme) -> Result<()> {
     renderer::configure(RendererOptions {
         font: config.font.clone(),
+        font_authority: config.font_authority,
         font_size: config.font_size,
         font_sizing_policy: config.font_sizing_policy,
         physical_dpi: 96.0,

--- a/crates/splinterm/src/app/window.rs
+++ b/crates/splinterm/src/app/window.rs
@@ -34,6 +34,24 @@ use super::{
     topology_manager::{initial_window_dojo_identity, run_topology_manager, spawn_topology_smoke},
 };
 
+struct AbortOnDropTask(tokio::task::JoinHandle<()>);
+
+impl AbortOnDropTask {
+    fn new(task: tokio::task::JoinHandle<()>) -> Self {
+        Self(task)
+    }
+
+    fn abort(&self) {
+        self.0.abort();
+    }
+}
+
+impl Drop for AbortOnDropTask {
+    fn drop(&mut self) {
+        self.abort();
+    }
+}
+
 async fn run_graphical_focus_reporter(
     factory: ConnectionFactory,
     mut updates: watch::Receiver<Option<SplintId>>,
@@ -166,20 +184,20 @@ pub(super) async fn run_live_multipane_window_with_app_id(
         factory.capabilities().forced_control_transfer == ForcedControlTransfer::Enabled;
     let optimistic_remote_splits =
         factory.capabilities().launch_semantics == LaunchSemantics::RemoteInteractive;
-    let theme_task = tokio::spawn(watch_theme(
+    let theme_task = AbortOnDropTask::new(tokio::spawn(watch_theme(
         config.theme_source(),
         config.background_alpha,
         config.background_blur,
         theme,
         ThemeUpdateSink::Topology(topology_update_sender.clone()),
-    ));
+    )));
     let font_task = (config.font_authority == FontAuthority::NativeOmarchy).then(|| {
-        tokio::spawn(watch_font(
+        AbortOnDropTask::new(tokio::spawn(watch_font(
             config.font.clone(),
             config.font_authority,
             initial_font_generation,
             FontUpdateSink::Topology(topology_update_sender.clone()),
-        ))
+        )))
     });
     let mut panes = Vec::with_capacity(prepared.len());
     let mut tasks = HashMap::with_capacity(prepared.len());
@@ -316,20 +334,20 @@ pub(super) async fn run_live_window(
         println!("Controller lease {controller_id} granted for live Splint");
     }
     let (updates, receiver) = mpsc::channel(WINDOW_UPDATE_QUEUE);
-    let _theme_watcher = tokio::spawn(watch_theme(
+    let _theme_watcher = AbortOnDropTask::new(tokio::spawn(watch_theme(
         config.theme_source(),
         config.background_alpha,
         config.background_blur,
         theme,
         ThemeUpdateSink::Panes(vec![updates.clone()]),
-    ));
+    )));
     let _font_watcher = (config.font_authority == FontAuthority::NativeOmarchy).then(|| {
-        tokio::spawn(watch_font(
+        AbortOnDropTask::new(tokio::spawn(watch_font(
             config.font.clone(),
             config.font_authority,
             initial_font_generation,
             FontUpdateSink::Panes(vec![updates.clone()]),
-        ))
+        )))
     });
     let (command_sender, commands) = mpsc::channel(WINDOW_COMMAND_QUEUE);
     let (resync_sender, mut resyncs) = mpsc::channel(1);
@@ -601,7 +619,7 @@ pub(super) async fn run_live_window(
 
 #[cfg(test)]
 mod tests {
-    use super::resolved_window_app_id;
+    use super::{AbortOnDropTask, resolved_window_app_id};
 
     #[test]
     fn xdg_window_identity_defaults_and_preserves_exact_override() {
@@ -610,5 +628,18 @@ mod tests {
             resolved_window_app_id(Some("org.omarchy.screensaver".to_owned())),
             "org.omarchy.screensaver"
         );
+    }
+
+    #[tokio::test]
+    async fn watcher_tasks_abort_on_scope_exit() {
+        let (sender, receiver) = tokio::sync::oneshot::channel::<()>();
+        let watcher = AbortOnDropTask::new(tokio::spawn(async move {
+            std::future::pending::<()>().await;
+            let _ = sender.send(());
+        }));
+
+        drop(watcher);
+
+        assert!(receiver.await.is_err());
     }
 }

--- a/crates/splinterm/src/app/window.rs
+++ b/crates/splinterm/src/app/window.rs
@@ -1,12 +1,12 @@
 //! Graphical window lifecycle orchestration.
 
-use std::{collections::HashMap, env, path::PathBuf};
+use std::{collections::HashMap, env, path::PathBuf, sync::Arc};
 
 use anyhow::{Context, Result, bail};
 use splinterm::{
     PerfTraceCorrelation, WindowOptions, WindowUpdate,
     automation::{MAX_RENDERER_IMAGE_RESIDENT_BYTES, SharedImageContentCache},
-    config::AppConfig,
+    config::{AppConfig, FontAuthority},
     endpoint::{
         ConnectionFactory, ForcedControlTransfer, GraphicalFocusPublication, LaunchSemantics,
     },
@@ -21,6 +21,7 @@ use splinterm_protocol::{
 use tokio::sync::{mpsc, watch};
 
 use super::{
+    font_watch::{FontUpdateSink, watch_font},
     pane_bridge::{
         ControllerOutputs, EventAction, WINDOW_COMMAND_QUEUE, WINDOW_UPDATE_QUEUE, attach,
         classify_subscription_event, layout_splint_ids, lease_snapshot_images, lease_update_images,
@@ -140,6 +141,7 @@ pub(super) async fn run_live_multipane_window_with_app_id(
         padding: config.padding,
         background_alpha: theme.background_alpha,
     })?;
+    let initial_font_generation = Arc::clone(renderer::snapshot_font_generation()?);
     let mut ids = Vec::new();
     layout_splint_ids(&dojo_model.root, &mut ids);
     let image_cache =
@@ -171,6 +173,14 @@ pub(super) async fn run_live_multipane_window_with_app_id(
         theme,
         ThemeUpdateSink::Topology(topology_update_sender.clone()),
     ));
+    let font_task = (config.font_authority == FontAuthority::NativeOmarchy).then(|| {
+        tokio::spawn(watch_font(
+            config.font.clone(),
+            config.font_authority,
+            initial_font_generation,
+            FontUpdateSink::Topology(topology_update_sender.clone()),
+        ))
+    });
     let mut panes = Vec::with_capacity(prepared.len());
     let mut tasks = HashMap::with_capacity(prepared.len());
     for pane in prepared {
@@ -226,6 +236,9 @@ pub(super) async fn run_live_multipane_window_with_app_id(
     .await
     .context("Wayland window task failed")?;
     theme_task.abort();
+    if let Some(font_task) = font_task {
+        font_task.abort();
+    }
     if let Some(smoke) = topology_smoke {
         smoke.await.context("topology smoke task failed")??;
     }
@@ -255,6 +268,7 @@ pub(super) async fn run_live_window(
         padding: config.padding,
         background_alpha: theme.background_alpha,
     })?;
+    let initial_font_generation = Arc::clone(renderer::snapshot_font_generation()?);
     let mut connection = factory.connect().await?;
     let terminal_grid_limits = terminal_grid_limits(connection.limits());
     let incarnation = connection.live_incarnation(splint_id).await?;
@@ -309,6 +323,14 @@ pub(super) async fn run_live_window(
         theme,
         ThemeUpdateSink::Panes(vec![updates.clone()]),
     ));
+    let _font_watcher = (config.font_authority == FontAuthority::NativeOmarchy).then(|| {
+        tokio::spawn(watch_font(
+            config.font.clone(),
+            config.font_authority,
+            initial_font_generation,
+            FontUpdateSink::Panes(vec![updates.clone()]),
+        ))
+    });
     let (command_sender, commands) = mpsc::channel(WINDOW_COMMAND_QUEUE);
     let (resync_sender, mut resyncs) = mpsc::channel(1);
     let controller_cancellation = tokio_util::sync::CancellationToken::new();

--- a/crates/splinterm/src/app/window.rs
+++ b/crates/splinterm/src/app/window.rs
@@ -133,6 +133,7 @@ pub(super) async fn run_live_multipane_window_with_app_id(
     let theme = load_startup_theme(&config);
     renderer::configure(RendererOptions {
         font: config.font.clone(),
+        font_authority: config.font_authority,
         font_size: config.font_size,
         font_sizing_policy: config.font_sizing_policy,
         physical_dpi: 96.0,
@@ -247,6 +248,7 @@ pub(super) async fn run_live_window(
     let theme = load_startup_theme(&config);
     renderer::configure(RendererOptions {
         font: config.font.clone(),
+        font_authority: config.font_authority,
         font_size: config.font_size,
         font_sizing_policy: config.font_sizing_policy,
         physical_dpi: 96.0,

--- a/crates/splinterm/src/bin/final-buffer-capture.rs
+++ b/crates/splinterm/src/bin/final-buffer-capture.rs
@@ -4,7 +4,7 @@ use anyhow::{Context, Result, bail};
 use clap::Parser;
 use serde::Deserialize;
 use splinterm::{
-    config::CursorStyle,
+    config::{CursorStyle, FontAuthority},
     geometry::{FontSize, FontSizingPolicy, TerminalPadding, resolve_font_size},
     renderer::{
         CursorPresentation, RendererOptions, UnfocusedCursorStyle, capture_final_buffer,
@@ -328,6 +328,7 @@ fn main() -> Result<()> {
     )?;
     configure(RendererOptions {
         font: arguments.font.clone(),
+        font_authority: FontAuthority::Explicit,
         font_size,
         font_sizing_policy,
         physical_dpi: arguments.physical_dpi,

--- a/crates/splinterm/src/config.rs
+++ b/crates/splinterm/src/config.rs
@@ -27,11 +27,20 @@ use crate::{
 };
 
 pub const APP_ID: &str = "com.oldjobobo.splinterm";
-pub const DEFAULT_FONT: &str = "JetBrains Mono Nerd Font:style=Regular";
+pub const DEFAULT_FONT: &str = "monospace:style=Regular";
+pub const STARTUP_FONT_FALLBACK: &str = "JetBrains Mono Nerd Font:style=Regular";
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum FontAuthority {
+    #[default]
+    NativeOmarchy,
+    Explicit,
+}
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct AppConfig {
     pub font: String,
+    pub font_authority: FontAuthority,
     pub font_size: FontSize,
     pub font_sizing_policy: FontSizingPolicy,
     pub padding: TerminalPadding,
@@ -93,6 +102,7 @@ impl Default for AppConfig {
     fn default() -> Self {
         Self {
             font: DEFAULT_FONT.to_owned(),
+            font_authority: FontAuthority::NativeOmarchy,
             font_size: FontSize::Pixels(14.0),
             font_sizing_policy: FontSizingPolicy::OutputScale,
             padding: TerminalPadding::DEFAULT,
@@ -247,6 +257,7 @@ fn parse_with_base(text: &str, config_dir: &Path) -> Result<ConfigLoad> {
                     );
                 }
                 config.font = font;
+                config.font_authority = FontAuthority::Explicit;
                 false
             }
             "main.font-size" | "font-size" | "main.font-pixelsize" => {
@@ -1025,6 +1036,8 @@ mod tests {
     #[test]
     fn defaults_match_foot_font_and_resize_behavior() {
         let defaults = AppConfig::default();
+        assert_eq!(defaults.font, "monospace:style=Regular");
+        assert_eq!(defaults.font_authority, FontAuthority::NativeOmarchy);
         assert_eq!(defaults.font_size, FontSize::Pixels(14.0));
         assert_eq!(defaults.resize_delay_ms, 100);
         assert_eq!(defaults.keymap_profile, KeymapProfile::Splinterm);
@@ -1049,6 +1062,13 @@ mod tests {
                 .is_some_and(|catalog| catalog.contains("omarchy.tdl"))
         );
         assert!(!defaults.allow_unrestricted_commands);
+    }
+
+    #[test]
+    fn explicit_monospace_pattern_retains_explicit_authority() {
+        let loaded = parse("[main]\nfont=monospace:style=Regular\n").unwrap();
+        assert_eq!(loaded.config.font, "monospace:style=Regular");
+        assert_eq!(loaded.config.font_authority, FontAuthority::Explicit);
     }
 
     #[test]

--- a/crates/splinterm/src/frontend/message.rs
+++ b/crates/splinterm/src/frontend/message.rs
@@ -1,12 +1,14 @@
 //! Bounded messages exchanged by the application owner and graphical adapter.
 
+use std::sync::Arc;
+
 use splinterm_automation_client::ImageContentLeaseSet;
 use splinterm_core::SplintId;
 use splinterm_protocol::{
     ControlTransferDecision, ControlTransferOutcome, SearchPage, TerminalSnapshot, TerminalUpdate,
 };
 
-use crate::config::ResolvedTheme;
+use crate::{config::ResolvedTheme, renderer::FontGeneration};
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct AuthorityStatus {
@@ -49,6 +51,7 @@ pub enum WindowUpdate {
     SearchResults(SearchPage),
     SearchResyncRequired,
     Theme(ThemeUpdate),
+    Font(FontUpdate),
     Exited {
         splint_id: SplintId,
     },
@@ -59,6 +62,11 @@ pub enum WindowUpdate {
 pub struct ThemeUpdate {
     pub generation: u64,
     pub theme: ResolvedTheme,
+}
+
+#[derive(Clone, Debug)]
+pub struct FontUpdate {
+    pub generation: Arc<FontGeneration>,
 }
 
 /// Bounded Wayland-to-protocol commands for the first interactive slice.

--- a/crates/splinterm/src/frontend/mod.rs
+++ b/crates/splinterm/src/frontend/mod.rs
@@ -18,7 +18,7 @@ pub(crate) use action_menu::{
 };
 pub(crate) use binding_help::{BINDING_HELP_PAGE_ITEMS, BindingHelpUi};
 pub use message::{
-    AuthorityStatus, PerfTraceCorrelation, ThemeUpdate, WindowCommand, WindowUpdate,
+    AuthorityStatus, FontUpdate, PerfTraceCorrelation, ThemeUpdate, WindowCommand, WindowUpdate,
 };
 pub use options::{TerminalGridLimits, TrustedConsentUi, WindowOptions, WindowPaneOptions};
 pub(crate) use picker::PickerHitTarget;

--- a/crates/splinterm/src/frontend/topology.rs
+++ b/crates/splinterm/src/frontend/topology.rs
@@ -7,7 +7,7 @@ use splinterm_core::{
 };
 use splinterm_protocol::{MutationTarget, PresetDojoLaunch, PresetTarget};
 
-use super::{SessionPickerItem, ThemeUpdate, WindowPaneOptions};
+use super::{FontUpdate, SessionPickerItem, ThemeUpdate, WindowPaneOptions};
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct WindowDojoIdentity {
@@ -188,6 +188,7 @@ pub enum WindowTopologyUpdate {
     },
     SessionPickerFailed(String),
     Theme(ThemeUpdate),
+    Font(FontUpdate),
     Closed,
     Shutdown(String),
 }

--- a/crates/splinterm/src/lib.rs
+++ b/crates/splinterm/src/lib.rs
@@ -28,9 +28,9 @@ pub mod viewport;
 pub mod wayland;
 
 pub use frontend::{
-    AuthorityStatus, LairDirection, LairPromptKind, LairPromptTarget, PerfTraceCorrelation,
-    SelectorKind, SessionPickerDecision, SessionPickerItem, SessionPickerUi, TerminalGridLimits,
-    ThemeUpdate, TrustedConsentUi, WindowCommand, WindowDojoIdentity, WindowOptions,
-    WindowPaneOptions, WindowTopologyCommand, WindowTopologyUpdate, WindowUpdate,
+    AuthorityStatus, FontUpdate, LairDirection, LairPromptKind, LairPromptTarget,
+    PerfTraceCorrelation, SelectorKind, SessionPickerDecision, SessionPickerItem, SessionPickerUi,
+    TerminalGridLimits, ThemeUpdate, TrustedConsentUi, WindowCommand, WindowDojoIdentity,
+    WindowOptions, WindowPaneOptions, WindowTopologyCommand, WindowTopologyUpdate, WindowUpdate,
 };
 pub use wayland::run as run_window;

--- a/crates/splinterm/src/renderer.rs
+++ b/crates/splinterm/src/renderer.rs
@@ -69,7 +69,7 @@ use decorations::DecorationMetrics;
 #[cfg(test)]
 use decorations::DecorationSpan;
 pub use evidence::{benchmark_json, phase4_benchmark_json, write_ppm};
-pub(super) use fonts::*;
+pub use fonts::*;
 pub use fonts::{ascii_glyph_evidence, production_ascii_glyph_evidence, snapshot_cache_metrics};
 pub(crate) use frame::SnapshotFrame;
 use frame::{SnapshotGlyph, packed_rgb};

--- a/crates/splinterm/src/renderer/fonts.rs
+++ b/crates/splinterm/src/renderer/fonts.rs
@@ -5,7 +5,10 @@ use std::{
     collections::{HashMap, VecDeque},
     path::PathBuf,
     process::Command,
-    sync::{Arc, OnceLock},
+    sync::{
+        Arc, OnceLock,
+        atomic::{AtomicU64, Ordering},
+    },
     time::Instant,
 };
 
@@ -42,15 +45,16 @@ pub(super) const SNAPSHOT_PRIMARY_BOLD_ITALIC: usize = 3;
 pub(super) const SNAPSHOT_CJK: usize = 4;
 pub(super) const SNAPSHOT_EMOJI: usize = 5;
 
-pub(super) static SNAPSHOT_FONT_GENERATION: OnceLock<Result<FontGeneration, String>> =
+static NEXT_FONT_GENERATION_ID: AtomicU64 = AtomicU64::new(1);
+pub(super) static SNAPSHOT_FONT_GENERATION: OnceLock<Result<Arc<FontGeneration>, String>> =
     OnceLock::new();
 #[derive(Default)]
 pub(super) struct PersistentGlyphCache {
-    pub(super) raster_faces: HashMap<(isize, usize), RasterFace>,
-    pub(super) raster_face_order: VecDeque<(isize, usize)>,
-    pub(super) glyphs: HashMap<(isize, GlyphKey), Arc<CachedGlyph>>,
-    pub(super) advances: HashMap<(isize, GlyphKey), i32>,
-    pub(super) order: VecDeque<(isize, GlyphKey)>,
+    pub(super) raster_faces: HashMap<(u64, isize, usize), RasterFace>,
+    pub(super) raster_face_order: VecDeque<(u64, isize, usize)>,
+    pub(super) glyphs: HashMap<(u64, isize, GlyphKey), Arc<CachedGlyph>>,
+    pub(super) advances: HashMap<(u64, isize, GlyphKey), i32>,
+    pub(super) order: VecDeque<(u64, isize, GlyphKey)>,
     pub(super) glyph_bytes: usize,
     pub(super) hits: u64,
     pub(super) misses: u64,
@@ -61,7 +65,7 @@ pub(super) struct PersistentGlyphCache {
 impl PersistentGlyphCache {
     pub(super) fn insert_glyph(
         &mut self,
-        cache_key: (isize, GlyphKey),
+        cache_key: (u64, isize, GlyphKey),
         glyph: Arc<CachedGlyph>,
         color_advance: Option<i32>,
     ) {
@@ -76,7 +80,7 @@ impl PersistentGlyphCache {
 
     pub(super) fn insert_glyph_bounded(
         &mut self,
-        cache_key: (isize, GlyphKey),
+        cache_key: (u64, isize, GlyphKey),
         glyph: Arc<CachedGlyph>,
         color_advance: Option<i32>,
         entry_budget: usize,
@@ -104,7 +108,7 @@ impl PersistentGlyphCache {
         self.glyphs.insert(cache_key, glyph);
     }
 
-    pub(super) fn prepare_raster_face_insert(&mut self, raster_key: (isize, usize)) {
+    pub(super) fn prepare_raster_face_insert(&mut self, raster_key: (u64, isize, usize)) {
         while self.raster_faces.len() >= SNAPSHOT_RASTER_FACE_BUDGET {
             let Some(oldest) = self.raster_face_order.pop_front() else {
                 break;
@@ -172,11 +176,14 @@ pub(super) struct FontFingerprint {
     pub(super) faces: [FontFaceFingerprint; 6],
 }
 
-pub(super) struct FontGeneration {
+#[derive(Debug)]
+pub(crate) struct FontGeneration {
+    pub(super) id: u64,
     pub(super) fingerprint: FontFingerprint,
     pub(super) faces: [FontFace; 6],
 }
 
+#[derive(Debug)]
 pub(super) struct FontFace {
     pub(super) label: &'static str,
     pub(super) family: String,
@@ -185,6 +192,7 @@ pub(super) struct FontFace {
     pub(super) index: usize,
     pub(super) weight: i32,
     pub(super) slant: i32,
+    pub(super) generation_id: u64,
     pub(super) selected_pixel_size_26_6: isize,
     pub(super) source_identity: FileIdentity,
     pub(super) data: Arc<ReadOnlyFileMap>,
@@ -200,6 +208,7 @@ impl FontFace {
             index: self.index,
             weight: self.weight,
             slant: self.slant,
+            generation_id: self.generation_id,
             selected_pixel_size_26_6: self.selected_pixel_size_26_6,
             source_identity: self.source_identity,
             data: self.data.clone(),
@@ -541,11 +550,12 @@ pub(super) fn cache_glyph(
     Ok(())
 }
 
-pub(super) fn snapshot_font_generation() -> Result<&'static FontGeneration> {
+pub(super) fn snapshot_font_generation() -> Result<&'static Arc<FontGeneration>> {
     SNAPSHOT_FONT_GENERATION
         .get_or_init(|| {
             let options = renderer_options();
             stage_startup_font_generation(&options.font, options.font_authority)
+                .map(Arc::new)
                 .map_err(|error| error.to_string())
         })
         .as_ref()
@@ -563,20 +573,28 @@ pub(super) fn snapshot_glyph(
     font_size: f32,
 ) -> Result<Arc<CachedGlyph>> {
     let effective_size_26_6 = pixel_size_26_6(font_size)?;
+    let generation_id = faces
+        .get(face_index)
+        .context("glyph face index is in the active font generation")?
+        .generation_id;
     let key = GlyphKey {
         face: face_index,
         glyph: glyph_id,
     };
     SNAPSHOT_GLYPH_CACHE.with(|cache| {
         let mut cache = cache.borrow_mut();
-        if let Some(glyph) = cache.glyphs.get(&(effective_size_26_6, key)).cloned() {
+        if let Some(glyph) = cache
+            .glyphs
+            .get(&(generation_id, effective_size_26_6, key))
+            .cloned()
+        {
             cache.hits = cache.hits.saturating_add(1);
             return Ok(glyph);
         }
         cache.misses = cache.misses.saturating_add(1);
         let (glyph, color_advance) = if face_index == SNAPSHOT_EMOJI {
             let face = &faces[face_index];
-            let raster_key = (face.selected_pixel_size_26_6, face_index);
+            let raster_key = (generation_id, face.selected_pixel_size_26_6, face_index);
             if !cache.raster_faces.contains_key(&raster_key) {
                 let raster_face = RasterFace::open_memory(
                     &face.data,
@@ -609,7 +627,7 @@ pub(super) fn snapshot_glyph(
                 Some(raster.advance_x),
             )
         } else {
-            let raster_key = (effective_size_26_6, face_index);
+            let raster_key = (generation_id, effective_size_26_6, face_index);
             if !cache.raster_faces.contains_key(&raster_key) {
                 let raster_face = RasterFace::open_memory(
                     &faces[face_index].data,
@@ -642,7 +660,7 @@ pub(super) fn snapshot_glyph(
         };
         let glyph = Arc::new(glyph);
         cache.insert_glyph(
-            (effective_size_26_6, key),
+            (generation_id, effective_size_26_6, key),
             Arc::clone(&glyph),
             color_advance,
         );
@@ -663,11 +681,16 @@ pub(super) fn pixel_size_26_6(font_size: f32) -> Result<isize> {
 }
 
 pub(super) fn snapshot_color_advance(
+    faces: &[FontFace],
     face_index: usize,
     glyph_id: u16,
     font_size: f32,
 ) -> Result<i32> {
     let cache_key = (
+        faces
+            .get(face_index)
+            .context("color face index is in the active font generation")?
+            .generation_id,
         pixel_size_26_6(font_size)?,
         GlyphKey {
             face: face_index,
@@ -971,7 +994,7 @@ pub fn production_ascii_glyph_evidence() -> Result<Vec<serde_json::Value>> {
         right: 0,
         bottom: 0,
     });
-    let emoji_advance = snapshot_color_advance(SNAPSHOT_EMOJI, glyph_id, font_size)?;
+    let emoji_advance = snapshot_color_advance(faces, SNAPSHOT_EMOJI, glyph_id, font_size)?;
     records.push(serde_json::json!({
         "schema": 1,
         "label": "emoji",
@@ -1231,6 +1254,7 @@ pub(super) fn resolve_face(
         index,
         weight,
         slant,
+        generation_id: 0,
         selected_pixel_size_26_6,
         source_identity,
         data,
@@ -1429,7 +1453,8 @@ fn resolve_font_candidate(
     } else {
         resolve_primary_faces_exact(pattern)?
     };
-    let faces = [
+    let id = NEXT_FONT_GENERATION_ID.fetch_add(1, Ordering::Relaxed);
+    let mut faces = [
         regular,
         bold,
         italic,
@@ -1437,12 +1462,19 @@ fn resolve_font_candidate(
         resolve_face("CJK fallback", CJK_FONT, "noto sans cjk")?,
         resolve_face("emoji fallback", EMOJI_FONT, "noto color emoji")?,
     ];
+    for face in &mut faces {
+        face.generation_id = id;
+    }
     let fingerprint = FontFingerprint {
         pattern: pattern.to_owned(),
         authority,
         faces: std::array::from_fn(|index| faces[index].fingerprint()),
     };
-    Ok(FontGeneration { fingerprint, faces })
+    Ok(FontGeneration {
+        id,
+        fingerprint,
+        faces,
+    })
 }
 
 fn stage_stable_with<F, T>(mut stage: impl FnMut() -> Result<(F, T)>) -> Result<T>
@@ -1481,7 +1513,7 @@ fn stage_startup_font_generation(
     dead_code,
     reason = "the next Plan 0038 milestone wires staged live generations into the watcher"
 )]
-pub(super) fn stage_live_font_generation(
+pub(crate) fn stage_live_font_generation(
     pattern: &str,
     authority: FontAuthority,
 ) -> Result<FontGeneration> {
@@ -1618,6 +1650,7 @@ mod tests {
             index: 0,
             weight,
             slant,
+            generation_id: 0,
             selected_pixel_size_26_6: 12 * 64,
             source_identity: data.identity(),
             data,
@@ -1804,6 +1837,7 @@ mod tests {
         let mut cache = PersistentGlyphCache::default();
         for glyph in 0..=SNAPSHOT_GLYPH_CACHE_BUDGET {
             let key = (
+                1,
                 768,
                 GlyphKey {
                     face: SNAPSHOT_EMOJI,
@@ -1824,6 +1858,7 @@ mod tests {
             );
         }
         let first = (
+            1,
             768,
             GlyphKey {
                 face: SNAPSHOT_EMOJI,
@@ -1840,7 +1875,7 @@ mod tests {
         let mut byte_bounded = PersistentGlyphCache::default();
         for glyph in 0..3 {
             byte_bounded.insert_glyph_bounded(
-                (768, GlyphKey { face: 0, glyph }),
+                (1, 768, GlyphKey { face: 0, glyph }),
                 Arc::new(CachedGlyph {
                     content: Content::Mask,
                     left: 0,

--- a/crates/splinterm/src/renderer/fonts.rs
+++ b/crates/splinterm/src/renderer/fonts.rs
@@ -10,8 +10,8 @@ use std::{
 };
 
 use anyhow::{Context, Result, bail};
-use splinterm_filemap::ReadOnlyFileMap;
-use splinterm_freetype::RasterFace;
+use splinterm_filemap::{FileIdentity, ReadOnlyFileMap};
+use splinterm_freetype::{MAX_STAGED_FONT_BYTES, RasterFace};
 use swash::{
     FontRef,
     scale::{Render, ScaleContext, Source, StrikeWith, image::Content},
@@ -42,7 +42,8 @@ pub(super) const SNAPSHOT_PRIMARY_BOLD_ITALIC: usize = 3;
 pub(super) const SNAPSHOT_CJK: usize = 4;
 pub(super) const SNAPSHOT_EMOJI: usize = 5;
 
-pub(super) static SNAPSHOT_FACES: OnceLock<Result<[FontFace; 6], String>> = OnceLock::new();
+pub(super) static SNAPSHOT_FONT_GENERATION: OnceLock<Result<FontGeneration, String>> =
+    OnceLock::new();
 #[derive(Default)]
 pub(super) struct PersistentGlyphCache {
     pub(super) raster_faces: HashMap<(isize, usize), RasterFace>,
@@ -152,6 +153,30 @@ pub(super) struct GlyphKey {
 
 pub(super) const BOX_DRAWING_FACE: usize = usize::MAX;
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(super) struct FontFaceFingerprint {
+    pub(super) family: String,
+    pub(super) style: String,
+    pub(super) path: PathBuf,
+    pub(super) index: usize,
+    pub(super) weight: i32,
+    pub(super) slant: i32,
+    pub(super) selected_pixel_size_26_6: isize,
+    pub(super) source_identity: FileIdentity,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(super) struct FontFingerprint {
+    pub(super) pattern: String,
+    pub(super) authority: FontAuthority,
+    pub(super) faces: [FontFaceFingerprint; 6],
+}
+
+pub(super) struct FontGeneration {
+    pub(super) fingerprint: FontFingerprint,
+    pub(super) faces: [FontFace; 6],
+}
+
 pub(super) struct FontFace {
     pub(super) label: &'static str,
     pub(super) family: String,
@@ -161,7 +186,8 @@ pub(super) struct FontFace {
     pub(super) weight: i32,
     pub(super) slant: i32,
     pub(super) selected_pixel_size_26_6: isize,
-    pub(super) data: OnceLock<Result<ReadOnlyFileMap, String>>,
+    pub(super) source_identity: FileIdentity,
+    pub(super) data: Arc<ReadOnlyFileMap>,
 }
 
 impl FontFace {
@@ -175,12 +201,26 @@ impl FontFace {
             weight: self.weight,
             slant: self.slant,
             selected_pixel_size_26_6: self.selected_pixel_size_26_6,
-            data: OnceLock::new(),
+            source_identity: self.source_identity,
+            data: self.data.clone(),
         }
     }
 
     fn identity(&self) -> (&std::path::Path, usize) {
         (&self.path, self.index)
+    }
+
+    fn fingerprint(&self) -> FontFaceFingerprint {
+        FontFaceFingerprint {
+            family: self.family.clone(),
+            style: self.style.clone(),
+            path: self.path.clone(),
+            index: self.index,
+            weight: self.weight,
+            slant: self.slant,
+            selected_pixel_size_26_6: self.selected_pixel_size_26_6,
+            source_identity: self.source_identity,
+        }
     }
 }
 
@@ -501,26 +541,19 @@ pub(super) fn cache_glyph(
     Ok(())
 }
 
-pub(super) fn snapshot_faces() -> Result<&'static [FontFace; 6]> {
-    SNAPSHOT_FACES
+pub(super) fn snapshot_font_generation() -> Result<&'static FontGeneration> {
+    SNAPSHOT_FONT_GENERATION
         .get_or_init(|| {
             let options = renderer_options();
-            let [regular, bold, italic, bold_italic] =
-                resolve_primary_faces(&options.font, options.font_authority)
-                    .map_err(|error| error.to_string())?;
-            Ok([
-                regular,
-                bold,
-                italic,
-                bold_italic,
-                resolve_face("CJK fallback", CJK_FONT, "noto sans cjk")
-                    .map_err(|error| error.to_string())?,
-                resolve_face("emoji fallback", EMOJI_FONT, "noto color emoji")
-                    .map_err(|error| error.to_string())?,
-            ])
+            stage_startup_font_generation(&options.font, options.font_authority)
+                .map_err(|error| error.to_string())
         })
         .as_ref()
         .map_err(|error| anyhow::anyhow!(error.clone()))
+}
+
+pub(super) fn snapshot_faces() -> Result<&'static [FontFace; 6]> {
+    Ok(&snapshot_font_generation()?.faces)
 }
 
 pub(super) fn snapshot_glyph(
@@ -543,14 +576,27 @@ pub(super) fn snapshot_glyph(
         cache.misses = cache.misses.saturating_add(1);
         let (glyph, color_advance) = if face_index == SNAPSHOT_EMOJI {
             let face = &faces[face_index];
-            let raster = RasterFace::rasterize_color(
-                &face.path,
-                u32::try_from(face.index).context("emoji face index fits u32")?,
-                effective_size_26_6,
-                face.selected_pixel_size_26_6,
-                u32::from(glyph_id),
-            )
-            .with_context(|| format!("rasterize color snapshot glyph {glyph_id}"))?;
+            let raster_key = (face.selected_pixel_size_26_6, face_index);
+            if !cache.raster_faces.contains_key(&raster_key) {
+                let raster_face = RasterFace::open_memory(
+                    &face.data,
+                    u32::try_from(face.index).context("emoji face index fits u32")?,
+                    face.selected_pixel_size_26_6,
+                )
+                .context("open staged emoji raster face")?;
+                cache.prepare_raster_face_insert(raster_key);
+                cache.raster_faces.insert(raster_key, raster_face);
+            }
+            let raster = cache
+                .raster_faces
+                .get_mut(&raster_key)
+                .context("inserted emoji raster face remains present")?
+                .rasterize_color_glyph(
+                    effective_size_26_6,
+                    face.selected_pixel_size_26_6,
+                    u32::from(glyph_id),
+                )
+                .with_context(|| format!("rasterize color snapshot glyph {glyph_id}"))?;
             (
                 CachedGlyph {
                     content: Content::Color,
@@ -565,8 +611,8 @@ pub(super) fn snapshot_glyph(
         } else {
             let raster_key = (effective_size_26_6, face_index);
             if !cache.raster_faces.contains_key(&raster_key) {
-                let raster_face = RasterFace::open(
-                    &faces[face_index].path,
+                let raster_face = RasterFace::open_memory(
+                    &faces[face_index].data,
                     u32::try_from(faces[face_index].index).context("face index fits u32")?,
                     pixel_size_26_6(font_size)?,
                 )
@@ -1066,8 +1112,8 @@ pub(super) struct CellMetrics {
     reason = "the protocol-bounded integer terminal advance is exactly representable in f32"
 )]
 pub(super) fn cell_metrics(primary_face: &FontFace, font_size: f32) -> Result<CellMetrics> {
-    let mut face = RasterFace::open(
-        &primary_face.path,
+    let mut face = RasterFace::open_memory(
+        &primary_face.data,
         u32::try_from(primary_face.index).context("primary face index")?,
         pixel_size_26_6(font_size)?,
     )
@@ -1173,6 +1219,10 @@ pub(super) fn resolve_face(
     if !normalized_expected.is_empty() && !normalized_family.contains(&normalized_expected) {
         bail!("explicit {label} pattern {pattern:?} resolved unexpectedly to {family:?}");
     }
+    let snapshot = ReadOnlyFileMap::immutable_snapshot(&path, MAX_STAGED_FONT_BYTES)
+        .with_context(|| format!("snapshot resolved {label} font"))?;
+    let source_identity = snapshot.source_identity;
+    let data = Arc::new(snapshot.mapping);
     let face = FontFace {
         label,
         family,
@@ -1182,8 +1232,10 @@ pub(super) fn resolve_face(
         weight,
         slant,
         selected_pixel_size_26_6,
-        data: OnceLock::new(),
+        source_identity,
+        data,
     };
+    font_ref(&face).with_context(|| format!("parse resolved {label} font"))?;
     eprintln!(
         "Resolved {label}: {} {} (face {}, {})",
         face.family,
@@ -1367,20 +1419,81 @@ fn resolve_primary_faces(pattern: &str, authority: FontAuthority) -> Result<[Fon
     resolve_startup_primary_with(pattern, authority, resolve_primary_faces_exact)
 }
 
-pub(super) fn font_data(face: &FontFace) -> Result<&[u8]> {
-    face.data
-        .get_or_init(|| {
-            ReadOnlyFileMap::open(&face.path)
-                .with_context(|| format!("map {}", face.path.display()))
-                .map_err(|error| error.to_string())
-        })
-        .as_ref()
-        .map(|mapping| &**mapping)
-        .map_err(|error| anyhow::anyhow!(error.clone()))
+fn resolve_font_candidate(
+    pattern: &str,
+    authority: FontAuthority,
+    startup: bool,
+) -> Result<FontGeneration> {
+    let [regular, bold, italic, bold_italic] = if startup {
+        resolve_primary_faces(pattern, authority)?
+    } else {
+        resolve_primary_faces_exact(pattern)?
+    };
+    let faces = [
+        regular,
+        bold,
+        italic,
+        bold_italic,
+        resolve_face("CJK fallback", CJK_FONT, "noto sans cjk")?,
+        resolve_face("emoji fallback", EMOJI_FONT, "noto color emoji")?,
+    ];
+    let fingerprint = FontFingerprint {
+        pattern: pattern.to_owned(),
+        authority,
+        faces: std::array::from_fn(|index| faces[index].fingerprint()),
+    };
+    Ok(FontGeneration { fingerprint, faces })
+}
+
+fn stage_stable_with<F, T>(mut stage: impl FnMut() -> Result<(F, T)>) -> Result<T>
+where
+    F: std::fmt::Debug + Eq,
+{
+    let (first_fingerprint, first) = stage()?;
+    let (second_fingerprint, second) = stage()?;
+    anyhow::ensure!(
+        first_fingerprint == second_fingerprint,
+        "font resolution changed while staging: first={first_fingerprint:?}, second={second_fingerprint:?}"
+    );
+    drop(first);
+    Ok(second)
+}
+
+fn stage_font_generation(
+    pattern: &str,
+    authority: FontAuthority,
+    startup: bool,
+) -> Result<FontGeneration> {
+    stage_stable_with(|| {
+        let generation = resolve_font_candidate(pattern, authority, startup)?;
+        Ok((generation.fingerprint.clone(), generation))
+    })
+}
+
+fn stage_startup_font_generation(
+    pattern: &str,
+    authority: FontAuthority,
+) -> Result<FontGeneration> {
+    stage_font_generation(pattern, authority, true)
+}
+
+#[allow(
+    dead_code,
+    reason = "the next Plan 0038 milestone wires staged live generations into the watcher"
+)]
+pub(super) fn stage_live_font_generation(
+    pattern: &str,
+    authority: FontAuthority,
+) -> Result<FontGeneration> {
+    stage_font_generation(pattern, authority, false)
+}
+
+pub(super) fn font_data(face: &FontFace) -> &[u8] {
+    &face.data
 }
 
 pub(super) fn font_ref(face: &FontFace) -> Result<FontRef<'_>> {
-    FontRef::from_index(font_data(face)?, face.index).with_context(|| {
+    FontRef::from_index(font_data(face), face.index).with_context(|| {
         format!(
             "parse {} face {} with Swash",
             face.path.display(),
@@ -1487,6 +1600,16 @@ mod tests {
         weight: i32,
         slant: i32,
     ) -> FontFace {
+        static NEXT_SYNTHETIC_FACE: std::sync::atomic::AtomicU64 =
+            std::sync::atomic::AtomicU64::new(1);
+        let mapped_path = std::env::temp_dir().join(format!(
+            "splinterm-synthetic-face-{}-{}",
+            std::process::id(),
+            NEXT_SYNTHETIC_FACE.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+        ));
+        std::fs::write(&mapped_path, b"synthetic face bytes").unwrap();
+        let data = Arc::new(ReadOnlyFileMap::open(&mapped_path).unwrap());
+        std::fs::remove_file(mapped_path).unwrap();
         FontFace {
             label,
             family: family.to_owned(),
@@ -1496,7 +1619,8 @@ mod tests {
             weight,
             slant,
             selected_pixel_size_26_6: 12 * 64,
-            data: OnceLock::new(),
+            source_identity: data.identity(),
+            data,
         }
     }
 
@@ -1647,6 +1771,20 @@ mod tests {
         )
         .unwrap_err();
         assert!(error.to_string().contains("startup fallback"));
+    }
+
+    #[test]
+    fn stable_staging_accepts_identical_fingerprints_and_returns_the_second_candidate() {
+        let mut candidates = [(7_u8, "first"), (7_u8, "second")].into_iter();
+        let staged = stage_stable_with(|| Ok(candidates.next().unwrap())).unwrap();
+        assert_eq!(staged, "second");
+    }
+
+    #[test]
+    fn stable_staging_rejects_a_mixed_resolution() {
+        let mut candidates = [(7_u8, "first"), (8_u8, "second")].into_iter();
+        let error = stage_stable_with(|| Ok(candidates.next().unwrap())).unwrap_err();
+        assert!(error.to_string().contains("changed while staging"));
     }
 
     #[test]

--- a/crates/splinterm/src/renderer/fonts.rs
+++ b/crates/splinterm/src/renderer/fonts.rs
@@ -2,7 +2,7 @@
 
 use std::{
     cell::RefCell,
-    collections::{HashMap, VecDeque},
+    collections::{HashMap, HashSet, VecDeque},
     os::unix::fs::MetadataExt,
     path::PathBuf,
     process::Command,
@@ -17,7 +17,7 @@ use anyhow::{Context, Result, bail};
 use splinterm_filemap::{FileIdentity, ReadOnlyFileMap};
 use splinterm_freetype::{MAX_STAGED_FONT_BYTES, RasterFace};
 use swash::{
-    FontRef,
+    FontRef, NormalizedCoord,
     scale::{Render, ScaleContext, Source, StrikeWith, image::Content},
     shape::ShapeContext,
     zeno::Format,
@@ -38,6 +38,7 @@ pub(super) const EMOJI_FONT: &str = "Noto Color Emoji";
 pub(super) const SNAPSHOT_GLYPH_CACHE_BUDGET: usize = 2_048;
 pub(super) const SNAPSHOT_GLYPH_CACHE_BYTE_BUDGET: usize = 64 * 1024 * 1024;
 pub(super) const SNAPSHOT_RASTER_FACE_BUDGET: usize = 24;
+pub(super) const SNAPSHOT_FALLBACK_MAPPING_BUDGET: usize = 24;
 
 pub(super) const SNAPSHOT_PRIMARY_REGULAR: usize = 0;
 pub(super) const SNAPSHOT_PRIMARY_BOLD: usize = 1;
@@ -45,10 +46,40 @@ pub(super) const SNAPSHOT_PRIMARY_ITALIC: usize = 2;
 pub(super) const SNAPSHOT_PRIMARY_BOLD_ITALIC: usize = 3;
 pub(super) const SNAPSHOT_CJK: usize = 4;
 pub(super) const SNAPSHOT_EMOJI: usize = 5;
+pub(super) const SNAPSHOT_FALLBACK_START: usize = 6;
 
 static NEXT_FONT_GENERATION_ID: AtomicU64 = AtomicU64::new(1);
 pub(super) static SNAPSHOT_FONT_GENERATION: OnceLock<Result<Arc<FontGeneration>, String>> =
     OnceLock::new();
+#[derive(Default)]
+pub(super) struct PersistentFontMappingCache {
+    pub(super) mappings: HashMap<(PathBuf, FileIdentity), Arc<ReadOnlyFileMap>>,
+    pub(super) order: VecDeque<(PathBuf, FileIdentity)>,
+    pub(super) hits: u64,
+    pub(super) misses: u64,
+    pub(super) evictions: u64,
+}
+
+impl PersistentFontMappingCache {
+    fn insert(
+        &mut self,
+        key: (PathBuf, FileIdentity),
+        mapping: Arc<ReadOnlyFileMap>,
+    ) -> Arc<ReadOnlyFileMap> {
+        while self.mappings.len() >= SNAPSHOT_FALLBACK_MAPPING_BUDGET {
+            let Some(oldest) = self.order.pop_front() else {
+                break;
+            };
+            if self.mappings.remove(&oldest).is_some() {
+                self.evictions = self.evictions.saturating_add(1);
+            }
+        }
+        self.order.push_back(key.clone());
+        self.mappings.insert(key, Arc::clone(&mapping));
+        mapping
+    }
+}
+
 #[derive(Default)]
 pub(super) struct PersistentGlyphCache {
     pub(super) raster_faces: HashMap<(u64, isize, usize), RasterFace>,
@@ -125,10 +156,15 @@ impl PersistentGlyphCache {
 thread_local! {
     pub(super) static SNAPSHOT_GLYPH_CACHE: RefCell<PersistentGlyphCache> =
         RefCell::new(PersistentGlyphCache::default());
+    pub(super) static SNAPSHOT_FALLBACK_MAPPING_CACHE: RefCell<PersistentFontMappingCache> =
+        RefCell::new(PersistentFontMappingCache::default());
 }
 
 pub(crate) fn clear_snapshot_caches() {
     SNAPSHOT_GLYPH_CACHE.with(|cache| *cache.borrow_mut() = PersistentGlyphCache::default());
+    SNAPSHOT_FALLBACK_MAPPING_CACHE.with(|cache| {
+        *cache.borrow_mut() = PersistentFontMappingCache::default();
+    });
 }
 
 pub(super) const CORPUS: &[(CorpusKind, &str)] = &[
@@ -158,12 +194,52 @@ pub(super) struct GlyphKey {
 
 pub(super) const BOX_DRAWING_FACE: usize = usize::MAX;
 
+/// Fontconfig exposes `FC_INDEX` using `FreeType`'s packed face index: the low
+/// 16 bits select a face in a collection and bits 16-30 select a one-based
+/// named variable instance. Swash expects only the collection index.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub(super) struct FontconfigFaceIndex(u32);
+
+impl FontconfigFaceIndex {
+    const COLLECTION_MASK: u32 = 0xffff;
+    const NAMED_INSTANCE_MASK: u32 = 0x7fff;
+
+    const fn new(raw: u32) -> Self {
+        Self(raw)
+    }
+
+    fn from_fontconfig(raw: u32) -> Result<Self> {
+        anyhow::ensure!(
+            raw & 0x8000_0000 == 0,
+            "Fontconfig face index sets reserved bit 31"
+        );
+        Ok(Self::new(raw))
+    }
+
+    pub(super) const fn raw(self) -> u32 {
+        self.0
+    }
+
+    pub(super) const fn collection_index(self) -> usize {
+        (self.0 & Self::COLLECTION_MASK) as usize
+    }
+
+    const fn named_instance_index(self) -> Option<usize> {
+        let one_based = (self.0 >> 16) & Self::NAMED_INSTANCE_MASK;
+        if one_based == 0 {
+            None
+        } else {
+            Some((one_based - 1) as usize)
+        }
+    }
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(super) struct FontFaceFingerprint {
     pub(super) family: String,
     pub(super) style: String,
     pub(super) path: PathBuf,
-    pub(super) index: usize,
+    pub(super) index: u32,
     pub(super) weight: i32,
     pub(super) slant: i32,
     pub(super) selected_pixel_size_26_6: isize,
@@ -175,7 +251,7 @@ pub(super) struct FontFaceFingerprint {
 pub struct FontFingerprint {
     pub(super) pattern: String,
     pub(super) authority: FontAuthority,
-    pub(super) faces: [FontFaceFingerprint; 6],
+    pub(super) faces: Vec<FontFaceFingerprint>,
 }
 
 #[doc(hidden)]
@@ -183,7 +259,7 @@ pub struct FontFingerprint {
 pub struct FontGeneration {
     pub(super) id: u64,
     pub(super) fingerprint: FontFingerprint,
-    pub(super) faces: [FontFace; 6],
+    pub(super) faces: Vec<FontFace>,
 }
 
 impl FontGeneration {
@@ -206,13 +282,16 @@ pub(super) struct FontFace {
     pub(super) family: String,
     pub(super) style: String,
     pub(super) path: PathBuf,
-    pub(super) index: usize,
+    pub(super) index: FontconfigFaceIndex,
     pub(super) weight: i32,
     pub(super) slant: i32,
     pub(super) generation_id: u64,
     pub(super) selected_pixel_size_26_6: isize,
     pub(super) source_identity: FileIdentity,
-    pub(super) data: Arc<ReadOnlyFileMap>,
+    pub(super) outline: bool,
+    pub(super) coverage: Box<[(u32, u32)]>,
+    pub(super) data: Option<Arc<ReadOnlyFileMap>>,
+    normalized_coords: OnceLock<Result<Box<[NormalizedCoord]>, String>>,
 }
 
 impl FontFace {
@@ -228,12 +307,24 @@ impl FontFace {
             generation_id: self.generation_id,
             selected_pixel_size_26_6: self.selected_pixel_size_26_6,
             source_identity: self.source_identity,
+            outline: self.outline,
+            coverage: self.coverage.clone(),
             data: self.data.clone(),
+            normalized_coords: OnceLock::new(),
         }
     }
 
-    fn identity(&self) -> (&std::path::Path, usize) {
-        (&self.path, self.index)
+    fn identity(&self) -> (&std::path::Path, u32) {
+        (&self.path, self.index.raw())
+    }
+
+    pub(super) fn covers_text(&self, text: &str) -> bool {
+        text.chars().all(|character| {
+            let codepoint = u32::from(character);
+            self.coverage
+                .iter()
+                .any(|(start, end)| (*start..=*end).contains(&codepoint))
+        })
     }
 
     fn fingerprint(&self) -> FontFaceFingerprint {
@@ -241,7 +332,7 @@ impl FontFace {
             family: self.family.clone(),
             style: self.style.clone(),
             path: self.path.clone(),
-            index: self.index,
+            index: self.index.raw(),
             weight: self.weight,
             slant: self.slant,
             selected_pixel_size_26_6: self.selected_pixel_size_26_6,
@@ -376,9 +467,13 @@ impl TextRow {
             }
             if *kind == CorpusKind::Combining {
                 let face_index = 0;
-                let font = font_ref(&faces[face_index])?;
+                let (font, coords) = font_ref_with_coords(&faces[face_index])?;
                 let mut shaped_glyphs = Vec::new();
-                let mut shaper = shape_context.builder(font).size(font_size).build();
+                let mut shaper = shape_context
+                    .builder(font)
+                    .size(font_size)
+                    .normalized_coords(coords)
+                    .build();
                 shaper.add_str(text);
                 shaper.shape_with(|cluster| {
                     let cluster_advance = cluster.advance();
@@ -461,9 +556,9 @@ impl TextRow {
                     continue;
                 }
                 let (face_index, glyph_id) = select_glyph(&faces, *kind, character)?;
-                let font = font_ref(&faces[face_index])?;
+                let (font, coords) = font_ref_with_coords(&faces[face_index])?;
                 let advance = font
-                    .glyph_metrics(&[])
+                    .glyph_metrics(coords)
                     .scale(font_size)
                     .advance_width(glyph_id);
                 let raster_started = Instant::now();
@@ -532,8 +627,13 @@ pub(super) fn cache_glyph(
     if cache.contains_key(&key) {
         return Ok(());
     }
-    let font = font_ref(&faces[face_index])?;
-    let mut scaler = context.builder(font).size(font_size).hint(true).build();
+    let (font, coords) = font_ref_with_coords(&faces[face_index])?;
+    let mut scaler = context
+        .builder(font)
+        .size(font_size)
+        .hint(true)
+        .normalized_coords(coords)
+        .build();
     let image = Render::new(&[
         Source::ColorOutline(0),
         Source::ColorBitmap(StrikeWith::BestFit),
@@ -584,7 +684,7 @@ pub fn snapshot_font_generation() -> Result<&'static Arc<FontGeneration>> {
         .map_err(|error| anyhow::anyhow!(error.clone()))
 }
 
-pub(super) fn snapshot_faces() -> Result<&'static [FontFace; 6]> {
+pub(super) fn snapshot_faces() -> Result<&'static [FontFace]> {
     Ok(&snapshot_font_generation()?.faces)
 }
 
@@ -619,8 +719,8 @@ pub(super) fn snapshot_glyph(
             let raster_key = (generation_id, face.selected_pixel_size_26_6, face_index);
             if !cache.raster_faces.contains_key(&raster_key) {
                 let raster_face = RasterFace::open_memory(
-                    &face.data,
-                    u32::try_from(face.index).context("emoji face index fits u32")?,
+                    face.data.as_deref().context("emoji face is staged")?,
+                    face.index.raw(),
                     face.selected_pixel_size_26_6,
                 )
                 .context("open staged emoji raster face")?;
@@ -651,14 +751,17 @@ pub(super) fn snapshot_glyph(
         } else {
             let raster_key = (generation_id, effective_size_26_6, face_index);
             if !cache.raster_faces.contains_key(&raster_key) {
-                let raster_face = RasterFace::open_memory(
-                    &faces[face_index].data,
-                    u32::try_from(faces[face_index].index).context("face index fits u32")?,
-                    pixel_size_26_6(font_size)?,
-                )
-                .with_context(|| {
-                    format!("open FreeType raster face {}", faces[face_index].label)
-                })?;
+                let face = &faces[face_index];
+                let pixel_size = pixel_size_26_6(font_size)?;
+                let fallback_mapping;
+                let data = if let Some(data) = face.data.as_deref() {
+                    data
+                } else {
+                    fallback_mapping = fallback_font_mapping(face)?;
+                    &fallback_mapping
+                };
+                let raster_face = RasterFace::open_memory(data, face.index.raw(), pixel_size)
+                    .with_context(|| format!("open FreeType raster face {}", face.label))?;
                 cache.prepare_raster_face_insert(raster_key);
                 cache.raster_faces.insert(raster_key, raster_face);
             }
@@ -736,7 +839,7 @@ pub(super) fn snapshot_color_advance(
 }
 
 pub(super) fn reset_snapshot_cache() {
-    SNAPSHOT_GLYPH_CACHE.with(|cache| *cache.borrow_mut() = PersistentGlyphCache::default());
+    clear_snapshot_caches();
 }
 
 pub(super) fn evict_snapshot_glyphs() -> usize {
@@ -769,20 +872,28 @@ pub(super) fn process_rss_bytes() -> Option<u64> {
 /// Returns bounded persistent snapshot-glyph-cache metrics.
 #[must_use]
 pub fn snapshot_cache_metrics() -> serde_json::Value {
-    SNAPSHOT_GLYPH_CACHE.with(|cache| {
-        let cache = cache.borrow();
-        serde_json::json!({
-            "entries": cache.glyphs.len(),
-            "raster_faces": cache.raster_faces.len(),
-            "budget": SNAPSHOT_GLYPH_CACHE_BUDGET,
-            "glyph_budget": SNAPSHOT_GLYPH_CACHE_BUDGET,
-            "glyph_byte_budget": SNAPSHOT_GLYPH_CACHE_BYTE_BUDGET,
-            "raster_face_budget": SNAPSHOT_RASTER_FACE_BUDGET,
-            "hits": cache.hits,
-            "misses": cache.misses,
-            "evictions": cache.evictions,
-            "raster_face_evictions": cache.raster_face_evictions,
-            "approximate_bytes": cache.glyph_bytes,
+    SNAPSHOT_GLYPH_CACHE.with(|glyph_cache| {
+        SNAPSHOT_FALLBACK_MAPPING_CACHE.with(|mapping_cache| {
+            let glyph_cache = glyph_cache.borrow();
+            let mapping_cache = mapping_cache.borrow();
+            serde_json::json!({
+                "entries": glyph_cache.glyphs.len(),
+                "raster_faces": glyph_cache.raster_faces.len(),
+                "fallback_mappings": mapping_cache.mappings.len(),
+                "budget": SNAPSHOT_GLYPH_CACHE_BUDGET,
+                "glyph_budget": SNAPSHOT_GLYPH_CACHE_BUDGET,
+                "glyph_byte_budget": SNAPSHOT_GLYPH_CACHE_BYTE_BUDGET,
+                "raster_face_budget": SNAPSHOT_RASTER_FACE_BUDGET,
+                "fallback_mapping_budget": SNAPSHOT_FALLBACK_MAPPING_BUDGET,
+                "hits": glyph_cache.hits,
+                "misses": glyph_cache.misses,
+                "evictions": glyph_cache.evictions,
+                "raster_face_evictions": glyph_cache.raster_face_evictions,
+                "fallback_mapping_hits": mapping_cache.hits,
+                "fallback_mapping_misses": mapping_cache.misses,
+                "fallback_mapping_evictions": mapping_cache.evictions,
+                "approximate_bytes": glyph_cache.glyph_bytes,
+            })
         })
     })
 }
@@ -798,13 +909,13 @@ pub fn snapshot_cache_metrics() -> serde_json::Value {
 pub fn ascii_glyph_evidence() -> Result<Vec<serde_json::Value>> {
     let face = resolve_face("ASCII evidence", &renderer_options().font, "")?;
     let font_size = effective_font_size(120)?;
-    let font = font_ref(&face)?;
-    let metrics = font.metrics(&[]).scale(font_size);
+    let (font, coords) = font_ref_with_coords(&face)?;
+    let metrics = font.metrics(coords).scale(font_size);
     let font_ascent = ceil_to_i32(metrics.ascent);
     let font_descent = ceil_to_i32(metrics.descent);
     let resolved_metrics = cell_metrics(&face, font_size)?;
     let font_height = i32::try_from(resolved_metrics.height).context("font height fits i32")?;
-    let glyph_metrics = font.glyph_metrics(&[]).scale(font_size);
+    let glyph_metrics = font.glyph_metrics(coords).scale(font_size);
     let mut context = ScaleContext::new();
     let mut records = Vec::with_capacity(95);
 
@@ -812,7 +923,12 @@ pub fn ascii_glyph_evidence() -> Result<Vec<serde_json::Value>> {
         let character = char::from_u32(codepoint).context("printable ASCII is valid Unicode")?;
         let glyph_id = font.charmap().map(character);
         let advance = positive_round_to_u32(glyph_metrics.advance_width(glyph_id));
-        let mut scaler = context.builder(font).size(font_size).hint(true).build();
+        let mut scaler = context
+            .builder(font)
+            .size(font_size)
+            .hint(true)
+            .normalized_coords(coords)
+            .build();
         let rendered = Render::new(&[
             Source::ColorOutline(0),
             Source::ColorBitmap(StrikeWith::BestFit),
@@ -853,7 +969,7 @@ pub fn ascii_glyph_evidence() -> Result<Vec<serde_json::Value>> {
             "glyph_id": glyph_id,
             "font": face.family.as_str(),
             "font_path": face.path.display().to_string(),
-            "font_index": face.index,
+            "font_index": face.index.raw(),
             "font_ascent": font_ascent,
             "font_descent": font_descent,
             "font_height": font_height,
@@ -907,9 +1023,9 @@ pub fn production_ascii_glyph_evidence() -> Result<Vec<serde_json::Value>> {
         value.parse().context("parse evidence scale")
     })?;
     let font_size = effective_font_size(scale_120)?;
-    let font = font_ref(face)?;
+    let (font, coords) = font_ref_with_coords(face)?;
     let metrics = cell_metrics(face, font_size)?;
-    let glyph_metrics = font.glyph_metrics(&[]).scale(font_size);
+    let glyph_metrics = font.glyph_metrics(coords).scale(font_size);
     let mut records = Vec::with_capacity(96);
     for codepoint in 0x20_u32..=0x7e {
         let character = char::from_u32(codepoint).context("printable ASCII is valid Unicode")?;
@@ -930,7 +1046,7 @@ pub fn production_ascii_glyph_evidence() -> Result<Vec<serde_json::Value>> {
             "glyph_id": glyph_id,
             "font": face.family.as_str(),
             "font_path": face.path.display().to_string(),
-            "font_index": face.index,
+            "font_index": face.index.raw(),
             "font_ascent": metrics.ascent,
             "font_descent": metrics.descent,
             "font_height": metrics.font_height,
@@ -961,7 +1077,7 @@ pub fn production_ascii_glyph_evidence() -> Result<Vec<serde_json::Value>> {
 
     let codepoint = 0x754c;
     let fallback_face = &faces[SNAPSHOT_CJK];
-    let fallback_font = font_ref(fallback_face)?;
+    let (fallback_font, fallback_coords) = font_ref_with_coords(fallback_face)?;
     let glyph_id = fallback_font
         .charmap()
         .map(char::from_u32(codepoint).context("CJK codepoint")?);
@@ -972,7 +1088,9 @@ pub fn production_ascii_glyph_evidence() -> Result<Vec<serde_json::Value>> {
         right: 0,
         bottom: 0,
     });
-    let fallback_metrics = fallback_font.glyph_metrics(&[]).scale(font_size);
+    let fallback_metrics = fallback_font
+        .glyph_metrics(fallback_coords)
+        .scale(font_size);
     records.push(serde_json::json!({
         "schema": 1,
         "label": "CJK",
@@ -981,7 +1099,7 @@ pub fn production_ascii_glyph_evidence() -> Result<Vec<serde_json::Value>> {
         "glyph_id": glyph_id,
         "font": fallback_face.family.as_str(),
         "font_path": fallback_face.path.display().to_string(),
-        "font_index": fallback_face.index,
+        "font_index": fallback_face.index.raw(),
         "font_ascent": metrics.ascent,
         "font_descent": metrics.descent,
         "font_height": metrics.font_height,
@@ -1031,7 +1149,7 @@ pub fn production_ascii_glyph_evidence() -> Result<Vec<serde_json::Value>> {
         "glyph_id": glyph_id,
         "font": emoji_face.family.as_str(),
         "font_path": emoji_face.path.display().to_string(),
-        "font_index": emoji_face.index,
+        "font_index": emoji_face.index.raw(),
         "font_ascent": metrics.ascent,
         "font_descent": metrics.descent,
         "font_height": metrics.font_height,
@@ -1059,7 +1177,11 @@ pub fn production_ascii_glyph_evidence() -> Result<Vec<serde_json::Value>> {
 
     let mut shaped_glyphs = Vec::new();
     let mut shape_context = ShapeContext::new();
-    let mut shaper = shape_context.builder(font).size(font_size).build();
+    let mut shaper = shape_context
+        .builder(font)
+        .size(font_size)
+        .normalized_coords(coords)
+        .build();
     shaper.add_str("e\u{301}");
     shaper.shape_with(|cluster| {
         let mut pen = 0.0;
@@ -1091,7 +1213,7 @@ pub fn production_ascii_glyph_evidence() -> Result<Vec<serde_json::Value>> {
         "glyph_id": glyph_id,
         "font": face.family.as_str(),
         "font_path": face.path.display().to_string(),
-        "font_index": face.index,
+        "font_index": face.index.raw(),
         "font_ascent": metrics.ascent,
         "font_descent": metrics.descent,
         "font_height": metrics.font_height,
@@ -1164,8 +1286,11 @@ pub(super) struct CellMetrics {
 )]
 pub(super) fn cell_metrics(primary_face: &FontFace, font_size: f32) -> Result<CellMetrics> {
     let mut face = RasterFace::open_memory(
-        &primary_face.data,
-        u32::try_from(primary_face.index).context("primary face index")?,
+        primary_face
+            .data
+            .as_deref()
+            .context("primary face is staged")?,
+        primary_face.index.raw(),
         pixel_size_26_6(font_size)?,
     )
     .context("open primary FreeType face for cell metrics")?;
@@ -1216,11 +1341,13 @@ pub(crate) struct ResolvedFaceSource {
     family: String,
     style: String,
     path: PathBuf,
-    index: usize,
+    index: FontconfigFaceIndex,
     weight: i32,
     slant: i32,
     selected_pixel_size_26_6: isize,
     source_identity: FileIdentity,
+    outline: bool,
+    coverage: Box<[(u32, u32)]>,
 }
 
 impl ResolvedFaceSource {
@@ -1229,7 +1356,7 @@ impl ResolvedFaceSource {
             family: self.family.clone(),
             style: self.style.clone(),
             path: self.path.clone(),
-            index: self.index,
+            index: self.index.raw(),
             weight: self.weight,
             slant: self.slant,
             selected_pixel_size_26_6: self.selected_pixel_size_26_6,
@@ -1238,17 +1365,124 @@ impl ResolvedFaceSource {
     }
 }
 
-fn resolve_face_source(
+const FONTCONFIG_FACE_FORMAT: &str = "%{file}\\n%{index}\\n%{family[0]}\\n%{style}\\n%{weight}\\n%{slant}\\n%{pixelsize}\\n%{outline}\\n%{charset}\\n--record--\\n";
+
+fn parse_fontconfig_charset(value: &str) -> Result<Box<[(u32, u32)]>> {
+    value
+        .split_whitespace()
+        .map(|range| {
+            let (start, end) = range.split_once('-').unwrap_or((range, range));
+            let start = u32::from_str_radix(start, 16)
+                .with_context(|| format!("invalid Fontconfig charset start {start:?}"))?;
+            let end = u32::from_str_radix(end, 16)
+                .with_context(|| format!("invalid Fontconfig charset end {end:?}"))?;
+            anyhow::ensure!(
+                start <= end && end <= u32::from(char::MAX),
+                "invalid Fontconfig charset range {range:?}"
+            );
+            Ok((start, end))
+        })
+        .collect::<Result<Vec<_>>>()
+        .map(Vec::into_boxed_slice)
+}
+
+fn parse_fontconfig_sources(label: &'static str, stdout: &[u8]) -> Result<Vec<ResolvedFaceSource>> {
+    let stdout = std::str::from_utf8(stdout).context("fc-match output is not UTF-8")?;
+    stdout
+        .split("--record--\n")
+        .filter(|record| !record.trim().is_empty())
+        .map(|record| {
+            let mut lines = record.lines();
+            let path = PathBuf::from(
+                lines
+                    .next()
+                    .with_context(|| format!("fc-match returned no font path for {label}"))?,
+            );
+            let index = FontconfigFaceIndex::from_fontconfig(
+                lines
+                    .next()
+                    .with_context(|| format!("fc-match returned no face index for {label}"))?
+                    .parse::<u32>()
+                    .with_context(|| {
+                        format!("fc-match returned a non-numeric face index for {label}")
+                    })?,
+            )?;
+            let family = lines
+                .next()
+                .with_context(|| format!("fc-match returned no font family for {label}"))?
+                .to_owned();
+            let style = lines
+                .next()
+                .with_context(|| format!("fc-match returned no style for {label}"))?
+                .to_owned();
+            let weight = lines
+                .next()
+                .with_context(|| format!("fc-match returned no weight for {label}"))?
+                .parse::<i32>()
+                .with_context(|| format!("fc-match returned a non-numeric weight for {label}"))?;
+            let slant = lines
+                .next()
+                .with_context(|| format!("fc-match returned no slant for {label}"))?
+                .parse::<i32>()
+                .with_context(|| format!("fc-match returned a non-numeric slant for {label}"))?;
+            let selected_pixel_size = lines
+                .next()
+                .with_context(|| format!("fc-match returned no pixel size for {label}"))?
+                .parse::<f32>()
+                .with_context(|| format!("fc-match returned an invalid pixel size for {label}"))?;
+            let outline = match lines
+                .next()
+                .with_context(|| format!("fc-match returned no outline flag for {label}"))?
+            {
+                "True" => true,
+                "False" => false,
+                value => bail!("fc-match returned an invalid outline flag {value:?} for {label}"),
+            };
+            let coverage = parse_fontconfig_charset(
+                lines
+                    .next()
+                    .with_context(|| format!("fc-match returned no charset for {label}"))?,
+            )?;
+            let metadata = std::fs::metadata(&path)
+                .with_context(|| format!("inspect resolved {label} font {}", path.display()))?;
+            anyhow::ensure!(
+                metadata.is_file() && metadata.len() > 0,
+                "resolved font is not a non-empty regular file"
+            );
+            Ok(ResolvedFaceSource {
+                label,
+                family,
+                style,
+                path,
+                index,
+                weight,
+                slant,
+                selected_pixel_size_26_6: pixel_size_26_6(selected_pixel_size)?,
+                source_identity: FileIdentity {
+                    device: metadata.dev(),
+                    inode: metadata.ino(),
+                    length: metadata.len(),
+                    modified_seconds: metadata.mtime(),
+                    modified_nanoseconds: metadata.mtime_nsec(),
+                },
+                outline,
+                coverage,
+            })
+        })
+        .collect()
+}
+
+fn run_fontconfig_sources(
     label: &'static str,
     pattern: &str,
-    expected_family_fragment: &str,
-) -> Result<ResolvedFaceSource> {
-    let output = Command::new("fc-match")
-        .args([
-            "-f",
-            "%{file}\\n%{index}\\n%{family[0]}\\n%{style}\\n%{weight}\\n%{slant}\\n%{pixelsize}\\n",
-            pattern,
-        ])
+    sorted: bool,
+) -> Result<Vec<ResolvedFaceSource>> {
+    let mut command = Command::new("fc-match");
+    if sorted {
+        command.arg("-s");
+    }
+    let output = command
+        .args(["-f", FONTCONFIG_FACE_FORMAT, pattern])
         .output()
         .with_context(|| format!("run fc-match for {label}"))?;
     if !output.status.success() {
@@ -1257,71 +1491,27 @@ fn resolve_face_source(
             String::from_utf8_lossy(&output.stderr)
         );
     }
-    let stdout = String::from_utf8(output.stdout).context("fc-match output is not UTF-8")?;
-    let mut lines = stdout.lines();
-    let path = PathBuf::from(
-        lines
-            .next()
-            .with_context(|| format!("fc-match returned no font path for {label}"))?,
-    );
-    let index = lines
+    parse_fontconfig_sources(label, &output.stdout)
+}
+
+fn resolve_face_source(
+    label: &'static str,
+    pattern: &str,
+    expected_family_fragment: &str,
+) -> Result<ResolvedFaceSource> {
+    let source = run_fontconfig_sources(label, pattern, false)?
+        .into_iter()
         .next()
-        .with_context(|| format!("fc-match returned no face index for {label}"))?
-        .parse::<usize>()
-        .with_context(|| format!("fc-match returned a non-numeric face index for {label}"))?;
-    let family = lines
-        .next()
-        .with_context(|| format!("fc-match returned no font family for {label}"))?
-        .to_owned();
-    let style = lines
-        .next()
-        .with_context(|| format!("fc-match returned no style for {label}"))?
-        .to_owned();
-    let weight = lines
-        .next()
-        .with_context(|| format!("fc-match returned no weight for {label}"))?
-        .parse::<i32>()
-        .with_context(|| format!("fc-match returned a non-numeric weight for {label}"))?;
-    let slant = lines
-        .next()
-        .with_context(|| format!("fc-match returned no slant for {label}"))?
-        .parse::<i32>()
-        .with_context(|| format!("fc-match returned a non-numeric slant for {label}"))?;
-    let selected_pixel_size = lines
-        .next()
-        .with_context(|| format!("fc-match returned no pixel size for {label}"))?
-        .parse::<f32>()
-        .with_context(|| format!("fc-match returned an invalid pixel size for {label}"))?;
-    let selected_pixel_size_26_6 = pixel_size_26_6(selected_pixel_size)?;
-    let normalized_family = normalize_family(&family);
+        .with_context(|| format!("fc-match returned no face for {label}"))?;
+    let normalized_family = normalize_family(&source.family);
     let normalized_expected = normalize_family(expected_family_fragment);
     if !normalized_expected.is_empty() && !normalized_family.contains(&normalized_expected) {
-        bail!("explicit {label} pattern {pattern:?} resolved unexpectedly to {family:?}");
+        bail!(
+            "explicit {label} pattern {pattern:?} resolved unexpectedly to {:?}",
+            source.family
+        );
     }
-    let metadata = std::fs::metadata(&path)
-        .with_context(|| format!("inspect resolved {label} font {}", path.display()))?;
-    anyhow::ensure!(
-        metadata.is_file() && metadata.len() > 0,
-        "resolved font is not a non-empty regular file"
-    );
-    let source_identity = FileIdentity {
-        device: metadata.dev(),
-        inode: metadata.ino(),
-        length: metadata.len(),
-        modified_seconds: metadata.mtime(),
-        modified_nanoseconds: metadata.mtime_nsec(),
-    };
-    Ok(ResolvedFaceSource {
-        label,
-        family,
-        style,
-        path,
-        index,
-        weight,
-        slant,
-        selected_pixel_size_26_6,
-        source_identity,
-    })
+    Ok(source)
 }
 
 fn stage_face(source: ResolvedFaceSource) -> Result<FontFace> {
@@ -1343,7 +1533,10 @@ fn stage_face(source: ResolvedFaceSource) -> Result<FontFace> {
         generation_id: 0,
         selected_pixel_size_26_6: source.selected_pixel_size_26_6,
         source_identity: source.source_identity,
-        data,
+        outline: source.outline,
+        coverage: source.coverage,
+        data: Some(data),
+        normalized_coords: OnceLock::new(),
     };
     font_ref(&face).with_context(|| format!("parse resolved {} font", face.label))?;
     eprintln!(
@@ -1351,10 +1544,44 @@ fn stage_face(source: ResolvedFaceSource) -> Result<FontFace> {
         face.label,
         face.family,
         face.style,
-        face.index,
+        face.index.raw(),
         face.path.display()
     );
     Ok(face)
+}
+
+fn unstaged_fallback_face(source: ResolvedFaceSource) -> FontFace {
+    FontFace {
+        label: source.label,
+        family: source.family,
+        style: source.style,
+        path: source.path,
+        index: source.index,
+        weight: source.weight,
+        slant: source.slant,
+        generation_id: 0,
+        selected_pixel_size_26_6: source.selected_pixel_size_26_6,
+        source_identity: source.source_identity,
+        outline: source.outline,
+        coverage: source.coverage,
+        data: None,
+        normalized_coords: OnceLock::new(),
+    }
+}
+
+fn resolve_fallback_sources(
+    pattern: &str,
+    excluded: &HashSet<(PathBuf, FontconfigFaceIndex)>,
+) -> Result<Vec<ResolvedFaceSource>> {
+    let mut identities = excluded.clone();
+    Ok(
+        run_fontconfig_sources("fontconfig fallback", pattern, true)?
+            .into_iter()
+            .filter(|source| {
+                source.outline && identities.insert((source.path.clone(), source.index))
+            })
+            .collect(),
+    )
 }
 
 pub(super) fn resolve_face(
@@ -1435,7 +1662,7 @@ fn probe_primary_style_source(
     match candidate {
         Ok(candidate)
             if normalize_family(&candidate.family) == normalize_family(&regular.family)
-                && candidate.path != regular.path
+                && (candidate.path != regular.path || candidate.index != regular.index)
                 && request.bold == (candidate.weight > regular.weight)
                 && request.italic == (candidate.slant != regular.slant) =>
         {
@@ -1461,25 +1688,33 @@ pub fn probe_live_font_sources(pattern: &str, authority: FontAuthority) -> Resul
         expected_primary_family_fragment(pattern),
     )?;
     let [bold_request, italic_request, bold_italic_request] = PRIMARY_STYLE_REQUESTS;
-    let sources = [
+    let mut sources = Vec::from([
         regular.clone(),
         probe_primary_style_source(&regular, bold_request),
         probe_primary_style_source(&regular, italic_request),
         probe_primary_style_source(&regular, bold_italic_request),
         resolve_face_source("CJK fallback", CJK_FONT, "noto sans cjk")?,
         resolve_face_source("emoji fallback", EMOJI_FONT, "noto color emoji")?,
-    ];
+    ]);
+    let excluded = sources
+        .iter()
+        .map(|source| (source.path.clone(), source.index))
+        .collect::<HashSet<_>>();
+    sources.extend(resolve_fallback_sources(pattern, &excluded)?);
     Ok(FontFingerprint {
         pattern: pattern.to_owned(),
         authority,
-        faces: std::array::from_fn(|index| sources[index].fingerprint()),
+        faces: sources
+            .iter()
+            .map(ResolvedFaceSource::fingerprint)
+            .collect(),
     })
 }
 
 fn face_advance(face: &FontFace, font_size: f32) -> Result<f32> {
-    let font = font_ref(face)?;
+    let (font, coords) = font_ref_with_coords(face)?;
     let advance = font
-        .glyph_metrics(&[])
+        .glyph_metrics(coords)
         .scale(font_size)
         .advance_width(font.charmap().map('M'));
     anyhow::ensure!(advance.is_finite() && advance > 0.0, "invalid M advance");
@@ -1603,21 +1838,31 @@ fn resolve_font_candidate(
         resolve_primary_faces_exact(pattern)?
     };
     let id = NEXT_FONT_GENERATION_ID.fetch_add(1, Ordering::Relaxed);
-    let mut faces = [
+    let mut faces = Vec::from([
         regular,
         bold,
         italic,
         bold_italic,
         resolve_face("CJK fallback", CJK_FONT, "noto sans cjk")?,
         resolve_face("emoji fallback", EMOJI_FONT, "noto color emoji")?,
-    ];
+    ]);
+    let excluded = faces
+        .iter()
+        .map(|face| (face.path.clone(), face.index))
+        .collect::<HashSet<_>>();
+    let fallback_sources = resolve_fallback_sources(pattern, &excluded)?;
+    eprintln!(
+        "Resolved {} ordered Fontconfig fallback faces",
+        fallback_sources.len()
+    );
+    faces.extend(fallback_sources.into_iter().map(unstaged_fallback_face));
     for face in &mut faces {
         face.generation_id = id;
     }
     let fingerprint = FontFingerprint {
         pattern: pattern.to_owned(),
         authority,
-        faces: std::array::from_fn(|index| faces[index].fingerprint()),
+        faces: faces.iter().map(FontFace::fingerprint).collect(),
     };
     Ok(FontGeneration {
         id,
@@ -1670,18 +1915,93 @@ pub fn stage_live_font_generation(
     stage_font_generation(pattern, authority, false)
 }
 
-pub(super) fn font_data(face: &FontFace) -> &[u8] {
-    &face.data
+pub(super) fn font_data(face: &FontFace) -> Result<&[u8]> {
+    face.data
+        .as_deref()
+        .map(|mapping| &**mapping)
+        .context("fallback font data requires the bounded mapping cache")
+}
+
+fn parse_font_ref<'a>(face: &FontFace, data: &'a [u8]) -> Result<FontRef<'a>> {
+    FontRef::from_index(data, face.index.collection_index()).with_context(|| {
+        format!(
+            "parse {} Fontconfig face {} (collection face {}) with Swash",
+            face.path.display(),
+            face.index.raw(),
+            face.index.collection_index()
+        )
+    })
+}
+
+fn normalized_coords<'a>(face: &'a FontFace, font: FontRef<'_>) -> Result<&'a [NormalizedCoord]> {
+    face.normalized_coords
+        .get_or_init(|| {
+            let Some(instance_index) = face.index.named_instance_index() else {
+                return Ok(Box::new([]));
+            };
+            let Some(instance) = font.instances().nth(instance_index) else {
+                return Err(format!(
+                    "Fontconfig face {} selects missing named instance {} in {}",
+                    face.index.raw(),
+                    instance_index + 1,
+                    face.path.display()
+                ));
+            };
+            Ok(instance
+                .normalized_coords()
+                .collect::<Vec<_>>()
+                .into_boxed_slice())
+        })
+        .as_ref()
+        .map(Box::as_ref)
+        .map_err(|error| anyhow::anyhow!(error.clone()))
 }
 
 pub(super) fn font_ref(face: &FontFace) -> Result<FontRef<'_>> {
-    FontRef::from_index(font_data(face), face.index).with_context(|| {
-        format!(
-            "parse {} face {} with Swash",
-            face.path.display(),
-            face.index
-        )
+    let font = parse_font_ref(face, font_data(face)?)?;
+    normalized_coords(face, font)?;
+    Ok(font)
+}
+
+fn font_ref_with_coords(face: &FontFace) -> Result<(FontRef<'_>, &[NormalizedCoord])> {
+    let font = font_ref(face)?;
+    let coords = normalized_coords(face, font)?;
+    Ok((font, coords))
+}
+
+fn fallback_font_mapping(face: &FontFace) -> Result<Arc<ReadOnlyFileMap>> {
+    let key = (face.path.clone(), face.source_identity);
+    SNAPSHOT_FALLBACK_MAPPING_CACHE.with(|cache| {
+        let mut cache = cache.borrow_mut();
+        if let Some(mapping) = cache.mappings.get(&key).cloned() {
+            cache.hits = cache.hits.saturating_add(1);
+            return Ok(mapping);
+        }
+        cache.misses = cache.misses.saturating_add(1);
+        let mapping = Arc::new(
+            ReadOnlyFileMap::open(&face.path)
+                .with_context(|| format!("map fallback {}", face.path.display()))?,
+        );
+        anyhow::ensure!(
+            mapping.identity() == face.source_identity,
+            "fallback font source changed before mapping"
+        );
+        Ok(cache.insert(key, mapping))
     })
+}
+
+pub(super) fn with_font_ref<T>(
+    face: &FontFace,
+    use_font: impl FnOnce(FontRef<'_>, &[NormalizedCoord]) -> Result<T>,
+) -> Result<T> {
+    if face.data.is_some() {
+        let (font, coords) = font_ref_with_coords(face)?;
+        return use_font(font, coords);
+    }
+    let mapping = fallback_font_mapping(face)?;
+    let font = parse_font_ref(face, &mapping)?;
+    let coords = normalized_coords(face, font)?;
+    use_font(font, coords)
 }
 
 pub(super) fn select_glyph(
@@ -1797,14 +2117,150 @@ mod tests {
             family: family.to_owned(),
             style: label.to_owned(),
             path: PathBuf::from(path),
-            index: 0,
+            index: FontconfigFaceIndex::new(0),
             weight,
             slant,
             generation_id: 0,
             selected_pixel_size_26_6: 12 * 64,
             source_identity: data.identity(),
-            data,
+            outline: true,
+            coverage: vec![(0, u32::from(char::MAX))].into_boxed_slice(),
+            data: Some(data),
+            normalized_coords: OnceLock::new(),
         }
+    }
+
+    #[test]
+    fn packed_fontconfig_face_index_separates_collection_and_named_instance() {
+        let static_face = FontconfigFaceIndex::new(7);
+        assert_eq!(static_face.raw(), 7);
+        assert_eq!(static_face.collection_index(), 7);
+        assert_eq!(static_face.named_instance_index(), None);
+
+        let victor_regular = FontconfigFaceIndex::new(0x0004_0000);
+        assert_eq!(victor_regular.raw(), 262_144);
+        assert_eq!(victor_regular.collection_index(), 0);
+        assert_eq!(victor_regular.named_instance_index(), Some(3));
+
+        let collection_instance = FontconfigFaceIndex::new(0x0003_0004);
+        assert_eq!(collection_instance.collection_index(), 4);
+        assert_eq!(collection_instance.named_instance_index(), Some(2));
+        assert!(FontconfigFaceIndex::from_fontconfig(0x8000_0000).is_err());
+    }
+
+    #[test]
+    fn fontconfig_source_parser_preserves_packed_variable_instance_index() {
+        let path = std::env::temp_dir().join(format!(
+            "splinterm-fontconfig-index-fixture-{}",
+            std::process::id()
+        ));
+        std::fs::write(&path, b"font fixture").unwrap();
+        let output = format!(
+            "{}\n262144\nVariable Mono\nRegular\n80\n0\n14\nTrue\n20-7e\n--record--\n",
+            path.display()
+        );
+        let sources = parse_fontconfig_sources("variable fixture", output.as_bytes()).unwrap();
+        std::fs::remove_file(path).unwrap();
+        assert_eq!(sources.len(), 1);
+        assert_eq!(sources[0].index.raw(), 262_144);
+        assert_eq!(sources[0].index.collection_index(), 0);
+        assert_eq!(sources[0].index.named_instance_index(), Some(3));
+    }
+
+    #[test]
+    #[ignore = "manual variable-font integration; requires SPLINTERM_VARIABLE_FONT_FIXTURE and SPLINTERM_VARIABLE_FONT_INDEX"]
+    fn variable_font_named_instance_shapes_and_rasterizes_with_freetype_identity() {
+        let path = PathBuf::from(
+            std::env::var("SPLINTERM_VARIABLE_FONT_FIXTURE")
+                .expect("SPLINTERM_VARIABLE_FONT_FIXTURE names a variable font"),
+        );
+        let raw_index = std::env::var("SPLINTERM_VARIABLE_FONT_INDEX")
+            .expect("SPLINTERM_VARIABLE_FONT_INDEX names a Fontconfig packed index")
+            .parse::<u32>()
+            .expect("packed index is numeric");
+        let snapshot = ReadOnlyFileMap::immutable_snapshot(&path, MAX_STAGED_FONT_BYTES).unwrap();
+        let mut face = synthetic_face("variable", "Variable Mono", "/fonts/variable.ttf", 80, 0);
+        face.path = path;
+        face.index = FontconfigFaceIndex::from_fontconfig(raw_index).unwrap();
+        face.source_identity = snapshot.source_identity;
+        face.data = Some(Arc::new(snapshot.mapping));
+
+        let (font, coords) = font_ref_with_coords(&face).unwrap();
+        assert!(face.index.named_instance_index().is_some());
+        assert!(!coords.is_empty());
+        let glyph_id = font.charmap().map('M');
+        assert_ne!(glyph_id, 0);
+        let swash_advance = font
+            .glyph_metrics(coords)
+            .scale(BASE_FONT_SIZE)
+            .advance_width(glyph_id);
+        assert!(swash_advance.is_finite() && swash_advance > 0.0);
+
+        let mut shape_context = ShapeContext::new();
+        let mut shaped_glyph_ids = Vec::new();
+        let mut shaper = shape_context
+            .builder(font)
+            .size(BASE_FONT_SIZE)
+            .normalized_coords(coords)
+            .build();
+        shaper.add_str("Mono");
+        shaper.shape_with(|cluster| {
+            shaped_glyph_ids.extend(cluster.glyphs.iter().map(|glyph| glyph.id));
+        });
+        assert!(!shaped_glyph_ids.is_empty());
+
+        let mut scale_context = ScaleContext::new();
+        let mut scaler = scale_context
+            .builder(font)
+            .size(BASE_FONT_SIZE)
+            .normalized_coords(coords)
+            .hint(true)
+            .build();
+        assert!(
+            Render::new(&[Source::Outline])
+                .format(Format::Alpha)
+                .render(&mut scaler, glyph_id)
+                .is_some()
+        );
+
+        let mut freetype = RasterFace::open_memory(
+            face.data.as_deref().unwrap(),
+            face.index.raw(),
+            pixel_size_26_6(BASE_FONT_SIZE).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(freetype.glyph_index('M'), u32::from(glyph_id));
+        assert!(freetype.rasterize_gray(u32::from(glyph_id)).is_ok());
+    }
+
+    #[test]
+    fn fontconfig_charset_parser_covers_singletons_ranges_and_non_bmp_codepoints() {
+        let coverage = parse_fontconfig_charset("20-7e 21d5 1f4e6-1f4e7").unwrap();
+        let mut face = synthetic_face("fallback", "Chosen Mono", "/fonts/fallback.ttf", 80, 0);
+        face.coverage = coverage;
+        assert!(face.covers_text("A⇕📦"));
+        assert!(!face.covers_text("A🦀"));
+        assert!(parse_fontconfig_charset("7e-20").is_err());
+        assert!(parse_fontconfig_charset("110000").is_err());
+    }
+
+    #[test]
+    fn fallback_font_mapping_cache_remains_bounded() {
+        let face = synthetic_face("mapping", "Chosen Mono", "/fonts/mapping.ttf", 80, 0);
+        let mapping = face.data.expect("synthetic face is mapped");
+        let identity = mapping.identity();
+        let mut cache = PersistentFontMappingCache::default();
+        for index in 0..=SNAPSHOT_FALLBACK_MAPPING_BUDGET {
+            cache.insert(
+                (
+                    PathBuf::from(format!("/fonts/fallback-{index}.ttf")),
+                    identity,
+                ),
+                Arc::clone(&mapping),
+            );
+        }
+        assert_eq!(cache.mappings.len(), SNAPSHOT_FALLBACK_MAPPING_BUDGET);
+        assert_eq!(cache.evictions, 1);
     }
 
     #[test]
@@ -1856,6 +2312,15 @@ mod tests {
             style_candidate_rejection(&regular, &compatible_oblique, request, 8.0, 8.0),
             None,
             "Fontconfig oblique faces satisfy an italic slant request"
+        );
+
+        let mut named_instance =
+            synthetic_face("bold italic", "Chosen Mono", "/fonts/regular.ttf", 200, 100);
+        named_instance.index = FontconfigFaceIndex::new(0x0007_0000);
+        assert_eq!(
+            style_candidate_rejection(&regular, &named_instance, request, 8.0, 8.0),
+            None,
+            "a distinct named instance in the same variable-font file is a distinct face"
         );
 
         let foreign = synthetic_face("bold italic", "Other Mono", "/fonts/other.ttf", 200, 100);

--- a/crates/splinterm/src/renderer/fonts.rs
+++ b/crates/splinterm/src/renderer/fonts.rs
@@ -3,6 +3,7 @@
 use std::{
     cell::RefCell,
     collections::{HashMap, VecDeque},
+    os::unix::fs::MetadataExt,
     path::PathBuf,
     process::Command,
     sync::{
@@ -169,18 +170,34 @@ pub(super) struct FontFaceFingerprint {
     pub(super) source_identity: FileIdentity,
 }
 
+#[doc(hidden)]
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub(super) struct FontFingerprint {
+pub struct FontFingerprint {
     pub(super) pattern: String,
     pub(super) authority: FontAuthority,
     pub(super) faces: [FontFaceFingerprint; 6],
 }
 
+#[doc(hidden)]
 #[derive(Debug)]
-pub(crate) struct FontGeneration {
+pub struct FontGeneration {
     pub(super) id: u64,
     pub(super) fingerprint: FontFingerprint,
     pub(super) faces: [FontFace; 6],
+}
+
+impl FontGeneration {
+    /// Returns the process-local monotonic generation identity.
+    #[must_use]
+    pub const fn id(&self) -> u64 {
+        self.id
+    }
+
+    /// Returns the stable effective source fingerprint.
+    #[must_use]
+    pub const fn fingerprint(&self) -> &FontFingerprint {
+        &self.fingerprint
+    }
 }
 
 #[derive(Debug)]
@@ -550,7 +567,12 @@ pub(super) fn cache_glyph(
     Ok(())
 }
 
-pub(super) fn snapshot_font_generation() -> Result<&'static Arc<FontGeneration>> {
+/// Returns the configured immutable startup generation.
+///
+/// # Errors
+/// Returns the retained startup staging failure.
+#[doc(hidden)]
+pub fn snapshot_font_generation() -> Result<&'static Arc<FontGeneration>> {
     SNAPSHOT_FONT_GENERATION
         .get_or_init(|| {
             let options = renderer_options();
@@ -1182,11 +1204,39 @@ pub(super) fn ceil_to_i32(value: f32) -> i32 {
     value.ceil() as i32
 }
 
-pub(super) fn resolve_face(
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct ResolvedFaceSource {
+    label: &'static str,
+    family: String,
+    style: String,
+    path: PathBuf,
+    index: usize,
+    weight: i32,
+    slant: i32,
+    selected_pixel_size_26_6: isize,
+    source_identity: FileIdentity,
+}
+
+impl ResolvedFaceSource {
+    fn fingerprint(&self) -> FontFaceFingerprint {
+        FontFaceFingerprint {
+            family: self.family.clone(),
+            style: self.style.clone(),
+            path: self.path.clone(),
+            index: self.index,
+            weight: self.weight,
+            slant: self.slant,
+            selected_pixel_size_26_6: self.selected_pixel_size_26_6,
+            source_identity: self.source_identity,
+        }
+    }
+}
+
+fn resolve_face_source(
     label: &'static str,
     pattern: &str,
     expected_family_fragment: &str,
-) -> Result<FontFace> {
+) -> Result<ResolvedFaceSource> {
     let output = Command::new("fc-match")
         .args([
             "-f",
@@ -1242,11 +1292,20 @@ pub(super) fn resolve_face(
     if !normalized_expected.is_empty() && !normalized_family.contains(&normalized_expected) {
         bail!("explicit {label} pattern {pattern:?} resolved unexpectedly to {family:?}");
     }
-    let snapshot = ReadOnlyFileMap::immutable_snapshot(&path, MAX_STAGED_FONT_BYTES)
-        .with_context(|| format!("snapshot resolved {label} font"))?;
-    let source_identity = snapshot.source_identity;
-    let data = Arc::new(snapshot.mapping);
-    let face = FontFace {
+    let metadata = std::fs::metadata(&path)
+        .with_context(|| format!("inspect resolved {label} font {}", path.display()))?;
+    anyhow::ensure!(
+        metadata.is_file() && metadata.len() > 0,
+        "resolved font is not a non-empty regular file"
+    );
+    let source_identity = FileIdentity {
+        device: metadata.dev(),
+        inode: metadata.ino(),
+        length: metadata.len(),
+        modified_seconds: metadata.mtime(),
+        modified_nanoseconds: metadata.mtime_nsec(),
+    };
+    Ok(ResolvedFaceSource {
         label,
         family,
         style,
@@ -1254,20 +1313,54 @@ pub(super) fn resolve_face(
         index,
         weight,
         slant,
-        generation_id: 0,
         selected_pixel_size_26_6,
         source_identity,
+    })
+}
+
+fn stage_face(source: ResolvedFaceSource) -> Result<FontFace> {
+    let snapshot = ReadOnlyFileMap::immutable_snapshot(&source.path, MAX_STAGED_FONT_BYTES)
+        .with_context(|| format!("snapshot resolved {} font", source.label))?;
+    anyhow::ensure!(
+        snapshot.source_identity == source.source_identity,
+        "resolved font source changed before staging"
+    );
+    let data = Arc::new(snapshot.mapping);
+    let face = FontFace {
+        label: source.label,
+        family: source.family,
+        style: source.style,
+        path: source.path,
+        index: source.index,
+        weight: source.weight,
+        slant: source.slant,
+        generation_id: 0,
+        selected_pixel_size_26_6: source.selected_pixel_size_26_6,
+        source_identity: source.source_identity,
         data,
     };
-    font_ref(&face).with_context(|| format!("parse resolved {label} font"))?;
+    font_ref(&face).with_context(|| format!("parse resolved {} font", face.label))?;
     eprintln!(
-        "Resolved {label}: {} {} (face {}, {})",
+        "Resolved {}: {} {} (face {}, {})",
+        face.label,
         face.family,
         face.style,
         face.index,
         face.path.display()
     );
     Ok(face)
+}
+
+pub(super) fn resolve_face(
+    label: &'static str,
+    pattern: &str,
+    expected_family_fragment: &str,
+) -> Result<FontFace> {
+    stage_face(resolve_face_source(
+        label,
+        pattern,
+        expected_family_fragment,
+    )?)
 }
 
 #[derive(Clone, Copy)]
@@ -1325,6 +1418,56 @@ fn primary_style_pattern(family: &str, request: PrimaryStyleRequest) -> String {
         "{}:weight={weight}:slant={slant}",
         escape_fontconfig_pattern_value(family)
     )
+}
+
+fn probe_primary_style_source(
+    regular: &ResolvedFaceSource,
+    request: PrimaryStyleRequest,
+) -> ResolvedFaceSource {
+    let pattern = primary_style_pattern(&regular.family, request);
+    let candidate = resolve_face_source(request.label, &pattern, &regular.family);
+    match candidate {
+        Ok(candidate)
+            if normalize_family(&candidate.family) == normalize_family(&regular.family)
+                && candidate.path != regular.path
+                && request.bold == (candidate.weight > regular.weight)
+                && request.italic == (candidate.slant != regular.slant) =>
+        {
+            candidate
+        }
+        _ => {
+            let mut fallback = regular.clone();
+            fallback.label = request.label;
+            fallback
+        }
+    }
+}
+
+/// Probes the effective fontconfig source identities without mapping font bytes.
+///
+/// # Errors
+/// Returns an error when Fontconfig output or selected source metadata is invalid.
+#[doc(hidden)]
+pub fn probe_live_font_sources(pattern: &str, authority: FontAuthority) -> Result<FontFingerprint> {
+    let regular = resolve_face_source(
+        "primary regular",
+        pattern,
+        expected_primary_family_fragment(pattern),
+    )?;
+    let [bold_request, italic_request, bold_italic_request] = PRIMARY_STYLE_REQUESTS;
+    let sources = [
+        regular.clone(),
+        probe_primary_style_source(&regular, bold_request),
+        probe_primary_style_source(&regular, italic_request),
+        probe_primary_style_source(&regular, bold_italic_request),
+        resolve_face_source("CJK fallback", CJK_FONT, "noto sans cjk")?,
+        resolve_face_source("emoji fallback", EMOJI_FONT, "noto color emoji")?,
+    ];
+    Ok(FontFingerprint {
+        pattern: pattern.to_owned(),
+        authority,
+        faces: std::array::from_fn(|index| sources[index].fingerprint()),
+    })
 }
 
 fn face_advance(face: &FontFace, font_size: f32) -> Result<f32> {
@@ -1509,11 +1652,12 @@ fn stage_startup_font_generation(
     stage_font_generation(pattern, authority, true)
 }
 
-#[allow(
-    dead_code,
-    reason = "the next Plan 0038 milestone wires staged live generations into the watcher"
-)]
-pub(crate) fn stage_live_font_generation(
+/// Stages one stable live generation without applying the startup fallback.
+///
+/// # Errors
+/// Returns an error when resolution is unstable or any complete face set is invalid.
+#[doc(hidden)]
+pub fn stage_live_font_generation(
     pattern: &str,
     authority: FontAuthority,
 ) -> Result<FontGeneration> {
@@ -1818,6 +1962,15 @@ mod tests {
         let mut candidates = [(7_u8, "first"), (8_u8, "second")].into_iter();
         let error = stage_stable_with(|| Ok(candidates.next().unwrap())).unwrap_err();
         assert!(error.to_string().contains("changed while staging"));
+    }
+
+    #[test]
+    #[ignore = "requires host fontconfig and installed system fonts"]
+    fn live_probe_matches_the_staged_generation_on_the_supported_host() {
+        let options = renderer_options();
+        let probe = probe_live_font_sources(&options.font, options.font_authority).unwrap();
+        let staged = stage_live_font_generation(&options.font, options.font_authority).unwrap();
+        assert_eq!(probe, staged.fingerprint);
     }
 
     #[test]

--- a/crates/splinterm/src/renderer/fonts.rs
+++ b/crates/splinterm/src/renderer/fonts.rs
@@ -19,16 +19,16 @@ use swash::{
     zeno::Format,
 };
 
-use crate::box_drawing;
+use crate::{
+    box_drawing,
+    config::{FontAuthority, STARTUP_FONT_FALLBACK},
+};
 
 use super::raster::{blend_glyph, fill_rect};
 use super::{BASE_FONT_SIZE, PRIMARY_FONT, effective_font_size, renderer_options};
 
 pub(super) const BASE_ROW_X: i32 = 32;
 pub(super) const BASE_ROW_Y: i32 = 96;
-pub(super) const PRIMARY_BOLD_FONT: &str = "JetBrains Mono Nerd Font:style=Bold";
-pub(super) const PRIMARY_ITALIC_FONT: &str = "JetBrains Mono Nerd Font:style=Italic";
-pub(super) const PRIMARY_BOLD_ITALIC_FONT: &str = "JetBrains Mono Nerd Font:style=Bold Italic";
 pub(super) const CJK_FONT: &str = "Noto Sans CJK JP:style=Regular";
 pub(super) const EMOJI_FONT: &str = "Noto Color Emoji";
 pub(super) const SNAPSHOT_GLYPH_CACHE_BUDGET: usize = 2_048;
@@ -158,8 +158,30 @@ pub(super) struct FontFace {
     pub(super) style: String,
     pub(super) path: PathBuf,
     pub(super) index: usize,
+    pub(super) weight: i32,
+    pub(super) slant: i32,
     pub(super) selected_pixel_size_26_6: isize,
     pub(super) data: OnceLock<Result<ReadOnlyFileMap, String>>,
+}
+
+impl FontFace {
+    fn fallback_for(&self, label: &'static str) -> Self {
+        Self {
+            label,
+            family: self.family.clone(),
+            style: self.style.clone(),
+            path: self.path.clone(),
+            index: self.index,
+            weight: self.weight,
+            slant: self.slant,
+            selected_pixel_size_26_6: self.selected_pixel_size_26_6,
+            data: OnceLock::new(),
+        }
+    }
+
+    fn identity(&self) -> (&std::path::Path, usize) {
+        (&self.path, self.index)
+    }
 }
 
 pub(super) struct CachedGlyph {
@@ -255,8 +277,9 @@ impl TextRow {
             .checked_mul(i32::try_from(integer_scale).context("integer scale fits i32")?)
             .context("scaled row y overflow")?;
         let started = Instant::now();
+        let [primary, _, _, _] = resolve_primary_faces(PRIMARY_FONT, FontAuthority::Explicit)?;
         let faces = [
-            resolve_face("primary", PRIMARY_FONT, "jetbrains mono")?,
+            primary,
             resolve_face("CJK fallback", CJK_FONT, "noto sans cjk")?,
             resolve_face("emoji fallback", EMOJI_FONT, "noto color emoji")?,
         ];
@@ -276,8 +299,6 @@ impl TextRow {
         eprintln!(
             "Text row metrics: scale={integer_scale} size={font_size:.1}px cell={cell_width}x{cell_height}px baseline={baseline}px primary-M-advance={mono_advance:.3}px"
         );
-        verify_style_advances(&faces[0], mono_advance, font_size)?;
-
         let mut scale_context = ScaleContext::new();
         let mut shape_context = ShapeContext::new();
         let mut cache = HashMap::new();
@@ -483,19 +504,15 @@ pub(super) fn cache_glyph(
 pub(super) fn snapshot_faces() -> Result<&'static [FontFace; 6]> {
     SNAPSHOT_FACES
         .get_or_init(|| {
+            let options = renderer_options();
+            let [regular, bold, italic, bold_italic] =
+                resolve_primary_faces(&options.font, options.font_authority)
+                    .map_err(|error| error.to_string())?;
             Ok([
-                resolve_face("primary", &renderer_options().font, "")
-                    .map_err(|error| error.to_string())?,
-                resolve_face("primary bold", PRIMARY_BOLD_FONT, "jetbrains mono")
-                    .map_err(|error| error.to_string())?,
-                resolve_face("primary italic", PRIMARY_ITALIC_FONT, "jetbrains mono")
-                    .map_err(|error| error.to_string())?,
-                resolve_face(
-                    "primary bold italic",
-                    PRIMARY_BOLD_ITALIC_FONT,
-                    "jetbrains mono",
-                )
-                .map_err(|error| error.to_string())?,
+                regular,
+                bold,
+                italic,
+                bold_italic,
                 resolve_face("CJK fallback", CJK_FONT, "noto sans cjk")
                     .map_err(|error| error.to_string())?,
                 resolve_face("emoji fallback", EMOJI_FONT, "noto color emoji")
@@ -1104,7 +1121,7 @@ pub(super) fn resolve_face(
     let output = Command::new("fc-match")
         .args([
             "-f",
-            "%{file}\\n%{index}\\n%{family}\\n%{style}\\n%{pixelsize}\\n",
+            "%{file}\\n%{index}\\n%{family[0]}\\n%{style}\\n%{weight}\\n%{slant}\\n%{pixelsize}\\n",
             pattern,
         ])
         .output()
@@ -1129,28 +1146,30 @@ pub(super) fn resolve_face(
         .with_context(|| format!("fc-match returned a non-numeric face index for {label}"))?;
     let family = lines
         .next()
-        .with_context(|| format!("fc-match returned no family for {label}"))?
+        .with_context(|| format!("fc-match returned no font family for {label}"))?
         .to_owned();
     let style = lines
         .next()
         .with_context(|| format!("fc-match returned no style for {label}"))?
         .to_owned();
+    let weight = lines
+        .next()
+        .with_context(|| format!("fc-match returned no weight for {label}"))?
+        .parse::<i32>()
+        .with_context(|| format!("fc-match returned a non-numeric weight for {label}"))?;
+    let slant = lines
+        .next()
+        .with_context(|| format!("fc-match returned no slant for {label}"))?
+        .parse::<i32>()
+        .with_context(|| format!("fc-match returned a non-numeric slant for {label}"))?;
     let selected_pixel_size = lines
         .next()
         .with_context(|| format!("fc-match returned no pixel size for {label}"))?
         .parse::<f32>()
         .with_context(|| format!("fc-match returned an invalid pixel size for {label}"))?;
     let selected_pixel_size_26_6 = pixel_size_26_6(selected_pixel_size)?;
-    let normalized_family: String = family
-        .chars()
-        .filter(|character| character.is_alphanumeric())
-        .flat_map(char::to_lowercase)
-        .collect();
-    let normalized_expected: String = expected_family_fragment
-        .chars()
-        .filter(|character| character.is_alphanumeric())
-        .flat_map(char::to_lowercase)
-        .collect();
+    let normalized_family = normalize_family(&family);
+    let normalized_expected = normalize_family(expected_family_fragment);
     if !normalized_expected.is_empty() && !normalized_family.contains(&normalized_expected) {
         bail!("explicit {label} pattern {pattern:?} resolved unexpectedly to {family:?}");
     }
@@ -1160,11 +1179,13 @@ pub(super) fn resolve_face(
         style,
         path,
         index,
+        weight,
+        slant,
         selected_pixel_size_26_6,
         data: OnceLock::new(),
     };
     eprintln!(
-        "Selected {label}: {} {} (face {}, {})",
+        "Resolved {label}: {} {} (face {}, {})",
         face.family,
         face.style,
         face.index,
@@ -1173,45 +1194,177 @@ pub(super) fn resolve_face(
     Ok(face)
 }
 
-pub(super) fn verify_style_advances(
-    regular: &FontFace,
-    regular_advance: f32,
-    font_size: f32,
-) -> Result<()> {
-    let mut identities = vec![(regular.path.clone(), regular.index)];
-    for (label, pattern, expected_style) in [
-        ("primary bold", PRIMARY_BOLD_FONT, "bold"),
-        ("primary italic", PRIMARY_ITALIC_FONT, "italic"),
-        (
-            "primary bold italic",
-            PRIMARY_BOLD_ITALIC_FONT,
-            "bold italic",
-        ),
-    ] {
-        let face = resolve_face(label, pattern, "jetbrains mono")?;
-        let identity = (face.path.clone(), face.index);
-        if identities.contains(&identity) {
-            bail!("{label} silently resolved to an already selected face");
+#[derive(Clone, Copy)]
+struct PrimaryStyleRequest {
+    label: &'static str,
+    style: &'static str,
+    bold: bool,
+    italic: bool,
+}
+
+const PRIMARY_STYLE_REQUESTS: [PrimaryStyleRequest; 3] = [
+    PrimaryStyleRequest {
+        label: "primary bold",
+        style: "Bold",
+        bold: true,
+        italic: false,
+    },
+    PrimaryStyleRequest {
+        label: "primary italic",
+        style: "Italic",
+        bold: false,
+        italic: true,
+    },
+    PrimaryStyleRequest {
+        label: "primary bold italic",
+        style: "Bold Italic",
+        bold: true,
+        italic: true,
+    },
+];
+
+fn normalize_family(family: &str) -> String {
+    family
+        .chars()
+        .filter(|character| character.is_alphanumeric())
+        .flat_map(char::to_lowercase)
+        .collect()
+}
+
+fn escape_fontconfig_pattern_value(value: &str) -> String {
+    let mut escaped = String::with_capacity(value.len());
+    for character in value.chars() {
+        if matches!(character, '\\' | '-' | ',' | ':') {
+            escaped.push('\\');
         }
-        if !face.style.eq_ignore_ascii_case(expected_style) {
-            bail!("{label} resolved to unexpected style {:?}", face.style);
-        }
-        identities.push(identity);
-        let font = font_ref(&face)?;
-        let advance = font
-            .glyph_metrics(&[])
-            .scale(font_size)
-            .advance_width(font.charmap().map('M'));
-        if !advance.is_finite() || (advance - regular_advance).abs() > 0.01 {
-            bail!("{label} advance {advance:.3}px differs from regular {regular_advance:.3}px");
-        }
-        eprintln!(
-            "Style evidence: {} path={} M-advance={advance:.3}px",
-            face.style,
-            face.path.display()
-        );
+        escaped.push(character);
     }
-    Ok(())
+    escaped
+}
+
+fn primary_style_pattern(family: &str, request: PrimaryStyleRequest) -> String {
+    let weight = if request.bold { "bold" } else { "regular" };
+    let slant = if request.italic { "italic" } else { "roman" };
+    format!(
+        "{}:weight={weight}:slant={slant}",
+        escape_fontconfig_pattern_value(family)
+    )
+}
+
+fn face_advance(face: &FontFace, font_size: f32) -> Result<f32> {
+    let font = font_ref(face)?;
+    let advance = font
+        .glyph_metrics(&[])
+        .scale(font_size)
+        .advance_width(font.charmap().map('M'));
+    anyhow::ensure!(advance.is_finite() && advance > 0.0, "invalid M advance");
+    Ok(advance)
+}
+
+fn style_candidate_rejection(
+    regular: &FontFace,
+    candidate: &FontFace,
+    request: PrimaryStyleRequest,
+    regular_advance: f32,
+    candidate_advance: f32,
+) -> Option<&'static str> {
+    if normalize_family(&candidate.family) != normalize_family(&regular.family) {
+        return Some("resolved to another family");
+    }
+    if candidate.identity() == regular.identity() {
+        return Some("resolved to the regular face");
+    }
+    if request.bold != (candidate.weight > regular.weight) {
+        return Some("did not resolve the requested weight");
+    }
+    if request.italic != (candidate.slant != regular.slant) {
+        return Some("did not resolve the requested slant");
+    }
+    if !candidate_advance.is_finite() || (candidate_advance - regular_advance).abs() > 0.01 {
+        return Some("has incompatible terminal-cell metrics");
+    }
+    None
+}
+
+fn resolve_primary_style(
+    regular: &FontFace,
+    request: PrimaryStyleRequest,
+    regular_advance: f32,
+) -> FontFace {
+    let pattern = primary_style_pattern(&regular.family, request);
+    let resolved = resolve_face(request.label, &pattern, &regular.family).and_then(|candidate| {
+        let candidate_advance = face_advance(&candidate, BASE_FONT_SIZE)?;
+        if let Some(reason) = style_candidate_rejection(
+            regular,
+            &candidate,
+            request,
+            regular_advance,
+            candidate_advance,
+        ) {
+            bail!("{reason}");
+        }
+        Ok(candidate)
+    });
+    match resolved {
+        Ok(candidate) => candidate,
+        Err(error) => {
+            eprintln!(
+                "splinterm font warning: {} for family {:?} is unavailable ({error}); using the regular face",
+                request.style, regular.family
+            );
+            regular.fallback_for(request.label)
+        }
+    }
+}
+
+fn expected_primary_family_fragment(pattern: &str) -> &'static str {
+    if pattern == STARTUP_FONT_FALLBACK {
+        "jetbrains mono"
+    } else {
+        ""
+    }
+}
+
+fn resolve_primary_faces_exact(pattern: &str) -> Result<[FontFace; 4]> {
+    let regular = resolve_face(
+        "primary regular",
+        pattern,
+        expected_primary_family_fragment(pattern),
+    )?;
+    let regular_advance = face_advance(&regular, BASE_FONT_SIZE)
+        .context("selected primary regular face is unusable")?;
+    let [bold_request, italic_request, bold_italic_request] = PRIMARY_STYLE_REQUESTS;
+    let bold = resolve_primary_style(&regular, bold_request, regular_advance);
+    let italic = resolve_primary_style(&regular, italic_request, regular_advance);
+    let bold_italic = resolve_primary_style(&regular, bold_italic_request, regular_advance);
+    Ok([regular, bold, italic, bold_italic])
+}
+
+fn resolve_startup_primary_with<T>(
+    pattern: &str,
+    authority: FontAuthority,
+    mut resolve: impl FnMut(&str) -> Result<T>,
+) -> Result<T> {
+    match resolve(pattern) {
+        Ok(resolved) => Ok(resolved),
+        Err(error) if authority == FontAuthority::Explicit => Err(error).with_context(|| {
+            format!("explicit primary font pattern {pattern:?} could not be resolved")
+        }),
+        Err(native_error) => {
+            eprintln!(
+                "splinterm font warning: native system monospace resolution failed ({native_error:#}); trying the documented JetBrains Mono Nerd Font fallback"
+            );
+            resolve(STARTUP_FONT_FALLBACK).with_context(|| {
+                format!(
+                    "native primary font pattern {pattern:?} failed ({native_error:#}) and startup fallback {STARTUP_FONT_FALLBACK:?} could not be resolved"
+                )
+            })
+        }
+    }
+}
+
+fn resolve_primary_faces(pattern: &str, authority: FontAuthority) -> Result<[FontFace; 4]> {
+    resolve_startup_primary_with(pattern, authority, resolve_primary_faces_exact)
 }
 
 pub(super) fn font_data(face: &FontFace) -> Result<&[u8]> {
@@ -1326,6 +1479,187 @@ pub(super) fn round_to_i32(value: f32) -> i32 {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn synthetic_face(
+        label: &'static str,
+        family: &str,
+        path: &str,
+        weight: i32,
+        slant: i32,
+    ) -> FontFace {
+        FontFace {
+            label,
+            family: family.to_owned(),
+            style: label.to_owned(),
+            path: PathBuf::from(path),
+            index: 0,
+            weight,
+            slant,
+            selected_pixel_size_26_6: 12 * 64,
+            data: OnceLock::new(),
+        }
+    }
+
+    #[test]
+    fn style_patterns_use_fontconfig_weight_and_slant_for_the_selected_family() {
+        let bold_italic = PRIMARY_STYLE_REQUESTS[2];
+        assert_eq!(
+            primary_style_pattern("Chosen-Family, Mono: Propo", bold_italic),
+            "Chosen\\-Family\\, Mono\\: Propo:weight=bold:slant=italic"
+        );
+        assert_eq!(
+            primary_style_pattern("Chosen", PRIMARY_STYLE_REQUESTS[0]),
+            "Chosen:weight=bold:slant=roman"
+        );
+        assert_eq!(
+            primary_style_pattern("Chosen", PRIMARY_STYLE_REQUESTS[1]),
+            "Chosen:weight=regular:slant=italic"
+        );
+        assert!(!primary_style_pattern("Chosen", bold_italic).contains("JetBrains"));
+    }
+
+    #[test]
+    fn style_policy_accepts_only_compatible_faces_from_the_selected_family() {
+        let regular = synthetic_face("regular", "Chosen Mono", "/fonts/regular.ttf", 80, 0);
+        let request = PrimaryStyleRequest {
+            label: "primary bold italic",
+            style: "Bold Italic",
+            bold: true,
+            italic: true,
+        };
+        let compatible = synthetic_face(
+            "bold italic",
+            "Chosen Mono",
+            "/fonts/bold-italic.ttf",
+            200,
+            100,
+        );
+        assert_eq!(
+            style_candidate_rejection(&regular, &compatible, request, 8.0, 8.0),
+            None
+        );
+        let compatible_oblique = synthetic_face(
+            "bold oblique",
+            "Chosen Mono",
+            "/fonts/bold-oblique.ttf",
+            200,
+            110,
+        );
+        assert_eq!(
+            style_candidate_rejection(&regular, &compatible_oblique, request, 8.0, 8.0),
+            None,
+            "Fontconfig oblique faces satisfy an italic slant request"
+        );
+
+        let foreign = synthetic_face("bold italic", "Other Mono", "/fonts/other.ttf", 200, 100);
+        assert_eq!(
+            style_candidate_rejection(&regular, &foreign, request, 8.0, 8.0),
+            Some("resolved to another family")
+        );
+
+        let duplicate =
+            synthetic_face("bold italic", "Chosen Mono", "/fonts/regular.ttf", 200, 100);
+        assert_eq!(
+            style_candidate_rejection(&regular, &duplicate, request, 8.0, 8.0),
+            Some("resolved to the regular face")
+        );
+
+        let wrong_style =
+            synthetic_face("bold italic", "Chosen Mono", "/fonts/italic.ttf", 80, 100);
+        assert_eq!(
+            style_candidate_rejection(&regular, &wrong_style, request, 8.0, 8.0),
+            Some("did not resolve the requested weight")
+        );
+
+        assert_eq!(
+            style_candidate_rejection(&regular, &compatible, request, 8.0, 8.5),
+            Some("has incompatible terminal-cell metrics")
+        );
+    }
+
+    #[test]
+    fn unavailable_style_fallback_preserves_the_selected_regular_identity() {
+        let regular = synthetic_face("regular", "Chosen Mono", "/fonts/regular.ttf", 80, 0);
+        let fallback = regular.fallback_for("primary bold");
+        assert_eq!(fallback.family, "Chosen Mono");
+        assert_eq!(fallback.identity(), regular.identity());
+        assert_eq!(fallback.weight, regular.weight);
+        assert_eq!(fallback.slant, regular.slant);
+    }
+
+    #[test]
+    fn documented_startup_fallback_requires_the_jetbrains_family() {
+        assert_eq!(
+            expected_primary_family_fragment(STARTUP_FONT_FALLBACK),
+            "jetbrains mono"
+        );
+        assert_eq!(expected_primary_family_fragment("monospace"), "");
+    }
+
+    #[test]
+    fn native_startup_tries_the_documented_fallback_after_resolution_failure() {
+        let mut patterns = Vec::new();
+        let resolved = resolve_startup_primary_with(
+            "monospace:style=Regular",
+            FontAuthority::NativeOmarchy,
+            |pattern| {
+                patterns.push(pattern.to_owned());
+                if pattern == STARTUP_FONT_FALLBACK {
+                    Ok("fallback")
+                } else {
+                    bail!("native unavailable")
+                }
+            },
+        )
+        .unwrap();
+        assert_eq!(resolved, "fallback");
+        assert_eq!(
+            patterns,
+            [
+                "monospace:style=Regular".to_owned(),
+                STARTUP_FONT_FALLBACK.to_owned()
+            ]
+        );
+    }
+
+    #[test]
+    fn explicit_startup_never_uses_the_native_fallback() {
+        let mut patterns = Vec::new();
+        let error = resolve_startup_primary_with(
+            "monospace:style=Regular",
+            FontAuthority::Explicit,
+            |pattern| -> Result<()> {
+                patterns.push(pattern.to_owned());
+                bail!("explicit unavailable")
+            },
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("explicit primary font pattern"));
+        assert_eq!(patterns, ["monospace:style=Regular".to_owned()]);
+    }
+
+    #[test]
+    fn native_startup_fails_when_native_and_fallback_resolution_fail() {
+        let error = resolve_startup_primary_with(
+            "monospace:style=Regular",
+            FontAuthority::NativeOmarchy,
+            |_pattern| -> Result<()> { bail!("unavailable") },
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("startup fallback"));
+    }
+
+    #[test]
+    #[ignore = "requires host fontconfig and installed system fonts"]
+    fn effective_system_monospace_resolves_one_coherent_primary_family() {
+        let faces =
+            resolve_primary_faces("monospace:style=Regular", FontAuthority::NativeOmarchy).unwrap();
+        let regular_family = normalize_family(&faces[0].family);
+        assert!(!regular_family.is_empty());
+        for face in &faces[1..] {
+            assert_eq!(normalize_family(&face.family), regular_family);
+        }
+    }
 
     #[test]
     fn persistent_glyph_cache_evicts_fifo_and_removes_color_advance() {

--- a/crates/splinterm/src/renderer/fonts.rs
+++ b/crates/splinterm/src/renderer/fonts.rs
@@ -1971,6 +1971,24 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "manual host resource timing; requires fontconfig and installed fonts"]
+    fn repeated_live_staging_is_fd_bounded() {
+        let options = renderer_options();
+        let before = std::fs::read_dir("/proc/self/fd").unwrap().count();
+        let started = Instant::now();
+        for _ in 0..3 {
+            drop(stage_live_font_generation(&options.font, options.font_authority).unwrap());
+        }
+        let elapsed = started.elapsed();
+        let after = std::fs::read_dir("/proc/self/fd").unwrap().count();
+        eprintln!(
+            "live-font-stage three_generations_ms={:.3} fd_before={before} fd_after={after}",
+            elapsed.as_secs_f64() * 1_000.0
+        );
+        assert!(after <= before.saturating_add(1));
+    }
+
+    #[test]
     #[ignore = "requires host fontconfig and installed system fonts"]
     fn live_probe_matches_the_staged_generation_on_the_supported_host() {
         let options = renderer_options();

--- a/crates/splinterm/src/renderer/fonts.rs
+++ b/crates/splinterm/src/renderer/fonts.rs
@@ -719,7 +719,7 @@ pub(super) fn snapshot_glyph(
             let raster_key = (generation_id, face.selected_pixel_size_26_6, face_index);
             if !cache.raster_faces.contains_key(&raster_key) {
                 let raster_face = RasterFace::open_memory(
-                    face.data.as_deref().context("emoji face is staged")?,
+                    face.data.clone().context("emoji face is staged")?,
                     face.index.raw(),
                     face.selected_pixel_size_26_6,
                 )
@@ -753,12 +753,10 @@ pub(super) fn snapshot_glyph(
             if !cache.raster_faces.contains_key(&raster_key) {
                 let face = &faces[face_index];
                 let pixel_size = pixel_size_26_6(font_size)?;
-                let fallback_mapping;
-                let data = if let Some(data) = face.data.as_deref() {
-                    data
+                let data = if let Some(data) = &face.data {
+                    Arc::clone(data)
                 } else {
-                    fallback_mapping = fallback_font_mapping(face)?;
-                    &fallback_mapping
+                    fallback_font_mapping(face)?
                 };
                 let raster_face = RasterFace::open_memory(data, face.index.raw(), pixel_size)
                     .with_context(|| format!("open FreeType raster face {}", face.label))?;
@@ -1288,7 +1286,7 @@ pub(super) fn cell_metrics(primary_face: &FontFace, font_size: f32) -> Result<Ce
     let mut face = RasterFace::open_memory(
         primary_face
             .data
-            .as_deref()
+            .clone()
             .context("primary face is staged")?,
         primary_face.index.raw(),
         pixel_size_26_6(font_size)?,
@@ -2224,7 +2222,7 @@ mod tests {
         );
 
         let mut freetype = RasterFace::open_memory(
-            face.data.as_deref().unwrap(),
+            face.data.clone().unwrap(),
             face.index.raw(),
             pixel_size_26_6(BASE_FONT_SIZE).unwrap(),
         )

--- a/crates/splinterm/src/renderer/fonts.rs
+++ b/crates/splinterm/src/renderer/fonts.rs
@@ -127,7 +127,7 @@ thread_local! {
         RefCell::new(PersistentGlyphCache::default());
 }
 
-pub(super) fn clear_snapshot_caches() {
+pub(crate) fn clear_snapshot_caches() {
     SNAPSHOT_GLYPH_CACHE.with(|cache| *cache.borrow_mut() = PersistentGlyphCache::default());
 }
 
@@ -719,6 +719,12 @@ pub(super) fn snapshot_color_advance(
             glyph: glyph_id,
         },
     );
+    if let Some(advance) =
+        SNAPSHOT_GLYPH_CACHE.with(|cache| cache.borrow().advances.get(&cache_key).copied())
+    {
+        return Ok(advance);
+    }
+    snapshot_glyph(faces, face_index, glyph_id, font_size)?;
     SNAPSHOT_GLYPH_CACHE.with(|cache| {
         cache
             .borrow()

--- a/crates/splinterm/src/renderer/fonts.rs
+++ b/crates/splinterm/src/renderer/fonts.rs
@@ -676,9 +676,11 @@ pub fn snapshot_font_generation() -> Result<&'static Arc<FontGeneration>> {
     SNAPSHOT_FONT_GENERATION
         .get_or_init(|| {
             let options = renderer_options();
-            stage_startup_font_generation(&options.font, options.font_authority)
-                .map(Arc::new)
-                .map_err(|error| error.to_string())
+            #[cfg(not(test))]
+            let generation = stage_startup_font_generation(&options.font, options.font_authority);
+            #[cfg(test)]
+            let generation = stage_renderer_test_generation(&options.font, options.font_authority);
+            generation.map(Arc::new).map_err(|error| error.to_string())
         })
         .as_ref()
         .map_err(|error| anyhow::anyhow!(error.clone()))
@@ -1901,6 +1903,38 @@ fn stage_startup_font_generation(
     stage_font_generation(pattern, authority, true)
 }
 
+#[cfg(test)]
+fn pinned_startup_font_is_available() -> Result<bool> {
+    let sources = run_fontconfig_sources(
+        "pinned renderer test prerequisite",
+        STARTUP_FONT_FALLBACK,
+        false,
+    )?;
+    let source = sources
+        .first()
+        .context("fc-match returned no pinned renderer test prerequisite")?;
+    Ok(normalize_family(&source.family).contains(&normalize_family("jetbrains mono")))
+}
+
+#[cfg(test)]
+fn use_host_renderer_test_font(pattern: &str, pinned_startup_font_available: bool) -> bool {
+    pattern == STARTUP_FONT_FALLBACK && !pinned_startup_font_available
+}
+
+/// Stages the pinned renderer-test generation, falling back only when Fontconfig
+/// positively reports that the pinned `JetBrains` family is absent.
+#[cfg(test)]
+pub(super) fn stage_renderer_test_generation(
+    pattern: &str,
+    authority: FontAuthority,
+) -> Result<FontGeneration> {
+    if !use_host_renderer_test_font(pattern, pinned_startup_font_is_available()?) {
+        return stage_startup_font_generation(pattern, authority);
+    }
+    stage_live_font_generation("monospace:style=Regular", FontAuthority::Explicit)
+        .context("stage the host's generic monospace renderer-test generation")
+}
+
 /// Stages one stable live generation without applying the startup fallback.
 ///
 /// # Errors
@@ -2364,6 +2398,16 @@ mod tests {
             "jetbrains mono"
         );
         assert_eq!(expected_primary_family_fragment("monospace"), "");
+    }
+
+    #[test]
+    fn host_test_font_is_used_only_when_the_pinned_default_is_absent() {
+        assert!(!use_host_renderer_test_font(STARTUP_FONT_FALLBACK, true));
+        assert!(use_host_renderer_test_font(STARTUP_FONT_FALLBACK, false));
+        assert!(!use_host_renderer_test_font(
+            "explicit configured font",
+            false
+        ));
     }
 
     #[test]

--- a/crates/splinterm/src/renderer/frame.rs
+++ b/crates/splinterm/src/renderer/frame.rs
@@ -20,12 +20,11 @@ use crate::{
 
 use super::{
     BOX_DRAWING_FACE, CachedGlyph, FontFace, FontGeneration, GlyphKey, RenderContext, SNAPSHOT_CJK,
-    SNAPSHOT_EMOJI, SNAPSHOT_PRIMARY_BOLD, SNAPSHOT_PRIMARY_BOLD_ITALIC, SNAPSHOT_PRIMARY_ITALIC,
-    SNAPSHOT_PRIMARY_REGULAR, cell_metrics, compatibility_render_context,
+    SNAPSHOT_EMOJI, SNAPSHOT_FALLBACK_START, SNAPSHOT_PRIMARY_BOLD, SNAPSHOT_PRIMARY_BOLD_ITALIC,
+    SNAPSHOT_PRIMARY_ITALIC, SNAPSHOT_PRIMARY_REGULAR, cell_metrics, compatibility_render_context,
     decorations::{DecorationMetrics, DecorationSpan},
-    font_ref,
     images::{SnapshotImage, prepare_snapshot_images},
-    snapshot_color_advance, snapshot_glyph, u32_to_f32,
+    snapshot_color_advance, snapshot_glyph, u32_to_f32, with_font_ref,
 };
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -787,18 +786,24 @@ pub(super) fn prepare_snapshot_row(
                 Ok(face_index) => (face_index, cell.content.as_str()),
                 Err(_) => (primary_face_index(&cell.attributes), "\u{fffd}"),
             };
-        let font = font_ref(&faces[face_index])?;
-        let mut shaped_glyphs = Vec::new();
-        let mut shaper = shape_context.builder(font).size(font_size).build();
-        shaper.add_str(content);
-        shaper.shape_with(|cluster| {
-            let advance = cluster.advance();
-            let mut pen = 0.0;
-            for glyph in cluster.glyphs {
-                shaped_glyphs.push((glyph.id, advance, pen + glyph.x, glyph.y));
-                pen += glyph.advance;
-            }
-        });
+        let shaped_glyphs = with_font_ref(&faces[face_index], |font, coords| {
+            let mut shaped_glyphs = Vec::new();
+            let mut shaper = shape_context
+                .builder(font)
+                .size(font_size)
+                .normalized_coords(coords)
+                .build();
+            shaper.add_str(content);
+            shaper.shape_with(|cluster| {
+                let advance = cluster.advance();
+                let mut pen = 0.0;
+                for glyph in cluster.glyphs {
+                    shaped_glyphs.push((glyph.id, advance, pen + glyph.x, glyph.y));
+                    pen += glyph.advance;
+                }
+            });
+            Ok(shaped_glyphs)
+        })?;
         for (glyph_id, cluster_advance, x_offset, y_offset) in shaped_glyphs {
             let key = GlyphKey {
                 face: face_index,
@@ -861,13 +866,18 @@ pub(super) fn select_face_for_text(
     let primary = primary_face_index(attributes);
     [primary, SNAPSHOT_CJK, SNAPSHOT_EMOJI]
         .into_iter()
+        .chain(SNAPSHOT_FALLBACK_START..faces.len())
         .find(|index| {
-            font_ref(&faces[*index]).is_ok_and(|font| {
-                text.chars()
-                    .all(|character| font.charmap().map(character) != 0)
-            })
+            let face = &faces[*index];
+            face.covers_text(text)
+                && with_font_ref(face, |font, _coords| {
+                    Ok(text
+                        .chars()
+                        .all(|character| font.charmap().map(character) != 0))
+                })
+                .unwrap_or(false)
         })
-        .with_context(|| format!("no explicit font covers snapshot cell {text:?}"))
+        .with_context(|| format!("no Fontconfig face covers snapshot cell {text:?}"))
 }
 
 pub(super) fn primary_face_index(attributes: &CellAttributes) -> usize {

--- a/crates/splinterm/src/renderer/frame.rs
+++ b/crates/splinterm/src/renderer/frame.rs
@@ -19,13 +19,13 @@ use crate::{
 };
 
 use super::{
-    BOX_DRAWING_FACE, CachedGlyph, FontFace, GlyphKey, RenderContext, SNAPSHOT_CJK, SNAPSHOT_EMOJI,
-    SNAPSHOT_PRIMARY_BOLD, SNAPSHOT_PRIMARY_BOLD_ITALIC, SNAPSHOT_PRIMARY_ITALIC,
+    BOX_DRAWING_FACE, CachedGlyph, FontFace, FontGeneration, GlyphKey, RenderContext, SNAPSHOT_CJK,
+    SNAPSHOT_EMOJI, SNAPSHOT_PRIMARY_BOLD, SNAPSHOT_PRIMARY_BOLD_ITALIC, SNAPSHOT_PRIMARY_ITALIC,
     SNAPSHOT_PRIMARY_REGULAR, cell_metrics, compatibility_render_context,
     decorations::{DecorationMetrics, DecorationSpan},
     font_ref,
     images::{SnapshotImage, prepare_snapshot_images},
-    snapshot_color_advance, snapshot_faces, snapshot_glyph, u32_to_f32,
+    snapshot_color_advance, snapshot_glyph, u32_to_f32,
 };
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -42,6 +42,7 @@ pub(super) struct SnapshotGlyph {
 
 /// One immutable, scale-dependent rendering of an owned daemon snapshot.
 pub(crate) struct SnapshotFrame {
+    pub(super) font_generation: Arc<FontGeneration>,
     pub(super) glyphs: Vec<SnapshotGlyph>,
     pub(super) decorations: Vec<DecorationSpan>,
     pub(super) cache: HashMap<GlyphKey, Arc<CachedGlyph>>,
@@ -335,7 +336,8 @@ impl SnapshotFrame {
         }
         let scale_120 = u16::try_from(scale_120).context("scale fits u16")?;
         let font_size = context.effective_font_size(u32::from(scale_120))?;
-        let faces = snapshot_faces()?;
+        let font_generation = Arc::clone(context.font_generation()?);
+        let faces = &font_generation.faces;
         let metrics = cell_metrics(&faces[0], font_size)?;
         let cell_width = metrics.width;
         let cell_height = metrics.height;
@@ -395,6 +397,7 @@ impl SnapshotFrame {
         let cursor = snapshot_cursor(snapshot, columns, rows);
         let images = prepare_snapshot_images(snapshot, sources)?;
         let mut frame = Self {
+            font_generation,
             glyphs,
             decorations,
             cache,
@@ -449,7 +452,12 @@ impl SnapshotFrame {
         if snapshot.palette.len() != 256 {
             bail!("snapshot palette must contain exactly 256 colors");
         }
-        let faces = snapshot_faces()?;
+        let context_generation = context.font_generation()?;
+        anyhow::ensure!(
+            self.font_generation.id == context_generation.id,
+            "incremental frame font generation changed; a full rebuild is required"
+        );
+        let faces = &self.font_generation.faces;
         let font_size = context.effective_font_size(u32::from(self.scale_120))?;
         let default_foreground = packed_rgb(snapshot.default_colors[0]);
         let default_background = packed_rgb(snapshot.default_colors[1]);
@@ -801,8 +809,10 @@ pub(super) fn prepare_snapshot_row(
                 .or_insert(snapshot_glyph(faces, face_index, glyph_id, font_size)?);
             let cluster_advance = if face_index == SNAPSHOT_EMOJI {
                 f32::from(
-                    i16::try_from(snapshot_color_advance(face_index, glyph_id, font_size)?)
-                        .context("color glyph advance fits i16")?,
+                    i16::try_from(snapshot_color_advance(
+                        faces, face_index, glyph_id, font_size,
+                    )?)
+                    .context("color glyph advance fits i16")?,
                 )
             } else {
                 cluster_advance.trunc()

--- a/crates/splinterm/src/renderer/settings.rs
+++ b/crates/splinterm/src/renderer/settings.rs
@@ -1,9 +1,11 @@
 //! Immutable renderer resources, explicit per-window state, and compatibility adapters.
 
-use std::sync::{Mutex, OnceLock};
+use std::sync::{Arc, Mutex, OnceLock};
 
 use anyhow::{Context, Result, bail};
 use splinterm_freetype::{MAX_PIXEL_SIZE_26_6, MIN_PIXEL_SIZE_26_6};
+
+use super::{FontGeneration, clear_snapshot_caches, snapshot_font_generation};
 
 use crate::{
     config::{FontAuthority, STARTUP_FONT_FALLBACK},
@@ -55,6 +57,7 @@ impl Default for RendererOptions {
 #[derive(Clone, Debug)]
 pub struct RenderContext {
     resources: &'static RendererResources,
+    font_generation: Result<Arc<FontGeneration>, Arc<String>>,
     output_dpi: OutputDpiObservation,
     font_zoom_steps: i16,
     background_alpha: u16,
@@ -68,13 +71,46 @@ impl RenderContext {
     #[must_use]
     pub fn new(background_alpha: u16) -> Self {
         let resources = renderer_resources();
+        let font_generation = snapshot_font_generation()
+            .map(Arc::clone)
+            .map_err(|error| Arc::new(format!("{error:#}")));
         Self {
             resources,
+            font_generation,
             output_dpi: OutputDpiObservation::provided(resources.options.physical_dpi)
                 .expect("configured physical DPI was validated"),
             font_zoom_steps: 0,
             background_alpha,
         }
+    }
+
+    pub(super) fn font_generation(&self) -> Result<&Arc<FontGeneration>> {
+        self.font_generation
+            .as_ref()
+            .map_err(|error| anyhow::anyhow!(error.to_string()))
+    }
+
+    #[must_use]
+    #[allow(dead_code, reason = "used by the next Plan 0038 delivery milestone")]
+    pub(crate) fn font_generation_id(&self) -> Option<u64> {
+        self.font_generation
+            .as_ref()
+            .ok()
+            .map(|generation| generation.id)
+    }
+
+    #[allow(dead_code, reason = "used by the next Plan 0038 delivery milestone")]
+    pub(crate) fn replace_font_generation(&mut self, next: Arc<FontGeneration>) -> bool {
+        if self
+            .font_generation
+            .as_ref()
+            .is_ok_and(|current| current.fingerprint == next.fingerprint)
+        {
+            return false;
+        }
+        self.font_generation = Ok(next);
+        clear_snapshot_caches();
+        true
     }
 
     #[must_use]

--- a/crates/splinterm/src/renderer/settings.rs
+++ b/crates/splinterm/src/renderer/settings.rs
@@ -5,13 +5,16 @@ use std::sync::{Mutex, OnceLock};
 use anyhow::{Context, Result, bail};
 use splinterm_freetype::{MAX_PIXEL_SIZE_26_6, MIN_PIXEL_SIZE_26_6};
 
-use crate::geometry::{
-    FontSize, FontSizingPolicy, OutputDpiObservation, TerminalPadding, resolve_font_size,
-    resolve_font_size_with_output,
+use crate::{
+    config::{FontAuthority, STARTUP_FONT_FALLBACK},
+    geometry::{
+        FontSize, FontSizingPolicy, OutputDpiObservation, TerminalPadding, resolve_font_size,
+        resolve_font_size_with_output,
+    },
 };
 
 pub(super) const BASE_FONT_SIZE: f32 = 22.0;
-pub(super) const PRIMARY_FONT: &str = "JetBrains Mono Nerd Font:style=Regular";
+pub(super) const PRIMARY_FONT: &str = STARTUP_FONT_FALLBACK;
 const FONT_ZOOM_STEP_POINTS: f32 = 0.5;
 
 /// Immutable process resources shared by renderer contexts.
@@ -26,6 +29,7 @@ static COMPATIBILITY_CONTEXT: OnceLock<Mutex<RenderContext>> = OnceLock::new();
 #[derive(Clone, Debug)]
 pub struct RendererOptions {
     pub font: String,
+    pub font_authority: FontAuthority,
     pub font_size: FontSize,
     pub font_sizing_policy: FontSizingPolicy,
     pub physical_dpi: f32,
@@ -37,6 +41,7 @@ impl Default for RendererOptions {
     fn default() -> Self {
         Self {
             font: PRIMARY_FONT.to_owned(),
+            font_authority: FontAuthority::Explicit,
             font_size: FontSize::Pixels(BASE_FONT_SIZE),
             font_sizing_policy: FontSizingPolicy::OutputScale,
             physical_dpi: 96.0,
@@ -159,6 +164,7 @@ pub(super) fn compatible_renderer_options(
     next: &RendererOptions,
 ) -> bool {
     current.font == next.font
+        && current.font_authority == next.font_authority
         && current.font_size == next.font_size
         && current.font_sizing_policy == next.font_sizing_policy
         && current.physical_dpi.to_bits() == next.physical_dpi.to_bits()
@@ -281,6 +287,10 @@ mod tests {
         let mut different_font = current.clone();
         different_font.font = "different font".to_owned();
         assert!(!compatible_renderer_options(&current, &different_font));
+
+        let mut different_authority = current.clone();
+        different_authority.font_authority = FontAuthority::NativeOmarchy;
+        assert!(!compatible_renderer_options(&current, &different_authority));
 
         let mut different_padding = current.clone();
         different_padding.padding.left += 1;

--- a/crates/splinterm/src/renderer/tests.rs
+++ b/crates/splinterm/src/renderer/tests.rs
@@ -756,8 +756,7 @@ fn snapshot_decorations_use_foot_baseline_metrics_in_full_and_row_paints() {
 #[test]
 fn fontconfig_fallback_renders_the_prompt_arrow_instead_of_replacement() {
     let generation = Arc::new(
-        stage_live_font_generation("monospace", crate::config::FontAuthority::NativeOmarchy)
-            .unwrap(),
+        stage_live_font_generation(PRIMARY_FONT, crate::config::FontAuthority::Explicit).unwrap(),
     );
     let faces = &generation.faces;
     let attributes = CellAttributes::default();

--- a/crates/splinterm/src/renderer/tests.rs
+++ b/crates/splinterm/src/renderer/tests.rs
@@ -779,9 +779,9 @@ fn color_fallback_cache_uses_fcft_fixed_strike_size_and_advance() {
     let font = font_ref(&faces[SNAPSHOT_EMOJI]).unwrap();
     let glyph_id = font.charmap().map('\u{1f642}');
     let small = snapshot_glyph(faces, SNAPSHOT_EMOJI, glyph_id, 12.0).unwrap();
-    let small_advance = snapshot_color_advance(SNAPSHOT_EMOJI, glyph_id, 12.0).unwrap();
+    let small_advance = snapshot_color_advance(faces, SNAPSHOT_EMOJI, glyph_id, 12.0).unwrap();
     let larger = snapshot_glyph(faces, SNAPSHOT_EMOJI, glyph_id, 15.0).unwrap();
-    let larger_advance = snapshot_color_advance(SNAPSHOT_EMOJI, glyph_id, 15.0).unwrap();
+    let larger_advance = snapshot_color_advance(faces, SNAPSHOT_EMOJI, glyph_id, 15.0).unwrap();
 
     assert_eq!((small.width, small.height, small_advance), (14, 14, 14));
     assert_eq!((larger.width, larger.height, larger_advance), (18, 17, 18));
@@ -1219,6 +1219,48 @@ fn empty_overlays_leave_compositor_border_area_untouched() {
 }
 
 #[test]
+fn incremental_refresh_rejects_a_different_font_generation() {
+    let snapshot = incremental_snapshot();
+    let context = compatibility_render_context().unwrap();
+    let mut frame = SnapshotFrame::load_scaled_with_context(&snapshot, 120, &context).unwrap();
+    let options = renderer_options();
+    let replacement =
+        Arc::new(stage_live_font_generation(&options.font, options.font_authority).unwrap());
+    assert_ne!(frame.font_generation.id, replacement.id);
+    frame.font_generation = replacement;
+    let error = frame
+        .refresh_rows_with_context(&snapshot, &[true, true], &context)
+        .unwrap_err();
+    assert!(error.to_string().contains("full rebuild is required"));
+}
+
+#[test]
+fn prepared_frame_retains_its_font_generation_until_drop() {
+    let snapshot = incremental_snapshot();
+    let frame = SnapshotFrame::load_scaled(&snapshot, 120).unwrap();
+    let generation = Arc::clone(&frame.font_generation);
+    let retained = Arc::strong_count(&generation);
+    assert!(retained >= 3);
+    drop(frame);
+    assert_eq!(Arc::strong_count(&generation), retained - 1);
+}
+
+#[test]
+fn identical_glyph_ids_do_not_share_cache_entries_across_generations() {
+    reset_snapshot_cache();
+    let current = snapshot_font_generation().unwrap();
+    let face = &current.faces[SNAPSHOT_PRIMARY_REGULAR];
+    let glyph_id = font_ref(face).unwrap().charmap().map('M');
+    let current_glyph =
+        snapshot_glyph(&current.faces, SNAPSHOT_PRIMARY_REGULAR, glyph_id, 22.0).unwrap();
+    let options = renderer_options();
+    let replacement = stage_live_font_generation(&options.font, options.font_authority).unwrap();
+    let replacement_glyph =
+        snapshot_glyph(&replacement.faces, SNAPSHOT_PRIMARY_REGULAR, glyph_id, 22.0).unwrap();
+    assert!(!Arc::ptr_eq(&current_glyph, &replacement_glyph));
+}
+
+#[test]
 fn incremental_refresh_preserves_unchanged_prepared_rows() {
     let mut snapshot = incremental_snapshot();
     let mut frame = SnapshotFrame::load(&snapshot, 1).expect("initial frame");
@@ -1384,6 +1426,7 @@ fn default_alpha_tracks_color_source_and_uses_premultiplied_argb() {
 fn snapshot_framebuffer_paints_background_wide_composed_glyphs_and_cursor() {
     let key = GlyphKey { face: 0, glyph: 1 };
     let frame = SnapshotFrame {
+        font_generation: Arc::clone(snapshot_font_generation().unwrap()),
         glyphs: vec![
             SnapshotGlyph {
                 key,
@@ -1476,6 +1519,7 @@ fn snapshot_framebuffer_paints_background_wide_composed_glyphs_and_cursor() {
 
 fn damage_test_frame() -> SnapshotFrame {
     SnapshotFrame {
+        font_generation: Arc::clone(snapshot_font_generation().unwrap()),
         glyphs: Vec::new(),
         decorations: Vec::new(),
         cache: HashMap::new(),
@@ -2374,6 +2418,7 @@ fn scroll_copy_clips_to_undersized_framebuffers() {
 #[test]
 fn terminal_size_calculation_clamps_minimum_and_protocol_limits() {
     let frame = SnapshotFrame {
+        font_generation: Arc::clone(snapshot_font_generation().unwrap()),
         glyphs: Vec::new(),
         decorations: Vec::new(),
         cache: HashMap::new(),

--- a/crates/splinterm/src/renderer/tests.rs
+++ b/crates/splinterm/src/renderer/tests.rs
@@ -762,14 +762,15 @@ fn snapshot_decorations_use_foot_baseline_metrics_in_full_and_row_paints() {
 #[test]
 fn fontconfig_fallback_renders_the_prompt_arrow_instead_of_replacement() {
     let generation = Arc::new(
-        stage_live_font_generation(PRIMARY_FONT, crate::config::FontAuthority::Explicit).unwrap(),
+        stage_renderer_test_generation(PRIMARY_FONT, crate::config::FontAuthority::Explicit)
+            .unwrap(),
     );
     let faces = &generation.faces;
     let attributes = CellAttributes::default();
     let face_index = select_face_for_text(faces, "⇕", &attributes).unwrap();
     assert!(
         face_index >= SNAPSHOT_FALLBACK_START,
-        "the pinned primary, CJK, and emoji faces do not cover U+21D5"
+        "the selected primary, CJK, and emoji faces do not cover U+21D5"
     );
     assert!(
         faces[face_index].data.is_none(),

--- a/crates/splinterm/src/renderer/tests.rs
+++ b/crates/splinterm/src/renderer/tests.rs
@@ -297,6 +297,26 @@ fn explicit_render_contexts_are_pixel_and_metric_isolated_when_interleaved() {
     assert_eq!(second_capture.pixels[3], alpha_u8(52_000));
 }
 
+#[test]
+fn font_generation_replacement_preserves_zoom_dpi_and_alpha() {
+    let mut context = RenderContext::new(12_345);
+    context.set_font_zoom_steps(2, 150).unwrap();
+    context
+        .update_output_dpi(OutputDpiObservation::provided(144.0).unwrap(), 150)
+        .unwrap();
+    let before = context.effective_font_resolution(150).unwrap();
+    let options = renderer_options();
+    let mut replacement =
+        stage_live_font_generation(&options.font, options.font_authority).unwrap();
+    replacement.fingerprint.pattern.push_str("#test-generation");
+    let replacement_id = replacement.id;
+
+    assert!(context.replace_font_generation(Arc::new(replacement)));
+    assert_eq!(context.font_generation_id(), Some(replacement_id));
+    assert_eq!(context.effective_font_resolution(150).unwrap(), before);
+    assert_eq!(context.background_alpha(), 12_345);
+}
+
 fn incremental_snapshot() -> TerminalSnapshot {
     let attributes = default_attributes();
     TerminalSnapshot {
@@ -787,6 +807,11 @@ fn color_fallback_cache_uses_fcft_fixed_strike_size_and_advance() {
     assert_eq!((larger.width, larger.height, larger_advance), (18, 17, 18));
     assert!(!Arc::ptr_eq(&small, &larger));
     assert_ne!(small.data, larger.data);
+    clear_snapshot_caches();
+    assert_eq!(
+        snapshot_color_advance(faces, SNAPSHOT_EMOJI, glyph_id, 15.0).unwrap(),
+        larger_advance
+    );
 }
 
 #[test]

--- a/crates/splinterm/src/renderer/tests.rs
+++ b/crates/splinterm/src/renderer/tests.rs
@@ -754,6 +754,42 @@ fn snapshot_decorations_use_foot_baseline_metrics_in_full_and_row_paints() {
 }
 
 #[test]
+fn fontconfig_fallback_renders_the_prompt_arrow_instead_of_replacement() {
+    let generation = Arc::new(
+        stage_live_font_generation("monospace", crate::config::FontAuthority::NativeOmarchy)
+            .unwrap(),
+    );
+    let faces = &generation.faces;
+    let attributes = CellAttributes::default();
+    let face_index = select_face_for_text(faces, "⇕", &attributes).unwrap();
+    assert!(
+        face_index >= SNAPSHOT_FALLBACK_START,
+        "the pinned primary, CJK, and emoji faces do not cover U+21D5"
+    );
+    assert!(
+        faces[face_index].data.is_none(),
+        "dynamic fallbacks must use the bounded mapping cache"
+    );
+    let glyph_id = with_font_ref(&faces[face_index], |font, _coords| {
+        Ok(font.charmap().map('⇕'))
+    })
+    .unwrap();
+    assert_ne!(glyph_id, 0);
+
+    let mut snapshot = incremental_snapshot();
+    snapshot.visible_rows[0].cells[0].content = "⇕".to_owned();
+    let mut context = RenderContext::new(u16::MAX);
+    context.replace_font_generation(generation);
+    let frame = SnapshotFrame::load_scaled_with_context(&snapshot, 120, &context).unwrap();
+    assert!(
+        frame
+            .glyphs
+            .iter()
+            .any(|glyph| glyph.column == 0 && glyph.row == 0 && glyph.key.face == face_index)
+    );
+}
+
+#[test]
 fn snapshot_styles_select_distinct_primary_faces_and_cache_keys() {
     let mut snapshot = incremental_snapshot();
     snapshot.visible_rows[0].cells[0].content = "A".to_owned();
@@ -868,12 +904,13 @@ fn underline_style_color_partial_mutation_matches_clean_full_rebuild() {
 #[test]
 fn selected_font_bytes_and_opened_identity_are_staged_together() {
     let face = resolve_face("staged CJK test", CJK_FONT, "noto sans cjk").unwrap();
-    assert!(!face.data.is_empty());
+    let data = face.data.as_ref().expect("explicit faces are staged");
+    assert!(!data.is_empty());
     assert_eq!(
         face.source_identity.length,
-        u64::try_from(face.data.len()).unwrap()
+        u64::try_from(data.len()).unwrap()
     );
-    assert_ne!(face.source_identity, face.data.identity());
+    assert_ne!(face.source_identity, data.identity());
     assert_ne!(font_ref(&face).unwrap().charmap().map('界'), 0);
 }
 
@@ -886,7 +923,11 @@ fn memory_backed_freetype_keeps_the_staged_inode_after_path_replacement() {
         std::process::id()
     ));
     let retired = path.with_extension("retired");
-    fs::write(&path, &**source.data).unwrap();
+    fs::write(
+        &path,
+        &***source.data.as_ref().expect("explicit faces are staged"),
+    )
+    .unwrap();
     let staged = Arc::new(
         splinterm_filemap::ReadOnlyFileMap::immutable_snapshot(
             &path,
@@ -898,14 +939,10 @@ fn memory_backed_freetype_keeps_the_staged_inode_after_path_replacement() {
     fs::rename(&path, &retired).unwrap();
     fs::write(&path, b"not a font").unwrap();
 
-    let shaped = swash::FontRef::from_index(&staged, source.index).unwrap();
+    let shaped = swash::FontRef::from_index(&staged, source.index.collection_index()).unwrap();
     assert_ne!(shaped.charmap().map('界'), 0);
-    let mut raster = splinterm_freetype::RasterFace::open_memory(
-        &staged,
-        u32::try_from(source.index).unwrap(),
-        22 * 64,
-    )
-    .unwrap();
+    let mut raster =
+        splinterm_freetype::RasterFace::open_memory(&staged, source.index.raw(), 22 * 64).unwrap();
     assert!(raster.metrics().unwrap().height > 0);
 
     fs::remove_file(path).unwrap();

--- a/crates/splinterm/src/renderer/tests.rs
+++ b/crates/splinterm/src/renderer/tests.rs
@@ -841,11 +841,50 @@ fn underline_style_color_partial_mutation_matches_clean_full_rebuild() {
 }
 
 #[test]
-fn selected_font_bytes_are_loaded_only_when_the_face_is_used() {
-    let face = resolve_face("lazy CJK test", CJK_FONT, "noto sans cjk").unwrap();
-    assert!(face.data.get().is_none());
+fn selected_font_bytes_and_opened_identity_are_staged_together() {
+    let face = resolve_face("staged CJK test", CJK_FONT, "noto sans cjk").unwrap();
+    assert!(!face.data.is_empty());
+    assert_eq!(
+        face.source_identity.length,
+        u64::try_from(face.data.len()).unwrap()
+    );
+    assert_ne!(face.source_identity, face.data.identity());
     assert_ne!(font_ref(&face).unwrap().charmap().map('界'), 0);
-    assert!(face.data.get().is_some_and(Result::is_ok));
+}
+
+#[test]
+#[ignore = "requires host fontconfig and installed system fonts"]
+fn memory_backed_freetype_keeps_the_staged_inode_after_path_replacement() {
+    let source = resolve_face("staged replacement test", CJK_FONT, "noto sans cjk").unwrap();
+    let path = std::env::temp_dir().join(format!(
+        "splinterm-font-generation-replacement-{}",
+        std::process::id()
+    ));
+    let retired = path.with_extension("retired");
+    fs::write(&path, &**source.data).unwrap();
+    let staged = Arc::new(
+        splinterm_filemap::ReadOnlyFileMap::immutable_snapshot(
+            &path,
+            splinterm_freetype::MAX_STAGED_FONT_BYTES,
+        )
+        .unwrap()
+        .mapping,
+    );
+    fs::rename(&path, &retired).unwrap();
+    fs::write(&path, b"not a font").unwrap();
+
+    let shaped = swash::FontRef::from_index(&staged, source.index).unwrap();
+    assert_ne!(shaped.charmap().map('界'), 0);
+    let mut raster = splinterm_freetype::RasterFace::open_memory(
+        &staged,
+        u32::try_from(source.index).unwrap(),
+        22 * 64,
+    )
+    .unwrap();
+    assert!(raster.metrics().unwrap().height > 0);
+
+    fs::remove_file(path).unwrap();
+    fs::remove_file(retired).unwrap();
 }
 
 #[test]

--- a/crates/splinterm/src/renderer/tests.rs
+++ b/crates/splinterm/src/renderer/tests.rs
@@ -1,4 +1,12 @@
-use super::*;
+use super::{frame::select_face_for_text, *};
+
+fn stage_test_font_generation() -> FontGeneration {
+    stage_live_font_generation(
+        "monospace:style=Regular",
+        crate::config::FontAuthority::NativeOmarchy,
+    )
+    .expect("stage the host's generic monospace family")
+}
 
 fn synthetic_row() -> TextRow {
     let key = GlyphKey { face: 0, glyph: 1 };
@@ -305,9 +313,7 @@ fn font_generation_replacement_preserves_zoom_dpi_and_alpha() {
         .update_output_dpi(OutputDpiObservation::provided(144.0).unwrap(), 150)
         .unwrap();
     let before = context.effective_font_resolution(150).unwrap();
-    let options = renderer_options();
-    let mut replacement =
-        stage_live_font_generation(&options.font, options.font_authority).unwrap();
+    let mut replacement = stage_test_font_generation();
     replacement.fingerprint.pattern.push_str("#test-generation");
     let replacement_id = replacement.id;
 
@@ -940,12 +946,39 @@ fn memory_backed_freetype_keeps_the_staged_inode_after_path_replacement() {
 
     let shaped = swash::FontRef::from_index(&staged, source.index.collection_index()).unwrap();
     assert_ne!(shaped.charmap().map('界'), 0);
-    let mut raster =
-        splinterm_freetype::RasterFace::open_memory(&staged, source.index.raw(), 22 * 64).unwrap();
+    let retained_before = Arc::strong_count(&staged);
+    let mut raster = splinterm_freetype::RasterFace::open_memory(
+        Arc::clone(&staged),
+        source.index.raw(),
+        22 * 64,
+    )
+    .unwrap();
+    assert!(Arc::strong_count(&staged) > retained_before);
     assert!(raster.metrics().unwrap().height > 0);
+    drop(raster);
+    assert_eq!(Arc::strong_count(&staged), retained_before);
 
     fs::remove_file(path).unwrap();
     fs::remove_file(retired).unwrap();
+}
+
+#[test]
+fn raster_faces_share_one_generation_mapping_across_sizes() {
+    let generation = stage_test_font_generation();
+    let face = &generation.faces[SNAPSHOT_PRIMARY_REGULAR];
+    let data = face.data.clone().expect("primary face is staged");
+    let retained_before = Arc::strong_count(&data);
+
+    let first =
+        splinterm_freetype::RasterFace::open_memory(Arc::clone(&data), face.index.raw(), 16 * 64)
+            .unwrap();
+    let second =
+        splinterm_freetype::RasterFace::open_memory(Arc::clone(&data), face.index.raw(), 32 * 64)
+            .unwrap();
+    assert!(Arc::strong_count(&data) > retained_before);
+
+    drop((first, second));
+    assert_eq!(Arc::strong_count(&data), retained_before);
 }
 
 #[test]
@@ -1203,8 +1236,11 @@ fn forward_and_reverse_viewport_scroll_copy_match_clean_full_repaint() {
 fn persistent_raster_face_cache_is_bounded_across_scale_churn() {
     SNAPSHOT_GLYPH_CACHE.with(|cache| *cache.borrow_mut() = PersistentGlyphCache::default());
     let snapshot = incremental_snapshot();
+    let mut context = RenderContext::new(u16::MAX);
+    assert!(context.replace_font_generation(Arc::new(stage_test_font_generation())));
     for scale_120 in 120..=u32::try_from(120 + SNAPSHOT_RASTER_FACE_BUDGET).unwrap() {
-        SnapshotFrame::load_scaled(&snapshot, scale_120).expect("scaled frame");
+        SnapshotFrame::load_scaled_with_context(&snapshot, scale_120, &context)
+            .expect("scaled frame");
     }
     let metrics = snapshot_cache_metrics();
     assert_eq!(
@@ -1282,11 +1318,10 @@ fn empty_overlays_leave_compositor_border_area_untouched() {
 #[test]
 fn incremental_refresh_rejects_a_different_font_generation() {
     let snapshot = incremental_snapshot();
-    let context = compatibility_render_context().unwrap();
+    let mut context = compatibility_render_context().unwrap();
+    assert!(context.replace_font_generation(Arc::new(stage_test_font_generation())));
     let mut frame = SnapshotFrame::load_scaled_with_context(&snapshot, 120, &context).unwrap();
-    let options = renderer_options();
-    let replacement =
-        Arc::new(stage_live_font_generation(&options.font, options.font_authority).unwrap());
+    let replacement = Arc::new(stage_test_font_generation());
     assert_ne!(frame.font_generation.id, replacement.id);
     frame.font_generation = replacement;
     let error = frame
@@ -1298,7 +1333,9 @@ fn incremental_refresh_rejects_a_different_font_generation() {
 #[test]
 fn prepared_frame_retains_its_font_generation_until_drop() {
     let snapshot = incremental_snapshot();
-    let frame = SnapshotFrame::load_scaled(&snapshot, 120).unwrap();
+    let mut context = compatibility_render_context().unwrap();
+    assert!(context.replace_font_generation(Arc::new(stage_test_font_generation())));
+    let frame = SnapshotFrame::load_scaled_with_context(&snapshot, 120, &context).unwrap();
     let generation = Arc::clone(&frame.font_generation);
     let retained = Arc::strong_count(&generation);
     assert!(retained >= 3);
@@ -1309,13 +1346,12 @@ fn prepared_frame_retains_its_font_generation_until_drop() {
 #[test]
 fn identical_glyph_ids_do_not_share_cache_entries_across_generations() {
     reset_snapshot_cache();
-    let current = snapshot_font_generation().unwrap();
+    let current = stage_test_font_generation();
     let face = &current.faces[SNAPSHOT_PRIMARY_REGULAR];
     let glyph_id = font_ref(face).unwrap().charmap().map('M');
     let current_glyph =
         snapshot_glyph(&current.faces, SNAPSHOT_PRIMARY_REGULAR, glyph_id, 22.0).unwrap();
-    let options = renderer_options();
-    let replacement = stage_live_font_generation(&options.font, options.font_authority).unwrap();
+    let replacement = stage_test_font_generation();
     let replacement_glyph =
         snapshot_glyph(&replacement.faces, SNAPSHOT_PRIMARY_REGULAR, glyph_id, 22.0).unwrap();
     assert!(!Arc::ptr_eq(&current_glyph, &replacement_glyph));

--- a/crates/splinterm/src/wayland.rs
+++ b/crates/splinterm/src/wayland.rs
@@ -127,7 +127,7 @@ use crate::frontend::{
     AuthorityStatus, BINDING_HELP_PAGE_ITEMS, BindingHelpUi, BoundedTextEditor,
     BuiltInCommandDispatch, BuiltInCommandId, CommandControlAction, CommandHistoryAction,
     CommandPaletteContext, CommandPaletteUi, CommandTabMoveAvailability, CommandZoomAction,
-    DojoPromptUi, LairDirection, LairPromptKind, PerfTraceCorrelation, SelectorKind,
+    DojoPromptUi, FontUpdate, LairDirection, LairPromptKind, PerfTraceCorrelation, SelectorKind,
     SessionPickerDecision, SessionPickerItem, SessionPickerUi, TabContextMenuUi, TabMenuActionId,
     TabMenuContext, TabMenuDispatch, TabMenuRightPress, TerminalGridLimits, TerminationDecision,
     ThemeUpdate, TrustedConsentUi, WindowCommand, WindowDojoIdentity, WindowOptions,
@@ -836,6 +836,7 @@ pub fn run(mut options: WindowOptions) -> Result<()> {
             text_row,
             renderer_generation: 0,
             theme_generation: 0,
+            pending_font_update: None,
             cursor_style: options.cursor_style,
             cursor_blink: options.cursor_blink,
             title_override: options.title,
@@ -1679,7 +1680,7 @@ impl PaneView {
             } else {
                 BackgroundUpdateImpact::NONE
             }),
-            WindowUpdate::Theme(_) => Ok(BackgroundUpdateImpact::NONE),
+            WindowUpdate::Theme(_) | WindowUpdate::Font(_) => Ok(BackgroundUpdateImpact::NONE),
             WindowUpdate::Exited { .. } | WindowUpdate::Shutdown => {
                 self.controller_active = false;
                 self.commands = None;
@@ -1813,6 +1814,7 @@ struct PresentationState {
     text_row: Option<TextRow>,
     renderer_generation: u64,
     theme_generation: u64,
+    pending_font_update: Option<FontUpdate>,
     cursor_style: CursorStyle,
     cursor_blink: bool,
     title_override: Option<String>,
@@ -2586,6 +2588,15 @@ fn update_graphical_focus_watch(
                 true
             }
         });
+    }
+}
+
+fn retain_newest_font(slot: &mut Option<FontUpdate>, update: FontUpdate) {
+    if slot
+        .as_ref()
+        .is_none_or(|current| current.generation.id() < update.generation.id())
+    {
+        *slot = Some(update);
     }
 }
 
@@ -7301,6 +7312,9 @@ impl App {
                         retain_newest_theme(&mut next_theme, update);
                     }
                 }
+                WindowTopologyUpdate::Font(update) => {
+                    retain_newest_font(&mut self.presentation.pending_font_update, update);
+                }
                 WindowTopologyUpdate::Closed => self
                     .scheduling
                     .request_exit(ExitClass::CleanFinalTabRemoved),
@@ -7896,6 +7910,9 @@ impl App {
                         rebuild_all_inactive |= impact.rebuild_pixels;
                         effect_desired_changed |= impact.reconcile_effect;
                     }
+                }
+                WindowUpdate::Font(update) => {
+                    retain_newest_font(&mut self.presentation.pending_font_update, update);
                 }
                 WindowUpdate::Exited { splint_id } => {
                     anyhow::ensure!(

--- a/crates/splinterm/src/wayland.rs
+++ b/crates/splinterm/src/wayland.rs
@@ -916,6 +916,7 @@ pub fn run(mut options: WindowOptions) -> Result<()> {
                 search: SearchUiState::default(),
                 authority: options.authority,
                 last_resize: None,
+                pending_resize: None,
                 prepare_dirty_rows: Vec::new(),
                 raster_dirty_rows: Vec::new(),
                 surface_dirty_rows: Vec::new(),
@@ -1004,6 +1005,7 @@ pub fn run(mut options: WindowOptions) -> Result<()> {
             app.apply_updates(&queue_handle)?;
             if !app.scheduling.exit {
                 app.flush_pending_terminal_input();
+                app.retry_pending_pane_resizes()?;
             }
             if app.scheduling.redraw_pending
                 && !pending_draw_waits_for_frame(
@@ -1119,6 +1121,12 @@ fn new_search_editor() -> BoundedTextEditor {
     )
 }
 
+#[derive(Debug)]
+struct PendingPaneResize {
+    size: (u16, u16, u16, u16),
+    command: WindowCommand,
+}
+
 #[allow(
     clippy::struct_excessive_bools,
     reason = "independent pane rendering, history, and input flags are not one state machine"
@@ -1145,6 +1153,7 @@ struct PaneView {
     search: SearchUiState,
     authority: AuthorityStatus,
     last_resize: Option<(u16, u16, u16, u16)>,
+    pending_resize: Option<PendingPaneResize>,
     prepare_dirty_rows: Vec<bool>,
     raster_dirty_rows: Vec<bool>,
     surface_dirty_rows: Vec<bool>,
@@ -1396,6 +1405,7 @@ impl PaneView {
             search: SearchUiState::default(),
             authority: options.authority,
             last_resize: None,
+            pending_resize: None,
             prepare_dirty_rows: Vec::new(),
             raster_dirty_rows: Vec::new(),
             surface_dirty_rows: Vec::new(),
@@ -2410,7 +2420,9 @@ fn event_loop_timeout(
 }
 
 fn pane_command_retry_pending(pane: &PaneView) -> bool {
-    pane.control_release_pending || pane.pending_focus_report.is_some()
+    pane.control_release_pending
+        || pane.pending_focus_report.is_some()
+        || pane.pending_resize.is_some()
 }
 
 fn command_retry_dispatch_timeout(
@@ -6958,9 +6970,12 @@ impl App {
         scale_120: u32,
         activate: bool,
     ) -> Result<()> {
-        let (Some(frame), Some(commands)) = (&pane.snapshot_frame, &pane.commands) else {
+        let Some(frame) = &pane.snapshot_frame else {
             return Ok(());
         };
+        if pane.commands.is_none() {
+            return Ok(());
+        }
         let (resize, column_capped, row_capped) = match frame.terminal_size_with_limit_status(
             logical_width,
             logical_height,
@@ -6986,6 +7001,7 @@ impl App {
             );
         }
         if !resize_changed(pane.last_resize, resize) {
+            pane.pending_resize = None;
             return Ok(());
         }
         let resize_command = if activate {
@@ -7003,13 +7019,30 @@ impl App {
                 pixel_height: resize.3,
             }
         };
-        match commands.try_send(resize_command) {
-            Ok(()) => pane.last_resize = Some(resize),
-            Err(TrySendError::Full(_)) => {
-                // Layout and scale reconciliation can briefly outpace the
-                // one-pane command worker. Keep the previous dimensions so a
-                // later update retries the newest resize instead of treating
-                // ordinary backpressure as a fatal Wayland failure.
+        pane.pending_resize = Some(PendingPaneResize {
+            size: resize,
+            command: resize_command,
+        });
+        Self::retry_pending_pane_resize(pane)
+    }
+
+    fn retry_pending_pane_resize(pane: &mut PaneView) -> Result<()> {
+        let Some(pending) = pane.pending_resize.take() else {
+            return Ok(());
+        };
+        let Some(commands) = &pane.commands else {
+            return Ok(());
+        };
+        match commands.try_send(pending.command) {
+            Ok(()) => pane.last_resize = Some(pending.size),
+            Err(TrySendError::Full(command)) => {
+                // Preserve the exact newest resize across ordinary queue
+                // backpressure. The event loop retries deferred pane commands
+                // after pending terminal input, without changing authority.
+                pane.pending_resize = Some(PendingPaneResize {
+                    size: pending.size,
+                    command,
+                });
             }
             Err(TrySendError::Closed(_)) => {
                 anyhow::bail!("Wayland command receiver disconnected");
@@ -8468,6 +8501,22 @@ impl App {
                     snapshot.input_modes,
                 )
             })
+    }
+
+    fn retry_pending_pane_resizes(&mut self) -> Result<()> {
+        for pane in
+            std::iter::once(&mut self.panes.pane).chain(self.panes.inactive_panes.iter_mut())
+        {
+            Self::retry_pending_pane_resize(pane)?;
+        }
+        for tab in self.tab_state.tabs.iter_mut() {
+            if let Some(view) = tab.value.as_mut() {
+                for pane in std::iter::once(&mut view.pane).chain(view.inactive_panes.iter_mut()) {
+                    Self::retry_pending_pane_resize(pane)?;
+                }
+            }
+        }
+        Ok(())
     }
 
     fn has_deferred_pane_command(&self) -> bool {
@@ -11638,30 +11687,48 @@ mod tests {
             SCALE_DENOMINATOR,
         )
         .unwrap();
+        App::emit_pane_resize(&mut pane, 320, 240, SCALE_DENOMINATOR, true).unwrap();
+        assert!(matches!(
+            command_receiver.try_recv().unwrap(),
+            WindowCommand::Resize { .. }
+        ));
+        let previous = pane.last_resize;
         commands
             .try_send(WindowCommand::Input(vec![1]))
             .expect("fill pane command queue");
 
-        App::emit_pane_resize(&mut pane, 320, 240, SCALE_DENOMINATOR, true)
+        App::emit_pane_resize(&mut pane, 640, 480, SCALE_DENOMINATOR, false)
             .expect("queue saturation defers resize");
-        assert_eq!(pane.last_resize, None);
+        assert_eq!(pane.last_resize, previous);
+        assert!(pane.pending_resize.is_some());
+        assert!(pane_command_retry_pending(&pane));
         assert_eq!(
             command_receiver.try_recv().unwrap(),
             WindowCommand::Input(vec![1])
         );
 
-        App::emit_pane_resize(&mut pane, 320, 240, SCALE_DENOMINATOR, true)
-            .expect("deferred resize retries");
+        App::retry_pending_pane_resize(&mut pane).expect("deferred resize retries");
         let retried = command_receiver.try_recv().unwrap();
-        assert!(matches!(retried, WindowCommand::Resize { .. }));
-        assert!(pane.last_resize.is_some());
+        assert!(matches!(retried, WindowCommand::PrepareResize { .. }));
+        assert_ne!(pane.last_resize, previous);
+        assert!(pane.pending_resize.is_none());
+        assert!(!pane_command_retry_pending(&pane));
 
+        commands
+            .try_send(WindowCommand::Input(vec![2]))
+            .expect("refill pane command queue");
+        App::emit_pane_resize(&mut pane, 800, 600, SCALE_DENOMINATOR, true)
+            .expect("second resize defers");
+        assert!(pane.pending_resize.is_some());
+        assert_eq!(
+            command_receiver.try_recv().unwrap(),
+            WindowCommand::Input(vec![2])
+        );
         drop(command_receiver);
-        pane.last_resize = None;
-        let error = App::emit_pane_resize(&mut pane, 640, 480, SCALE_DENOMINATOR, true)
-            .expect_err("disconnected resize receiver");
+        let error = App::retry_pending_pane_resize(&mut pane)
+            .expect_err("disconnected deferred resize receiver");
         assert!(error.to_string().contains("disconnected"));
-        assert_eq!(pane.last_resize, None);
+        assert!(pane.pending_resize.is_none());
     }
 
     #[test]

--- a/crates/splinterm/src/wayland.rs
+++ b/crates/splinterm/src/wayland.rs
@@ -151,9 +151,9 @@ use crate::renderer::{
     DojoPromptLayout, HistoryOverlayStatus, PickerHitTarget, RenderContext,
     SessionPickerOverlayLayout, SessionPickerPurpose, SessionPickerTextCache,
     SessionPickerTextItem, SnapshotFrame, SnapshotOverlays, TabContextMenuLayout, TextRow,
-    background_bgra, command_palette_hit_test, command_palette_layout, dojo_prompt_hit_test,
-    dojo_prompt_layout, fill_rect, history_overlay_layout, paint, paint_command_palette,
-    paint_dojo_prompt, paint_history_overlay, paint_session_picker_overlay,
+    background_bgra, clear_snapshot_caches, command_palette_hit_test, command_palette_layout,
+    dojo_prompt_hit_test, dojo_prompt_layout, fill_rect, history_overlay_layout, paint,
+    paint_command_palette, paint_dojo_prompt, paint_history_overlay, paint_session_picker_overlay,
     paint_snapshot_overlays, paint_snapshot_presented, paint_snapshot_region_presented,
     paint_snapshot_rows_presented, paint_tab_context_menu, premultiplied_theme_rgba,
     scroll_snapshot_pixels, session_picker_hit_test, session_picker_overlay_layout,
@@ -1191,6 +1191,29 @@ fn rebuild_pane_scaled_frame(pane: &mut PaneView, scale_120: u32) -> Result<bool
     Ok(true)
 }
 
+fn prepare_pane_scaled_frame_with_context(
+    pane: &PaneView,
+    scale_120: u32,
+    context: &RenderContext,
+) -> Result<Option<SnapshotFrame>> {
+    let Some(display) = pane.display_snapshot() else {
+        return Ok(None);
+    };
+    Ok(Some(SnapshotFrame::load_scaled_with_sources_and_context(
+        &display,
+        scale_120,
+        Some(&pane.image_sources),
+        context,
+    )?))
+}
+
+fn install_prepared_pane_frame(pane: &mut PaneView, frame: Option<SnapshotFrame>) {
+    if let Some(frame) = frame {
+        pane.snapshot_frame = Some(frame);
+        finish_rebuilt_pane_frame(pane);
+    }
+}
+
 fn rebuild_pane_scaled_frame_with_context(
     pane: &mut PaneView,
     scale_120: u32,
@@ -1752,6 +1775,11 @@ fn rebuild_inactive_frames_with_context(
         }
     }
     Ok(rebuilt)
+}
+
+struct PreparedTabFontFrames {
+    focused: Option<SnapshotFrame>,
+    inactive: Vec<Option<SnapshotFrame>>,
 }
 
 struct CachedFrameTitle {
@@ -5632,6 +5660,106 @@ impl App {
         Ok(rebuilt)
     }
 
+    fn reconcile_font_generation(&mut self, update: FontUpdate) -> Result<bool> {
+        let mut candidate_context = self.presentation.render_context.clone();
+        if !candidate_context.replace_font_generation(update.generation) {
+            return Ok(false);
+        }
+
+        let focused = if let Some(mut display) = self.panes.display_snapshot() {
+            apply_ime_preedit(&mut display, self.input.ime.visible_preedit.as_deref());
+            Some(SnapshotFrame::load_scaled_with_sources_and_context(
+                &display,
+                self.surface.scale_120,
+                Some(&self.panes.pane.image_sources),
+                &candidate_context,
+            )?)
+        } else {
+            None
+        };
+        let inactive = self
+            .panes
+            .inactive_panes
+            .iter()
+            .map(|pane| {
+                prepare_pane_scaled_frame_with_context(
+                    pane,
+                    self.surface.scale_120,
+                    &candidate_context,
+                )
+            })
+            .collect::<Result<Vec<_>>>()?;
+        let hidden = self
+            .tab_state
+            .tabs
+            .iter()
+            .map(|tab| {
+                let Some(view) = tab.value.as_ref() else {
+                    return Ok(None);
+                };
+                let focused = prepare_pane_scaled_frame_with_context(
+                    &view.pane,
+                    self.surface.scale_120,
+                    &candidate_context,
+                )?;
+                let inactive = view
+                    .inactive_panes
+                    .iter()
+                    .map(|pane| {
+                        prepare_pane_scaled_frame_with_context(
+                            pane,
+                            self.surface.scale_120,
+                            &candidate_context,
+                        )
+                    })
+                    .collect::<Result<Vec<_>>>()?;
+                Ok(Some(PreparedTabFontFrames { focused, inactive }))
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        self.presentation.render_context = candidate_context;
+        install_prepared_pane_frame(&mut self.panes.pane, focused);
+        for (pane, frame) in self.panes.inactive_panes.iter_mut().zip(inactive) {
+            install_prepared_pane_frame(pane, frame);
+        }
+        for (tab, prepared) in self.tab_state.tabs.iter_mut().zip(hidden) {
+            let (Some(view), Some(prepared)) = (tab.value.as_mut(), prepared) else {
+                continue;
+            };
+            install_prepared_pane_frame(&mut view.pane, prepared.focused);
+            for (pane, frame) in view.inactive_panes.iter_mut().zip(prepared.inactive) {
+                install_prepared_pane_frame(pane, frame);
+            }
+            view.frame_titles.clear();
+            view.dirty_inactive_panes.clear();
+        }
+        clear_snapshot_caches();
+        self.presentation.renderer_generation =
+            self.presentation.renderer_generation.saturating_add(1);
+        self.presentation.frame_titles.clear();
+        self.modal.session_picker_text_cache.clear();
+        self.modal.command_palette_text_cache.clear();
+        self.modal.dojo_prompt_text_cache.clear();
+        self.modal.tab_context_menu_text_cache.clear();
+        self.tab_state.tab_label_cache.clear();
+        self.tab_state.tab_close_text = None;
+        self.tab_state.tab_new_text = None;
+        self.modal.session_picker_layout = None;
+        self.modal.command_palette_layout = None;
+        self.modal.dojo_prompt_layout = None;
+        self.modal.tab_context_menu_layout = None;
+        self.surface.buffers.clear();
+        self.surface.backing.clear();
+        self.presentation.full_redraw = true;
+        self.input.cursor_blink_visible = true;
+        self.input.last_cursor_blink = Instant::now();
+        self.update_ime_cursor_rectangle();
+        if self.surface.configured {
+            self.emit_font_resize()?;
+        }
+        Ok(true)
+    }
+
     fn toggle_tab_strip(&mut self) -> Result<bool> {
         if !self.tab_state.managed_tabs {
             return Ok(false);
@@ -6765,6 +6893,44 @@ impl App {
         Ok(())
     }
 
+    fn emit_font_resize(&mut self) -> Result<()> {
+        let layout = self.computed_pane_layout()?;
+        let active_rect = self
+            .panes
+            .focused_splint()
+            .and_then(|splint_id| layout.as_ref().and_then(|layout| layout.rect(splint_id)));
+        let content = self.content_rect();
+        let (active_width, active_height) = active_rect
+            .map_or((content.width, content.height), |rect| {
+                (rect.width, rect.height)
+            });
+        let active = self.panes.pane.controller_active;
+        Self::emit_pane_resize(
+            &mut self.panes.pane,
+            active_width,
+            active_height,
+            self.surface.scale_120,
+            active,
+        )?;
+        for pane in &mut self.panes.inactive_panes {
+            let Some(splint_id) = pane.snapshot.as_ref().map(|snapshot| snapshot.splint_id) else {
+                continue;
+            };
+            let Some(rect) = layout.as_ref().and_then(|layout| layout.rect(splint_id)) else {
+                continue;
+            };
+            let active = pane.controller_active;
+            Self::emit_pane_resize(
+                pane,
+                rect.width,
+                rect.height,
+                self.surface.scale_120,
+                active,
+            )?;
+        }
+        Ok(())
+    }
+
     fn emit_active_pane_resize(
         pane: &mut PaneView,
         logical_width: u32,
@@ -7532,6 +7698,7 @@ impl App {
         let mut full_frame_reload = false;
         let mut rebuild_all_inactive = false;
         let mut effect_desired_changed = false;
+        let mut font_reconciled = false;
         if let Some(update) = next_theme {
             if inline_picker_open {
                 retain_newest_theme(&mut self.modal.deferred_picker_theme, update);
@@ -7950,6 +8117,22 @@ impl App {
                 }
             }
         }
+        if let Some(update) = self.presentation.pending_font_update.take() {
+            match self.reconcile_font_generation(update) {
+                Ok(true) => {
+                    font_reconciled = true;
+                    visual_changed = true;
+                    focused_visual_changed = true;
+                    self.presentation.full_redraw = true;
+                }
+                Ok(false) => {}
+                Err(error) => {
+                    eprintln!(
+                        "splinterm live font update rejected during frame reconciliation: {error:#}"
+                    );
+                }
+            }
+        }
         if !self.panes.pending_exited_splints.is_empty() {
             let topology_queue_open =
                 self.tab_state
@@ -8111,7 +8294,8 @@ impl App {
             }
             self.refresh_ime_preedit()?;
             self.update_ime_cursor_rectangle();
-            if !self.modal.inline_picker_open()
+            if !font_reconciled
+                && !self.modal.inline_picker_open()
                 && !self.modal.session_picker_reconcile_pending
                 && terminal_resize_allowed(
                     TerminalResizeCause::SnapshotAvailable,
@@ -11337,6 +11521,33 @@ mod tests {
         let first = command_receiver.try_recv().unwrap();
         assert!(matches!(first, WindowCommand::Resize { .. }));
         App::emit_pane_resize(&mut pane, 320, 240, SCALE_DENOMINATOR, true).unwrap();
+        assert!(command_receiver.try_recv().is_err());
+    }
+
+    #[test]
+    fn observer_font_resize_prepares_without_claiming_control() {
+        let splint_id = SplintId::new();
+        let (_updates, update_receiver) = tokio::sync::mpsc::channel(1);
+        let (commands, mut command_receiver) = tokio::sync::mpsc::channel(2);
+        let mut pane = PaneView::from_options(
+            WindowPaneOptions {
+                snapshot: valid_snapshot(splint_id),
+                terminal_grid_limits: TerminalGridLimits::default(),
+                updates: update_receiver,
+                commands,
+                authority: AuthorityStatus::default(),
+                controlled: false,
+                image_sources: ImageContentLeaseSet::default(),
+            },
+            SCALE_DENOMINATOR,
+        )
+        .unwrap();
+        App::emit_pane_resize(&mut pane, 320, 240, SCALE_DENOMINATOR, false).unwrap();
+        assert!(matches!(
+            command_receiver.try_recv().unwrap(),
+            WindowCommand::PrepareResize { .. }
+        ));
+        App::emit_pane_resize(&mut pane, 320, 240, SCALE_DENOMINATOR, false).unwrap();
         assert!(command_receiver.try_recv().is_err());
     }
 

--- a/crates/splinterm/src/wayland/tabs.rs
+++ b/crates/splinterm/src/wayland/tabs.rs
@@ -275,7 +275,7 @@ impl DojoTabView {
                     }
                     continue;
                 }
-                if matches!(update, WindowUpdate::Theme(_)) {
+                if matches!(update, WindowUpdate::Theme(_) | WindowUpdate::Font(_)) {
                     continue;
                 }
                 let splint_id = pane.snapshot.as_ref().map(|snapshot| snapshot.splint_id);

--- a/docs/adr/0004-font-and-cpu-renderer.md
+++ b/docs/adr/0004-font-and-cpu-renderer.md
@@ -121,12 +121,16 @@ Renderer ownership is explicit. `RendererResources` holds immutable
 process-wide sizing, padding, and renderer options. Every graphical Window owns
 one mutable `RenderContext` containing its output DPI, font zoom, background
 alpha, and an `Arc` to one immutable `FontGeneration`. A generation owns the
-complete resolved regular/bold/italic/bold-italic and fallback set, source
-fingerprints, and bounded sealed byte snapshots used by both Swash and the safe
-FreeType wrapper. Prepared frames retain their generation and capture their
-context-dependent metrics and alpha, so composition and deterministic capture
-do not consult ambient mutable state. Glyph and raster-face cache keys include
-the generation identity; incremental refresh rejects a generation mismatch.
+complete resolved regular/bold/italic/bold-italic and ordered fallback metadata,
+source fingerprints, and bounded sealed byte snapshots for the primary, CJK,
+and emoji faces used by both Swash and the safe FreeType wrapper. Dynamic
+fallback mappings remain lazy and bounded to 24 entries; their cache identity
+includes the resolved source identity so a same-path font replacement cannot
+reuse bytes from an older generation. Prepared frames retain their generation
+and capture their context-dependent metrics and alpha, so composition and
+deterministic capture do not consult ambient mutable state. Glyph and
+raster-face cache keys include the generation identity; incremental refresh
+rejects a generation mismatch.
 Existing public configuration and capture signatures retain a separate
 compatibility context, but production Wayland rendering uses explicit context
 paths. Bounded native FreeType handles remain renderer-thread-local and are

--- a/docs/adr/0004-font-and-cpu-renderer.md
+++ b/docs/adr/0004-font-and-cpu-renderer.md
@@ -138,13 +138,15 @@ cleared at successful generation publication; old bytes remain alive only while
 an old prepared frame still retains its generation.
 
 When `main.font` is unset, the client treats fontconfig `monospace` as native
-Omarchy family authority and probes complete effective source identities on a
-bounded interval. Resolution, immutable snapshotting, parsing, metric checks,
-and stable double-resolution run off Tokio and Wayland dispatch paths. A valid
-candidate is fully prepared for active, inactive, and hidden panes before one
-callback-boundary publication. Failure leaves the active generation in place.
-Explicit `main.font` disables this watcher. The startup-only documented
-JetBrains fallback is not available during live updates.
+Omarchy family authority and probes complete effective source identities every
+ten seconds after an initial ten-second delay. This bounds idle Fontconfig
+subprocess churn while retaining live following. Resolution, immutable
+snapshotting, parsing, metric checks, and stable double-resolution run off Tokio
+and Wayland dispatch paths. A valid candidate is fully prepared for active,
+inactive, and hidden panes before one callback-boundary publication. Failure
+leaves the active generation in place. Explicit `main.font` disables this
+watcher. The startup-only documented JetBrains fallback is not available during
+live updates.
 
 Release budgets are enforced by `tools/performance/phase9-thresholds.json`.
 Notable limits are 10/300 ms full-paint p95 at 80×24/240×80, 1/10 ms one-row

--- a/docs/adr/0004-font-and-cpu-renderer.md
+++ b/docs/adr/0004-font-and-cpu-renderer.md
@@ -1,7 +1,8 @@
 # ADR 0004: Use narrow fontconfig discovery with Swash and CPU SHM rendering
 
-- **Status:** Accepted — Phase 8.1 renderer and oracle policy closed
+- **Status:** Accepted — Phase 8.1 renderer and oracle policy closed; live font-generation amendment accepted
 - **Date:** 2026-07-18
+- **Amended:** 2026-08-29
 
 ## Context
 
@@ -117,15 +118,29 @@ cache keys or invalidation; cold/warm and full/damage/scroll-copy paths must
 produce identical pixels.
 
 Renderer ownership is explicit. `RendererResources` holds immutable
-process-wide renderer options and font configuration. Every graphical Window
-owns one mutable `RenderContext` containing its output DPI, font zoom, and
-background alpha. Prepared frames capture their context-dependent metrics and
-alpha, so composition and deterministic capture do not consult ambient mutable
-state. Existing public configuration and capture signatures retain a separate
+process-wide sizing, padding, and renderer options. Every graphical Window owns
+one mutable `RenderContext` containing its output DPI, font zoom, background
+alpha, and an `Arc` to one immutable `FontGeneration`. A generation owns the
+complete resolved regular/bold/italic/bold-italic and fallback set, source
+fingerprints, and bounded sealed byte snapshots used by both Swash and the safe
+FreeType wrapper. Prepared frames retain their generation and capture their
+context-dependent metrics and alpha, so composition and deterministic capture
+do not consult ambient mutable state. Glyph and raster-face cache keys include
+the generation identity; incremental refresh rejects a generation mismatch.
+Existing public configuration and capture signatures retain a separate
 compatibility context, but production Wayland rendering uses explicit context
-paths. Immutable resolved font faces remain process-wide; bounded glyph and
-raster-face caches remain renderer-thread-local so native FreeType handles are
-not made `Send` or `Sync`.
+paths. Bounded native FreeType handles remain renderer-thread-local and are
+cleared at successful generation publication; old bytes remain alive only while
+an old prepared frame still retains its generation.
+
+When `main.font` is unset, the client treats fontconfig `monospace` as native
+Omarchy family authority and probes complete effective source identities on a
+bounded interval. Resolution, immutable snapshotting, parsing, metric checks,
+and stable double-resolution run off Tokio and Wayland dispatch paths. A valid
+candidate is fully prepared for active, inactive, and hidden panes before one
+callback-boundary publication. Failure leaves the active generation in place.
+Explicit `main.font` disables this watcher. The startup-only documented
+JetBrains fallback is not available during live updates.
 
 Release budgets are enforced by `tools/performance/phase9-thresholds.json`.
 Notable limits are 10/300 ms full-paint p95 at 80×24/240×80, 1/10 ms one-row
@@ -168,7 +183,11 @@ focus-safe history, and application-keypad text input.
 - CPU SHM rendering remains the baseline; a future GPU renderer must preserve
   the same cell, fallback, shaping, and damage semantics.
 - Glyph caches are invalidated and rerasterized when physical scale or font
-  identity changes.
+  identity changes; generation-keyed entries cannot cross a live family swap.
+- A live family swap preserves Window size, configured font size and policy,
+  padding, output DPI, runtime zoom, modal and IME state, topology, focus, and
+  history. Existing controller authority may emit one final changed PTY size;
+  observers do not acquire control for font reconciliation.
 - Full-window blend is fast for the current evidence row, but terminal rendering
   must consume semantic damage rather than repaint large windows continuously.
 - Fontconfig process startup is acceptable for the first client slice but may be

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -9,7 +9,7 @@ default path is `${XDG_CONFIG_HOME:-~/.config}/splinterm/config.ini`; set
 
 | Section/key | Meaning | Range/default |
 | --- | --- | --- |
-| `main.font` | fontconfig pattern | JetBrains Mono Nerd Font Regular |
+| `main.font` | explicit fontconfig pattern; when unset, follow Omarchy's effective `monospace` family | unset |
 | `main.font-pixelsize` | configured pixel font size | 6–96; 14 |
 | `main.font-point-size` | mutually exclusive point-size alternative | 6–96; unset |
 | `main.font-size` | deprecated alias for `main.font-pixelsize` | unset |
@@ -39,7 +39,26 @@ outside terminal hit-testing, and emits one bounded `grid_capped` diagnostic for
 the pane instead of silently treating the residual as terminal cells.
 
 Malformed supported values fail startup. Unknown sections and keys print
-line-numbered diagnostics. By default, palette roles come directly from the
+line-numbered diagnostics. When `main.font` is unset, each graphical client
+follows fontconfig's effective `monospace` family and watches that complete
+regular/bold/italic/bold-italic plus CJK/emoji generation for live changes. An
+explicit `main.font` remains authoritative and disables native live family
+following, including when its literal value is `monospace`. Native startup tries
+the documented JetBrains Mono Nerd Font pattern only if initial `monospace`
+resolution fails, then fails startup if that fallback is also unavailable; a
+live-update failure never switches to the fallback and retains the complete last
+valid generation.
+
+A valid native family change preserves configured size and sizing policy,
+padding, output DPI, runtime zoom, topology, focus, history and copy-mode
+anchors, modal input, visible IME preedit, and running processes. Splinterm
+stages immutable bounded font bytes off the Wayland dispatch path, publishes all
+faces atomically, rebuilds active and hidden pane frames, and lets only an
+existing pane controller issue the final PTY resize. Observer panes prepare a
+future size without acquiring control. Font changes do not imply live reload of
+font size, padding, shell, scrollback, cursor, or keymap settings.
+
+By default, palette roles come directly from the
 active Omarchy theme's `colors.toml` and effective `foot.ini`; `[colors] alpha`
 and `[colors] blur` are explicit user overrides. Whichever alpha source wins follows Foot's default
 alpha mode: only cells whose background source is default are translucent;

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -52,8 +52,9 @@ valid generation.
 A valid native family change preserves configured size and sizing policy,
 padding, output DPI, runtime zoom, topology, focus, history and copy-mode
 anchors, modal input, visible IME preedit, and running processes. Splinterm
-stages immutable bounded font bytes off the Wayland dispatch path, publishes all
-faces atomically, rebuilds active and hidden pane frames, and lets only an
+stages immutable bounded primary, CJK, and emoji font bytes plus ordered
+fallback metadata off the Wayland dispatch path, publishes the generation
+atomically, rebuilds active and hidden pane frames, and lets only an
 existing pane controller issue the final PTY resize. Observer panes prepare a
 future size without acquiring control. Font changes do not imply live reload of
 font size, padding, shell, scrollback, cursor, or keymap settings.

--- a/docs/product-roadmap.md
+++ b/docs/product-roadmap.md
@@ -97,7 +97,8 @@ work only through explicit bounded authority.
 - Make Lair and Dojo lifecycle intentional: named, pinned, disposable,
   restorable, and expired work should be recognizable and manageable.
 - Finish the fit-and-finish gaps that make the terminal feel native to Omarchy,
-  including exact theme fidelity and supported desktop integration.
+  including exact theme fidelity, live native system-font following, and
+  supported desktop integration.
 - Improve ordinary desktop workflows such as inserting local file and saved
   image paths without weakening terminal input or privacy boundaries.
 - Turn the existing CLI, SSH, and MCP capability into understandable user and

--- a/docs/status.md
+++ b/docs/status.md
@@ -55,6 +55,10 @@ and hidden presentation state while preserving configured size/policy, padding,
 DPI, runtime zoom, topology, focus, history, modal input, and IME preedit.
 Explicit `main.font` disables native following. Invalid live candidates retain
 the last valid generation, and observer panes do not acquire control to resize.
+Fontconfig named instances remain selected through shaping and rasterization;
+ambient probes and deferred resize retries are bounded. Accepted staging stays
+synchronized with probe state, and cached raster faces share immutable font
+mappings across sizes instead of copying complete files.
 
 Focused renderer, watcher, cache-generation, source-replacement, geometry, and
 resize-authority tests pass. This unreleased source state does **not** yet claim

--- a/docs/status.md
+++ b/docs/status.md
@@ -45,6 +45,22 @@ not current compatibility promises. Headless `splinterd` does not require a
 graphical environment, but its packaged and remote workflows remain beta
 interfaces on the documented platform.
 
+## Unreleased main
+
+Current `main` contains the non-graphical implementation for live native
+Omarchy system-font synchronization. When `main.font` is unset, a graphical
+client follows the effective fontconfig `monospace` family, stages complete
+immutable face generations off dispatch paths, and atomically rebuilds active
+and hidden presentation state while preserving configured size/policy, padding,
+DPI, runtime zoom, topology, focus, history, modal input, and IME preedit.
+Explicit `main.font` disables native following. Invalid live candidates retain
+the last valid generation, and observer panes do not acquire control to resize.
+
+Focused renderer, watcher, cache-generation, source-replacement, geometry, and
+resize-authority tests pass. This unreleased source state does **not** yet claim
+installed-package or guarded graphical acceptance; Beta 2 remains the latest
+published package authority.
+
 ## Beta 2 release
 
 [`v0.1.0-beta2`](https://github.com/OldJobobo/splinterm/releases/tag/v0.1.0-beta2)

--- a/tools/foot-oracle/README.md
+++ b/tools/foot-oracle/README.md
@@ -326,8 +326,9 @@ exact bytes at 1×, 1.25×, 1.5×, and 2×.
 
 ### Slice 4 face/size/scale matrix
 
-`run-font-matrix.py` compares pinned fcft against the isolated FreeType bridge
-and production glyph cache for regular, bold, italic, and bold italic faces;
+`run-font-matrix.py` first requires the exact pinned-host provenance, then
+compares pinned fcft against the isolated FreeType bridge and production glyph
+cache for regular, bold, italic, and bold italic faces;
 logical sizes 6, 12, 22, 32, 48, and 96 px; and scales 1×, 1.25×, 1.5×, and 2×.
 Every cell records the resolved face file, index, SHA-256, logical size, scale,
 and effective fractional 26.6 size. Metrics, decorations, advances, placement,
@@ -340,7 +341,7 @@ exact metrics, placement, dimensions, ink, and mask bytes; production shaping
 compares advance strictly.
 
 ```bash
-# One portable smoke cell
+# One pinned-host smoke cell
 tools/foot-oracle/run-font-matrix.py \
   /tmp/splinterm-font-smoke --case regular-6px-120
 

--- a/tools/foot-oracle/check-provenance.py
+++ b/tools/foot-oracle/check-provenance.py
@@ -139,22 +139,45 @@ def check_versions(manifest: dict[str, Any]) -> None:
         raise ProvenanceError("cargo version drifted")
 
 
+def font_remediation(font: dict[str, Any]) -> str:
+    package = (
+        "ttf-jetbrains-mono-nerd"
+        if "JetBrainsMonoNerdFont" in font["file"]
+        else "the package containing the pinned font"
+    )
+    return (
+        f"provision the exact pinned file (Omarchy/Arch: install {package}), "
+        "then run 'fc-cache --force'"
+    )
+
+
 def check_fonts(manifest: dict[str, Any]) -> None:
     for font in manifest["fonts"]:
         output = command_output(
             ["fc-match", "-f", "%{file}\n%{index}\n", font["pattern"]]
         ).splitlines()
         if len(output) < 2:
-            raise ProvenanceError(f"fontconfig did not resolve {font['role']}")
+            raise ProvenanceError(
+                f"fontconfig did not resolve pinned {font['role']} face; "
+                f"expected {font['file']} index {font['index']}; "
+                f"{font_remediation(font)}"
+            )
         path = pathlib.Path(output[0])
         try:
             index = int(output[1])
         except ValueError as error:
             raise ProvenanceError(f"invalid face index for {font['role']}") from error
         if str(path) != font["file"] or index != font["index"]:
-            raise ProvenanceError(f"resolved {font['role']} face drifted")
+            raise ProvenanceError(
+                f"resolved {font['role']} face drifted: expected "
+                f"{font['file']} index {font['index']}, got {path} index {index}; "
+                f"{font_remediation(font)}"
+            )
         if not path.is_file() or sha256(path) != font["sha256"]:
-            raise ProvenanceError(f"resolved {font['role']} font bytes drifted")
+            raise ProvenanceError(
+                f"resolved {font['role']} font bytes drifted at {path}; "
+                f"expected SHA-256 {font['sha256']}; {font_remediation(font)}"
+            )
 
 
 def check_environment(manifest: dict[str, Any]) -> None:

--- a/tools/foot-oracle/provenance.json
+++ b/tools/foot-oracle/provenance.json
@@ -59,7 +59,7 @@
   "rust": {
     "rustc": "1.91.0",
     "cargo": "1.91.0",
-    "cargo_lock_sha256": "39df189773888b6d84cdbf2aa15f11a5381a60abef776ea9e6e2d72dc7e79b62",
+    "cargo_lock_sha256": "64813433e7f92f30ba6ca75075844d69d89af76e34c0ed3949d8c8d364d1fe22",
     "dependencies": {
       "fontdb": "0.23.0",
       "freetype-rs": "0.38.0",
@@ -112,7 +112,7 @@
     },
     "foreground": "ebebeb",
     "background": "0e1216",
-    "cargo_lock_sha256": "39df189773888b6d84cdbf2aa15f11a5381a60abef776ea9e6e2d72dc7e79b62"
+    "cargo_lock_sha256": "64813433e7f92f30ba6ca75075844d69d89af76e34c0ed3949d8c8d364d1fe22"
   },
   "semantic_fixture_schema": "fixtures/terminal/v1/schema.md",
   "final_buffer_schema": "tools/foot-oracle/final-buffer-schema.md",

--- a/tools/foot-oracle/provenance.json
+++ b/tools/foot-oracle/provenance.json
@@ -59,7 +59,7 @@
   "rust": {
     "rustc": "1.91.0",
     "cargo": "1.91.0",
-    "cargo_lock_sha256": "6589c2b0f80313ceb520ca4bf35bd7b59cc553549364ebebc2dfe1ab74d1cd00",
+    "cargo_lock_sha256": "39df189773888b6d84cdbf2aa15f11a5381a60abef776ea9e6e2d72dc7e79b62",
     "dependencies": {
       "fontdb": "0.23.0",
       "freetype-rs": "0.38.0",
@@ -112,7 +112,7 @@
     },
     "foreground": "ebebeb",
     "background": "0e1216",
-    "cargo_lock_sha256": "6589c2b0f80313ceb520ca4bf35bd7b59cc553549364ebebc2dfe1ab74d1cd00"
+    "cargo_lock_sha256": "39df189773888b6d84cdbf2aa15f11a5381a60abef776ea9e6e2d72dc7e79b62"
   },
   "semantic_fixture_schema": "fixtures/terminal/v1/schema.md",
   "final_buffer_schema": "tools/foot-oracle/final-buffer-schema.md",

--- a/tools/foot-oracle/run-font-matrix.py
+++ b/tools/foot-oracle/run-font-matrix.py
@@ -80,6 +80,11 @@ def require_success(result: subprocess.CompletedProcess[str], label: str) -> Non
         raise RuntimeError(f"{label} failed: {detail}")
 
 
+def require_pinned_host() -> None:
+    result = run([sys.executable, TOOLS / "check-provenance.py"])
+    require_success(result, "pinned Foot oracle prerequisite check")
+
+
 def records_by_label(path: Path) -> dict[str, dict[str, Any]]:
     records: dict[str, dict[str, Any]] = {}
     for line in path.read_text(encoding="utf-8").splitlines():
@@ -298,8 +303,13 @@ def main() -> int:
     parser.add_argument("output", type=Path)
     parser.add_argument("--case", choices=[case.identifier for case in matrix_cases()])
     args = parser.parse_args()
-    args.output.mkdir(parents=True, exist_ok=False)
+    try:
+        require_pinned_host()
+    except (OSError, RuntimeError) as error:
+        print(f"font matrix prerequisites unavailable: {error}", file=sys.stderr)
+        return 1
 
+    args.output.mkdir(parents=True, exist_ok=False)
     selected = [case for case in matrix_cases() if args.case in (None, case.identifier)]
     build = run(
         [

--- a/tools/foot-oracle/test_check_provenance.py
+++ b/tools/foot-oracle/test_check_provenance.py
@@ -53,6 +53,33 @@ def test_lock_drift_names_the_atomic_refresh_command(monkeypatch):
         checker.check_repository_files(manifest)
 
 
+def test_font_drift_reports_exact_jetbrains_prerequisite(monkeypatch):
+    checker = load_checker()
+    manifest = {
+        "fonts": [
+            {
+                "role": "regular",
+                "pattern": "JetBrains Mono Nerd Font:style=Regular",
+                "file": "/usr/share/fonts/TTF/JetBrainsMonoNerdFont-Regular.ttf",
+                "index": 0,
+                "sha256": "0" * 64,
+            }
+        ]
+    }
+    monkeypatch.setattr(
+        checker,
+        "command_output",
+        lambda _arguments: "/usr/share/fonts/maple/MapleMono-Regular.ttf\n0",
+    )
+    with pytest.raises(checker.ProvenanceError) as failure:
+        checker.check_fonts(manifest)
+    message = str(failure.value)
+    assert "expected /usr/share/fonts/TTF/JetBrainsMonoNerdFont-Regular.ttf index 0" in message
+    assert "got /usr/share/fonts/maple/MapleMono-Regular.ttf index 0" in message
+    assert "ttf-jetbrains-mono-nerd" in message
+    assert "fc-cache --force" in message
+
+
 def test_non_reference_worker_is_an_explicit_unsupported_host(monkeypatch):
     checker = load_checker()
     manifest = checker.load_manifest()

--- a/tools/foot-oracle/test_run_font_matrix.py
+++ b/tools/foot-oracle/test_run_font_matrix.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import importlib.util
+import subprocess
 import sys
 from pathlib import Path
 
@@ -31,6 +32,40 @@ def test_effective_sizes_preserve_fractional_scale_boundaries() -> None:
     assert cases["regular-6px-150"].effective_size == 7.5
     assert cases["italic-22px-180"].effective_size == 33.0
     assert cases["bold-italic-96px-240"].effective_size == 192.0
+
+
+def test_pinned_host_preflight_invokes_strict_provenance(monkeypatch) -> None:
+    calls = []
+
+    def fake_run(command, **_kwargs):
+        calls.append(command)
+        return subprocess.CompletedProcess(command, 0, "", "")
+
+    monkeypatch.setattr(MATRIX, "run", fake_run)
+    MATRIX.require_pinned_host()
+    assert calls == [[sys.executable, MATRIX.TOOLS / "check-provenance.py"]]
+
+
+def test_failed_preflight_stops_before_creating_output(
+    monkeypatch, capsys, tmp_path: Path
+) -> None:
+    output = tmp_path / "matrix"
+
+    def failed_run(command, **_kwargs):
+        return subprocess.CompletedProcess(
+            command,
+            1,
+            "",
+            "provenance error: resolved regular face drifted; install fixture",
+        )
+
+    monkeypatch.setattr(MATRIX, "run", failed_run)
+    monkeypatch.setattr(sys, "argv", [str(MODULE_PATH), str(output)])
+    assert MATRIX.main() == 1
+    assert not output.exists()
+    captured = capsys.readouterr()
+    assert "font matrix prerequisites unavailable" in captured.err
+    assert "resolved regular face drifted" in captured.err
 
 
 def test_progress_summary_is_truthful(tmp_path: Path) -> None:


### PR DESCRIPTION
## Problem

New Splinterm windows followed Omarchy's current Fontconfig monospace family, but existing windows did not adopt later system-font changes. The implementation also needed atomic generation ownership, safe cache invalidation, controller-only resize reconciliation, variable-font index preservation, bounded polling/retries, and clear separation between ordinary tests and the pinned Foot oracle.

## Changes

- represent explicit versus native font authority and watch effective Fontconfig source identities
- stage immutable complete font generations off dispatch paths and publish them atomically
- rebuild active, inactive, and hidden pane presentation while preserving zoom, DPI, topology, focus, history, modal, and IME state
- keep PTY resize authority controller-only and bound deferred retries and ambient probes
- preserve Fontconfig named variable-font instances through shaping and FreeType rasterization
- share immutable mapped font bytes across raster sizes and fix accepted-stage/probe synchronization
- document the unreleased live-font contract without importing RC2 maintenance metadata
- make ordinary renderer tests use host monospace only when Fontconfig positively confirms the pinned default is absent
- make the exact Foot matrix fail once, before build/output, when strict pinned-host provenance is unavailable; add actionable font remediation

## Validation

- 410 `splinterm` library tests passed; 6 expected manual/host-dependent ignores
- all 111 `splinterm` binary tests passed
- all 46 Foot-oracle Python tests passed
- focused watcher, generation, mapping, raster-cache, variable-index, renderer, geometry, and resize tests passed
- workspace compile and strict workspace all-target/all-feature Clippy passed
- formatting, Python compile, portable provenance, and `git diff --check` passed
- independent complete-forward-port review: ACCEPT, no findings
- independent oracle-boundary review findings corrected; focused verification: ACCEPT

## Remaining gates

The source and non-graphical boundary is complete. Exact renderer comparison still requires the pinned Foot/fontconfig/FreeType/font environment, and packaged graphical live-change plus invalid-candidate rollback remain separately approval-gated. No reference images, tolerances, pinned hashes, package versions, or publication metadata are changed here.
