### PR TITLE
Make Splinterm contracts RC2 release authority

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,24 +84,3 @@ jobs:
           elif [ "$status" -ne 0 ]; then
             exit "$status"
           fi
-
-  oracle:
-    name: Optional pinned-host Foot differential
-    if: ${{ vars.SPLINTERM_ORACLE_RUNNER == 'enabled' }}
-    continue-on-error: true
-    runs-on: [self-hosted, linux, x64, splinterm-oracle]
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@v4
-      - name: Require exact pinned-host provenance
-        run: python tools/foot-oracle/check-provenance.py
-      - name: Run strict default raster smoke
-        run: python tools/foot-oracle/run-font-matrix.py /tmp/splinterm-oracle-ci --case regular-12px-120
-      - name: Upload reviewable failure evidence
-        if: ${{ failure() }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: splinterm-oracle-failure
-          path: /tmp/splinterm-oracle-ci
-          if-no-files-found: warn

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,14 +55,24 @@ jobs:
             tools/release/test_promote_release_workflow.py
       - run: cargo clippy --workspace --all-targets -- -D warnings
       - run: cargo test --workspace -- --test-threads=1
+      - run: python -m pip install 'jsonschema>=4.18' pillow pytest referencing
+      - run: python tools/benchmark/generate-semantic-fixture-vectors.py --check
+      - run: python tools/foot-oracle/validate-fixtures.py
+      - run: python tools/automation/validate-contract-fixtures.py
+      - run: python -m pytest -q tools/benchmark/test_benchmark.py
+
+  foot-reference:
+    name: Optional historical Foot differential tooling
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: python -m pip install 'jsonschema>=4.18' pillow pytest referencing
       - run: python tools/foot-oracle/check-provenance.py --portable
       - run: python tools/foot-oracle/validate-fixtures.py
       - run: python tools/foot-oracle/validate-slice3-fixtures.py
       - run: python tools/foot-oracle/validate-slice3-fixtures.py tools/foot-oracle/slice4-final-buffer-fixtures.json
-      - run: python -m pip install 'jsonschema>=4.18' pillow pytest referencing
-      - run: python tools/automation/validate-contract-fixtures.py
       - run: python -m pytest -q tools/foot-oracle/test_*.py
-      - run: python -m pytest -q tools/benchmark/test_benchmark.py
       - name: Classify host-sensitive raster support
         run: |
           set +e
@@ -70,13 +80,15 @@ jobs:
           status=$?
           set -e
           if [ "$status" -eq 77 ]; then
-            echo '::notice title=Unsupported raster environment::Pinned Foot raster tests require the declared Omarchy reference host.'
+            echo '::notice title=Unsupported raster environment::Historical Foot differentials require the declared Omarchy reference host.'
           elif [ "$status" -ne 0 ]; then
             exit "$status"
           fi
 
   oracle:
+    name: Optional pinned-host Foot differential
     if: ${{ vars.SPLINTERM_ORACLE_RUNNER == 'enabled' }}
+    continue-on-error: true
     runs-on: [self-hosted, linux, x64, splinterm-oracle]
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,7 @@ jobs:
       - run: python tools/foot-oracle/validate-fixtures.py
       - run: python tools/automation/validate-contract-fixtures.py
       - run: python -m pytest -q tools/benchmark/test_benchmark.py
+      - run: python -m pytest -q tools/foot-oracle/test_run_final_buffer_comparison.py
 
   foot-reference:
     name: Optional historical Foot differential tooling

--- a/.github/workflows/foot-oracle-pinned.yml
+++ b/.github/workflows/foot-oracle-pinned.yml
@@ -1,0 +1,34 @@
+name: Optional pinned-host Foot differential
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "37 4 * * 0"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: foot-oracle-pinned
+  cancel-in-progress: false
+
+jobs:
+  oracle:
+    name: Pinned-host Foot differential
+    if: ${{ vars.SPLINTERM_ORACLE_RUNNER == 'enabled' }}
+    runs-on: [self-hosted, linux, x64, splinterm-oracle]
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - name: Require exact pinned-host provenance
+        run: python tools/foot-oracle/check-provenance.py
+      - name: Run strict default raster smoke
+        run: python tools/foot-oracle/run-font-matrix.py /tmp/splinterm-oracle-ci --case regular-12px-120
+      - name: Upload reviewable failure evidence
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: splinterm-oracle-failure-${{ github.run_id }}
+          path: /tmp/splinterm-oracle-ci
+          if-no-files-found: warn
+          retention-days: 14

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -58,7 +58,6 @@ jobs:
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
           useradd --create-home validator
           chown -R validator:validator "$GITHUB_WORKSPACE"
-          runuser -u validator -- python tools/foot-oracle/check-provenance.py --portable
           runuser -u validator -- python -m unittest \
             tools/package/test_installer_safety.py \
             tools/package/test_omarchy_screensaver_integration.py \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -274,9 +274,11 @@ workspace 8 / DP-2 placement and no-focus isolation requirements.
 
 ## 4. Repository Safety
 
-### 4.1 Foot Oracle Authority
+### 4.1 Foot Differential Authority
 
-Preserve the pinned Foot 1.27.0 commit as the oracle authority:
+Preserve the pinned Foot 1.27.0 commit as the authority for optional Foot
+differential runs; Splinterm-owned contracts are release authority under ADR
+0013:
 
 `3c5b584b0eafa772eb4376fb6eaf6643399e190e`
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -138,13 +138,16 @@ install a package as an incidental test step.
 Use the exact commands named by the accepted plan that owns a changed subsystem.
 Do not broaden tolerances or regenerate accepted references silently.
 
-## Foot oracle and provenance
+## Optional Foot differential and provenance
 
 Foot 1.27.0 commit
-`3c5b584b0eafa772eb4376fb6eaf6643399e190e` is the terminal-behavior oracle.
-The canonical checkout and accepted comparison images are read-only authorities.
-Do not modify the checkout, translate comparison images, broadly widen pixel or
-semantic tolerances, or regenerate references without an explicit reviewed plan.
+`3c5b584b0eafa772eb4376fb6eaf6643399e190e` is the pinned historical
+differential. Splinterm-owned tests and adopted fixtures are release authority
+under [ADR 0013](docs/adr/0013-splinterm-owned-renderer-acceptance.md). The
+canonical checkout and accepted comparison images remain read-only. Do not
+modify the checkout, translate comparison images, broadly widen pixel or
+semantic tolerances, or regenerate references without an explicit reviewed
+plan.
 
 Oracle tooling and provenance live under [`tools/foot-oracle/`](tools/foot-oracle/).
 Start with its README and verify provenance before comparison work:

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -8,6 +8,18 @@ RC2 is intended for normal daily use and soak testing on the documented target:
 x86_64 Omarchy/Arch Linux with native Wayland under Hyprland. Any later code
 change requires another release candidate before the final `v0.1.0` release.
 
+## Release validation authority
+
+Splinterm-owned semantic, renderer, contract, package, and guarded graphical
+tests are now release authority. The pinned Foot 1.27.0 harness remains an exact
+optional historical differential; its host availability or provenance drift no
+longer blocks candidate construction or promotion. Existing Foot-derived
+fixtures and zero-tolerance evidence remain unchanged.
+
+The RC2 implementation at maintenance commit `d26cee9` passed guarded packaged
+live-font replacement and invalid-candidate rollback acceptance. This policy
+change does not modify shipped Rust code.
+
 ## Live-font closure fixes
 
 - A staged generation that differs from its preceding probe now becomes the

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -63,9 +63,9 @@ Terminal-centric work has several recurring failures:
 3. graphical use and automation often operate through unrelated state models;
 4. automation access is frequently either too weak to be useful or too broad to be trusted;
 5. remote access can accidentally turn a local terminal daemon into a network service; and
-6. compatibility claims can drift without a pinned behavioral authority.
+6. compatibility claims can drift without versioned, product-owned behavioral contracts.
 
-Splinterm should solve these problems with one daemon-owned topology, a native Omarchy-first interface, explicit and bounded authority, and Foot-derived terminal behavior.
+Splinterm should solve these problems with one daemon-owned topology, a native Omarchy-first interface, explicit and bounded authority, and tested terminal behavior initially informed by the pinned Foot reference.
 
 ## 4. Target users
 
@@ -117,7 +117,7 @@ They need:
 4. **Control safely:** Let multiple clients observe the same state while ensuring only one controller owns input and resize authority for a Splint at a time.
 5. **Automate explicitly:** Let authorized tools inspect and mutate terminal topology through stable machine contracts without inheriting human UI trust.
 6. **Work remotely without exposing a daemon port:** Let a human use native remote Splinterm through authenticated SSH, while separately policy-scoped automation uses the raw stdio relay.
-7. **Retain terminal compatibility:** Give me terminal behavior grounded in a pinned Foot authority rather than an undocumented approximation.
+7. **Retain terminal compatibility:** Give me terminal behavior governed by versioned Splinterm contracts and informed by a pinned Foot historical differential rather than an undocumented approximation.
 8. **Fit Omarchy naturally:** Follow the active Omarchy theme, launch through `xdg-terminal-exec`, and behave as a native Wayland application without modifying user configuration automatically.
 
 ## 6. Product principles
@@ -128,7 +128,7 @@ They need:
 4. **Disposable clients:** neither graphical nor automation clients become the source of persistent truth.
 5. **Exact targeting:** stale IDs, incarnations, revisions, or captured targets fail explicitly; operations never guess a replacement.
 6. **Terminal content is data:** output can never grant authority, approve consent, change policy, or become an automatic instruction.
-7. **Compatibility needs an oracle:** Foot 1.27.0 commit `3c5b584b0eafa772eb4376fb6eaf6643399e190e` remains the behavioral authority.
+7. **Compatibility needs owned contracts:** Splinterm-owned tests and adopted fixtures are release authority; Foot 1.27.0 commit `3c5b584b0eafa772eb4376fb6eaf6643399e190e` remains an optional historical differential.
 8. **Honest maturity:** implemented, validated, supported, proposed, deferred, and publicly released have distinct meanings.
 9. **Omarchy first, portability later:** optimize and validate the primary environment before claiming broader support.
 10. **No hidden mutation:** installation and integration do not silently change the default terminal, user keybindings, SSH policy, or Omarchy-owned files.
@@ -347,7 +347,7 @@ Detailed scope and policy behavior remain authoritative in [automation.md](autom
 
 ### 12.3 Compatibility
 
-- Foot 1.27.0 at the pinned commit is the terminal behavior and differential-test authority.
+- Splinterm-owned versioned tests and fixtures are terminal behavior and release authority; Foot 1.27.0 at the pinned commit is an optional historical differential.
 - The validated primary platform is x86_64 Arch/Omarchy with native Wayland under the documented Hyprland environment.
 - Broader compositor, distribution, Nix, sandboxed-package, or hardware claims require separate implementation and evidence.
 - Public JSON/NDJSON schemas and documented operation semantics are compatibility boundaries; private daemon frames and Rust types are not.

--- a/docs/adr/0001-foot-rust-port.md
+++ b/docs/adr/0001-foot-rust-port.md
@@ -1,7 +1,8 @@
 # ADR 0001: Foot is Splinterm's terminal foundation
 
-- **Status:** Accepted
+- **Status:** Accepted as source foundation; external release authority superseded by [ADR 0013](0013-splinterm-owned-renderer-acceptance.md)
 - **Date:** 2026-07-17
+- **Amended:** 2026-09-04
 
 ## Context
 
@@ -25,7 +26,7 @@ That architectural change does not change the source foundation.
 Splinterm's terminal engine and graphical terminal behavior will be developed
 as a Rust port of Foot.
 
-Foot is the authoritative implementation and behavioral baseline for:
+Foot is the historical implementation and differential baseline for:
 
 - VT parsing and command handling;
 - cells, grids, scrollback, resize, and reflow;
@@ -143,8 +144,8 @@ copyright and license notices, and affected files must be recorded in
 
 ### Positive
 
-- The project has a clear behavioral authority.
-- Compatibility work is measurable against a specific implementation.
+- The project has product-owned behavioral contracts with a specific historical
+  implementation available for differential measurement.
 - Existing Foot users and Omarchy integration have a defined migration target.
 - Foundational effort is not split across competing terminal engines.
 

--- a/docs/adr/0004-font-and-cpu-renderer.md
+++ b/docs/adr/0004-font-and-cpu-renderer.md
@@ -1,8 +1,8 @@
 # ADR 0004: Use narrow fontconfig discovery with Swash and CPU SHM rendering
 
-- **Status:** Accepted — Phase 8.1 renderer and oracle policy closed; live font-generation amendment accepted
+- **Status:** Accepted — renderer decisions remain current; external release authority superseded by [ADR 0013](0013-splinterm-owned-renderer-acceptance.md)
 - **Date:** 2026-07-18
-- **Amended:** 2026-08-29
+- **Amended:** 2026-09-04
 
 ## Context
 
@@ -106,16 +106,19 @@ The accepted observable tolerance is zero for every closure lane: final ARGB
 bytes, grayscale masks, cell metrics, advances, placement, four-sided ink and
 padding geometry, decoration vectors, cursor composition, renderer-path output,
 and accepted source-first scale cases. Comparators may not translate images,
-widen tolerances, or regenerate references during CI. The pinned authority is
-Foot 1.27.0 commit `3c5b584b0eafa772eb4376fb6eaf6643399e190e`.
+widen tolerances, or regenerate references during CI. The pinned historical
+reference is Foot 1.27.0 commit
+`3c5b584b0eafa772eb4376fb6eaf6643399e190e`.
 
-Strict reference generation is supported only when provenance matches the
-recorded Linux x86_64 font files/indices and hashes, fontconfig/FreeType/fcft/
-pixman versions and policy, Foot patch/build options, palette, geometry,
-scales, and Rust lockfile recorded by schema-v3
-`tools/foot-oracle/provenance.json`. Portable CI validates fixtures and tools;
-a supported reference-host drift fails rather than rewriting evidence, and an
-unsupported host is reported explicitly.
+Strict Foot reference generation remains available when output-relevant
+provenance matches the recorded Linux x86_64 font files/indices and hashes,
+fontconfig/FreeType/fcft/pixman versions and policy, Foot patch/build options,
+palette, geometry, scales, and explicit environment recorded by schema-v4
+`tools/foot-oracle/provenance.json`. Cargo-lock, compiler-version, and complete
+ambient Fontconfig-inventory identity are not comparison inputs. Under
+[ADR 0013](0013-splinterm-owned-renderer-acceptance.md), Foot is an optional
+historical differential rather than release authority; drift fails that
+optional run instead of rewriting evidence or blocking a release.
 
 The production cache policy is output-independent and bounded: 2,048 persistent
 glyph entries, 64 MiB of glyph data, 24 raster faces, and a 4,096-entry active
@@ -214,6 +217,8 @@ focus-safe history, and application-keypad text input.
 
 Maintainer-private validation records cover font discovery, initial visual,
 direct fcft-mask, style, ink-bound, release timing, and strict 95-character
-grayscale-mask parity. Public unit and oracle tests enforce deterministic
-blending, clipping, shaped placement, mask/color ink bounds, Foot-derived box
-geometry, cache reuse, and capture encoding.
+grayscale-mask parity. Public Splinterm-owned unit, integration, and adopted
+fixture tests enforce deterministic blending, clipping, shaped placement,
+mask/color ink bounds, Foot-derived box geometry, cache reuse, and capture
+encoding. Retained Foot comparisons are advisory historical differentials under
+ADR 0013.

--- a/docs/adr/0013-splinterm-owned-renderer-acceptance.md
+++ b/docs/adr/0013-splinterm-owned-renderer-acceptance.md
@@ -28,7 +28,7 @@ Splinterm-owned tests and fixtures are the renderer release authority.
 Mandatory CI and candidate construction require:
 
 - workspace tests, including terminal semantics and renderer behavior;
-- adopted source fixture vectors and contract validation;
+- adopted source fixture vectors, contract validation, and graphical workspace safety guards;
 - exact Splinterm pixel, geometry, cache, generation, and fallback regressions;
 - package and release automation; and
 - guarded packaged graphical acceptance when the changed behavior requires it.
@@ -36,8 +36,8 @@ Mandatory CI and candidate construction require:
 Foot remains a pinned **optional historical differential** at commit
 `3c5b584b0eafa772eb4376fb6eaf6643399e190e`. Its fixtures, adapter patches,
 comparators, zero-tolerance policy, and accepted evidence remain intact. The
-portable tooling job and standalone pinned-host workflow may report defects, but their
-failure or unavailability does not fail the aggregate release check and does not
+portable tooling job and standalone pinned-host workflow may report defects,
+but their failure or unavailability does not fail the aggregate release check and does not
 block candidate construction or promotion.
 
 The optional pinned-host preflight checks inputs that can directly affect the

--- a/docs/adr/0013-splinterm-owned-renderer-acceptance.md
+++ b/docs/adr/0013-splinterm-owned-renderer-acceptance.md
@@ -1,0 +1,71 @@
+# ADR 0013: Make Splinterm-owned contracts the renderer release authority
+
+- **Status:** Accepted
+- **Date:** 2026-09-04
+- **Supersedes:** The release-authority portions of [ADR 0004](0004-font-and-cpu-renderer.md)
+
+## Context
+
+Foot 1.27.0 was an effective bootstrap reference while Splinterm established its
+terminal semantics and CPU renderer. It exposed concrete compatibility defects
+and produced the source fixtures and exact raster evidence from which the current
+implementation was built.
+
+The pinned-host harness later accumulated requirements that did not themselves
+define observable renderer behavior. In particular, Cargo lockfile identity,
+Rust compiler version, and a hash of every active Fontconfig file could reject a
+run even when the selected font files, native raster stack, and compared output
+were unchanged. Requiring that environment as a release prerequisite made
+reference-host availability, rather than Splinterm behavior, a release gate.
+
+Splinterm now has source-owned semantic vectors, renderer unit and integration
+tests, exact comparators, package validation, and guarded graphical acceptance.
+Those contracts can identify product regressions directly.
+
+## Decision
+
+Splinterm-owned tests and fixtures are the renderer release authority.
+Mandatory CI and candidate construction require:
+
+- workspace tests, including terminal semantics and renderer behavior;
+- adopted source fixture vectors and contract validation;
+- exact Splinterm pixel, geometry, cache, generation, and fallback regressions;
+- package and release automation; and
+- guarded packaged graphical acceptance when the changed behavior requires it.
+
+Foot remains a pinned **optional historical differential** at commit
+`3c5b584b0eafa772eb4376fb6eaf6643399e190e`. Its fixtures, adapter patches,
+comparators, zero-tolerance policy, and accepted evidence remain intact. The
+portable tooling job and pinned-host differential may report defects, but their
+failure or unavailability does not fail the aggregate release check and does not
+block candidate construction or promotion.
+
+The optional pinned-host preflight checks inputs that can directly affect the
+comparison: the Foot revision and adapter patches; resolved font paths, face
+indexes, and hashes; Fontconfig, FreeType, fcft, and pixman versions; renderer
+policy; and explicit environment variables. It does not require Cargo.lock or a
+particular Rust compiler, because the comparison judges the produced output. It
+does not hash the complete ambient Fontconfig inventory after all resolved face
+identities have been checked.
+
+Existing fixtures marked `oracle_verified` retain that provenance, but are
+adopted as versioned Splinterm regression contracts. Their current contents do
+not become mutable expectations. Changes still require explicit review; tools
+must never translate images, widen tolerances, or silently regenerate accepted
+references.
+
+Foot should normally be rerun when a change intentionally modifies terminal
+semantics, glyph rasterization, placement, cell geometry, fallback behavior,
+decoration or cursor composition, or the accepted fixture corpus. Maintainers
+may also use it diagnostically at any time.
+
+## Consequences
+
+- Ordinary source, dependency, and release-metadata changes no longer require a
+  matching Foot host or Cargo-lock provenance refresh.
+- A Foot differential failure is useful evidence but must be triaged against the
+  Splinterm-owned contract before it can block a release.
+- Deliberate renderer changes remain subject to exact output review and guarded
+  graphical acceptance; making Foot advisory does not weaken those checks.
+- Historical evidence stays reproducible without granting an external program
+  permanent authority over Splinterm's release lifecycle.

--- a/docs/adr/0013-splinterm-owned-renderer-acceptance.md
+++ b/docs/adr/0013-splinterm-owned-renderer-acceptance.md
@@ -36,13 +36,14 @@ Mandatory CI and candidate construction require:
 Foot remains a pinned **optional historical differential** at commit
 `3c5b584b0eafa772eb4376fb6eaf6643399e190e`. Its fixtures, adapter patches,
 comparators, zero-tolerance policy, and accepted evidence remain intact. The
-portable tooling job and pinned-host differential may report defects, but their
+portable tooling job and standalone pinned-host workflow may report defects, but their
 failure or unavailability does not fail the aggregate release check and does not
 block candidate construction or promotion.
 
 The optional pinned-host preflight checks inputs that can directly affect the
 comparison: the Foot revision and adapter patches; resolved font paths, face
-indexes, and hashes; Fontconfig, FreeType, fcft, and pixman versions; renderer
+indexes and hashes; their resolved Fontconfig hinting, antialiasing, subpixel,
+and LCD-filter options; Fontconfig, FreeType, fcft, and pixman versions; renderer
 policy; and explicit environment variables. It does not require Cargo.lock or a
 particular Rust compiler, because the comparison judges the produced output. It
 does not hash the complete ambient Fontconfig inventory after all resolved face

--- a/docs/product-roadmap.md
+++ b/docs/product-roadmap.md
@@ -272,7 +272,8 @@ Across every horizon, Splinterm remains:
 - security-conscious rather than absolutely secure;
 - explicit about destructive lifecycle boundaries;
 - Omarchy-first before broadly portable;
-- grounded in Foot as the terminal-behavior oracle; and
+- grounded in Splinterm-owned contracts, with pinned Foot retained as an
+  optional historical differential; and
 - honest about implemented, validated, supported, planned, and deferred work.
 
 The product roadmap should be reconsidered if growth requires weakening those

--- a/docs/release-automation.md
+++ b/docs/release-automation.md
@@ -49,9 +49,10 @@ A failure never advances the state. Retrying candidate construction creates a ne
 The candidate manifest binds the repository, commit, version, tag, architecture, prior version tag, workflow run identity, and SHA-256 digest of every proposed release asset. A later publisher must consume this manifest and these exact artifacts rather than rebuilding.
 
 Foot 1.27.0 remains available as an optional historical differential. Its
-portable tooling and pinned-host jobs are advisory and do not determine the
-required `check` result or candidate eligibility. Cargo/compiler changes do not
-require Foot-provenance refreshes. See
+portable tooling job is advisory, while the exact pinned-host differential
+lives in the separate manual/scheduled `foot-oracle-pinned.yml` workflow so an
+offline self-hosted runner cannot delay required CI or candidate eligibility.
+Cargo/compiler changes do not require Foot-provenance refreshes. See
 [ADR 0013](adr/0013-splinterm-owned-renderer-acceptance.md).
 
 ## Human approval boundary

--- a/docs/release-automation.md
+++ b/docs/release-automation.md
@@ -40,13 +40,19 @@ A failure never advances the state. Retrying candidate construction creates a ne
 - no GitHub Environment, release token, AUR credential, tag creation, push, or release API call;
 - full Git history is fetched so the exact commit and previous version tag can be recorded;
 - the requested version must exactly match Cargo and all three Arch recipes;
-- repository-owned Foot oracle metadata must match the current `Cargo.lock` before
-  candidate construction;
+- Splinterm-owned workspace, renderer, semantic-fixture, contract, package, and
+  release-automation checks determine candidate eligibility;
 - website sources and deployment automation are absent from the source archive;
 - package validation runs against extracted package contents;
 - all output is uploaded as one private, retention-bounded workflow artifact.
 
 The candidate manifest binds the repository, commit, version, tag, architecture, prior version tag, workflow run identity, and SHA-256 digest of every proposed release asset. A later publisher must consume this manifest and these exact artifacts rather than rebuilding.
+
+Foot 1.27.0 remains available as an optional historical differential. Its
+portable tooling and pinned-host jobs are advisory and do not determine the
+required `check` result or candidate eligibility. Cargo/compiler changes do not
+require Foot-provenance refreshes. See
+[ADR 0013](adr/0013-splinterm-owned-renderer-acceptance.md).
 
 ## Human approval boundary
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -31,8 +31,10 @@ The current product target is:
 
 - x86_64 Omarchy/Arch Linux;
 - native Wayland under the documented Hyprland environment;
-- Foot 1.27.0 commit `3c5b584b0eafa772eb4376fb6eaf6643399e190e`
-  as the terminal-behavior oracle;
+- Splinterm-owned semantic, renderer, contract, package, and guarded graphical
+  tests as release authority; Foot 1.27.0 commit
+  `3c5b584b0eafa772eb4376fb6eaf6643399e190e` remains an optional historical
+  differential under [ADR 0013](adr/0013-splinterm-owned-renderer-acceptance.md);
 - public Beta 3 `0.1.0beta3-1` Arch packages built from clean committed
   source; and
 - guarded installed-package evidence for the Alpha3 command, scrollback,
@@ -57,9 +59,12 @@ share their immutable staged mappings instead of copying an entire font file per
 raster face. Generation identity and lifetime tests use Fontconfig's generic
 monospace family rather than requiring one host-specific family.
 
-Focused and complete non-graphical validation, independent review, candidate
-construction, packaged graphical acceptance, and publication remain separate
-release boundaries.
+Focused and complete non-graphical validation and independent source review
+passed. The exact RC2 implementation package at `d26cee9` passed guarded live
+valid-font replacement and invalid-candidate rollback acceptance without
+replacing the Window, daemon, shell, or Splint incarnation. Candidate
+construction and publication remain separate release boundaries. Foot is an
+optional historical differential and does not block either boundary.
 
 ## 0.1.0 RC1 release
 

--- a/site/src/content/docs/docs/development/index.md
+++ b/site/src/content/docs/docs/development/index.md
@@ -71,6 +71,6 @@ The helper intentionally labels and isolates its development authorization bypas
 - Plans and spikes record decisions and validation history; they are not user instructions.
 - Retained benchmark and graphical evidence should not enter ordinary documentation search.
 
-## Foot authority
+## Optional Foot differential
 
-Foot's pinned implementation remains the terminal behavior oracle. Do not modify the canonical Foot checkout or silently regenerate comparison references. Ported code must retain compatible licensing, exact provenance, and required notices in `THIRD_PARTY.md`.
+Splinterm-owned tests and adopted fixtures are release authority. Foot's pinned implementation remains an optional historical differential; do not modify the canonical checkout or silently regenerate comparison references. Ported code must retain compatible licensing, exact provenance, and required notices in `THIRD_PARTY.md`. See [ADR 0013](https://github.com/OldJobobo/splinterm/blob/main/docs/adr/0013-splinterm-owned-renderer-acceptance.md).

--- a/tools/benchmark/correctness-schema.json
+++ b/tools/benchmark/correctness-schema.json
@@ -1,30 +1,30 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://splinterm.invalid/schema/benchmark-correctness-v2.json",
-  "title": "Splinterbench correctness report v2",
+  "$id": "https://splinterm.invalid/schema/benchmark-correctness-v3.json",
+  "title": "Splinterbench correctness report v3",
   "type": "object",
   "additionalProperties": false,
-  "required": ["schema", "valid", "repository", "oracle", "semantic_fixtures", "checks", "feature_coverage", "fuzzing", "capability_matrix", "claim_policy"],
+  "required": ["schema", "valid", "repository", "historical_reference", "semantic_fixtures", "checks", "feature_coverage", "fuzzing", "capability_matrix", "claim_policy"],
   "properties": {
-    "schema": {"const": "splinterm.benchmark.correctness.v2"},
+    "schema": {"const": "splinterm.benchmark.correctness.v3"},
     "valid": {"type": "boolean"},
     "repository": {
       "type": "object", "additionalProperties": false, "required": ["revision", "dirty"],
       "properties": {"revision": {"type": "string", "pattern": "^[0-9a-f]{40}$"}, "dirty": {"type": "boolean"}}
     },
-    "oracle": {
-      "type": "object", "additionalProperties": false, "required": ["name", "version", "commit", "authority"],
+    "historical_reference": {
+      "type": "object", "additionalProperties": false, "required": ["name", "version", "commit", "role"],
       "properties": {
         "name": {"const": "foot"}, "version": {"const": "1.27.0"},
         "commit": {"const": "3c5b584b0eafa772eb4376fb6eaf6643399e190e"},
-        "authority": {"const": "behavioral-reference"}
+        "role": {"const": "optional-differential"}
       }
     },
     "semantic_fixtures": {
       "type": "object", "additionalProperties": false,
       "required": ["status", "fixture_count", "fixtures", "rust_test", "scope"],
       "properties": {
-        "status": {"const": "covered"}, "fixture_count": {"const": 5},
+        "status": {"const": "adopted-contract"}, "fixture_count": {"const": 5},
         "fixtures": {"type": "array", "minItems": 5, "maxItems": 5, "items": {"$ref": "#/$defs/fileEvidence"}},
         "rust_test": {"type": "string"}, "scope": {"type": "string"}
       }

--- a/tools/benchmark/correctness.py
+++ b/tools/benchmark/correctness.py
@@ -89,7 +89,16 @@ def run_checks(run: Run = default_run) -> list[dict[str, Any]]:
     )
     results = []
     for check, required, command in commands:
-        completed = run(command)
+        try:
+            completed = run(command)
+        except subprocess.TimeoutExpired as error:
+            completed = subprocess.CompletedProcess(
+                command, 124, stdout="", stderr=f"timed out: {error}"
+            )
+        except OSError as error:
+            completed = subprocess.CompletedProcess(
+                command, 127, stdout="", stderr=f"execution failed: {error}"
+            )
         output = "\n".join(
             line for line in (completed.stdout + completed.stderr).splitlines() if line.strip()
         )[-4000:]

--- a/tools/benchmark/correctness.py
+++ b/tools/benchmark/correctness.py
@@ -60,7 +60,7 @@ def collect_semantic_fixtures() -> dict[str, Any]:
     if len(fixtures) != 5:
         raise ValueError(f"expected 5 v1 semantic fixtures, found {len(fixtures)}")
     return {
-        "status": "covered",
+        "status": "adopted-contract",
         "fixture_count": len(fixtures),
         "fixtures": fixtures,
         "rust_test": "crates/splinterm-terminal/tests/oracle_fixtures.rs",
@@ -83,9 +83,9 @@ def run_checks(run: Run = default_run) -> list[dict[str, Any]]:
     commands = (
         ("semantic-vector-sync", True, [sys.executable, "tools/benchmark/generate-semantic-fixture-vectors.py", "--check"]),
         ("semantic-fixture-validation", True, [sys.executable, "tools/foot-oracle/validate-fixtures.py"]),
-        ("oracle-comparator-tests", True, [sys.executable, "-m", "pytest", "-q", *foot_tests]),
+        ("historical-foot-comparator-tests", False, [sys.executable, "-m", "pytest", "-q", *foot_tests]),
         ("terminal-correctness-tests", True, ["cargo", "test", "-q", "-p", "splinterm-terminal"]),
-        ("workspace-oracle-provenance", False, [sys.executable, "tools/foot-oracle/check-provenance.py", "--portable"]),
+        ("historical-foot-provenance", False, [sys.executable, "tools/foot-oracle/check-provenance.py", "--portable"]),
     )
     results = []
     for check, required, command in commands:
@@ -147,18 +147,18 @@ def build_report(run: Run = default_run) -> dict[str, Any]:
     semantic = collect_semantic_fixtures()
     checks = run_checks(run)
     report = {
-        "schema": "splinterm.benchmark.correctness.v2",
+        "schema": "splinterm.benchmark.correctness.v3",
         "valid": all(
             check["status"] == "passed" for check in checks if check["required"]
         ),
         "repository": repository_state(run),
-        "oracle": {"name": "foot", "version": "1.27.0", "commit": PINNED_FOOT, "authority": "behavioral-reference"},
+        "historical_reference": {"name": "foot", "version": "1.27.0", "commit": PINNED_FOOT, "role": "optional-differential"},
         "semantic_fixtures": semantic,
         "checks": checks,
         "feature_coverage": feature_coverage(),
         "fuzzing": {"target": "fuzz/fuzz_targets/terminal_advance.rs", "status": "available-not-run", "recorded_duration_seconds": None},
         "capability_matrix": capability_matrix(),
-        "claim_policy": "Correctness is independent from speed. This report runs public tests and checks source-owned semantic fixtures; benchmark observations and graphical acceptance records remain maintainer-private.",
+        "claim_policy": "Splinterm-owned tests and adopted source fixtures determine correctness independently from speed. Foot is retained only as an optional historical differential; benchmark observations and graphical acceptance records remain maintainer-private.",
     }
     return report
 
@@ -170,11 +170,11 @@ def render_markdown(report: dict[str, Any]) -> str:
         "",
         f"Overall non-graphical validation: **{'PASS' if report['valid'] else 'FAIL'}**  ",
         f"Repository revision: `{report['repository']['revision']}` ({'dirty' if report['repository']['dirty'] else 'clean'} worktree)  ",
-        f"Behavioral oracle: Foot 1.27.0 `{report['oracle']['commit']}`",
+        f"Optional historical reference: Foot 1.27.0 `{report['historical_reference']['commit']}`",
         "",
         "Correctness is reported separately from performance. Portable observations for other terminals do not expose or prove private terminal state.",
         "",
-        "## Oracle parity",
+        "## Splinterm-owned contract",
         "",
         f"- Semantic fixtures: **{semantic['fixture_count']}/{semantic['fixture_count']} covered** by the Rust fixture consumer, including chunking invariance.",
     ]

--- a/tools/benchmark/test_benchmark.py
+++ b/tools/benchmark/test_benchmark.py
@@ -2467,10 +2467,17 @@ def test_correctness_report_is_evidence_bounded_and_schema_valid(
     jsonschema = pytest.importorskip("jsonschema")
     report = build_report(_successful_correctness_run)
 
-    assert report["schema"] == "splinterm.benchmark.correctness.v2"
+    assert report["schema"] == "splinterm.benchmark.correctness.v3"
     assert report["valid"] is True
-    assert report["oracle"]["commit"] == "3c5b584b0eafa772eb4376fb6eaf6643399e190e"
+    assert report["historical_reference"]["commit"] == "3c5b584b0eafa772eb4376fb6eaf6643399e190e"
+    assert report["historical_reference"]["role"] == "optional-differential"
     assert report["semantic_fixtures"]["fixture_count"] == 5
+    assert report["semantic_fixtures"]["status"] == "adopted-contract"
+    assert all(
+        not check["required"]
+        for check in report["checks"]
+        if check["check"].startswith("historical-foot-")
+    )
     assert "final_buffer_evidence" not in report
     assert report["fuzzing"]["status"] == "available-not-run"
     assert report["fuzzing"]["recorded_duration_seconds"] is None

--- a/tools/benchmark/test_benchmark.py
+++ b/tools/benchmark/test_benchmark.py
@@ -2498,6 +2498,27 @@ def test_correctness_report_is_evidence_bounded_and_schema_valid(
     assert "available-not-run" in markdown
 
 
+def test_correctness_report_records_informational_timeout_and_continues() -> None:
+    def timeout_run(
+        command: list[str] | tuple[str, ...],
+    ) -> subprocess.CompletedProcess[str]:
+        if list(command)[:3] == [sys.executable, "-m", "pytest"]:
+            raise subprocess.TimeoutExpired(command, 300)
+        return _successful_correctness_run(command)
+
+    report = build_report(timeout_run)
+    historical = next(
+        check
+        for check in report["checks"]
+        if check["check"] == "historical-foot-comparator-tests"
+    )
+    assert report["valid"] is True
+    assert historical["required"] is False
+    assert historical["status"] == "failed"
+    assert historical["returncode"] == 124
+    assert "timed out" in historical["output"]
+
+
 def test_correctness_report_does_not_hide_failed_checks() -> None:
     def failing_run(
         command: list[str] | tuple[str, ...],

--- a/tools/foot-oracle/README.md
+++ b/tools/foot-oracle/README.md
@@ -281,13 +281,15 @@ python tools/foot-oracle/check-provenance.py --portable
 
 On the declared Omarchy reference host, omit `--portable` to require exact OS,
 architecture, native raster-library versions, all six resolved font
-files/indexes/hashes, explicit environment, and patches. Compiler version,
+files/indexes/hashes and raster options, explicit environment, and patches.
+Compiler version,
 Cargo.lock, and the complete ambient Fontconfig inventory are not comparison
 inputs. CI uses `--ci-host`: unsupported workers print
 `UNSUPPORTED_ORACLE_HOST` and exit 77; a supported worker with output-relevant
-drift fails that optional run normally. Both the portable tooling job and the
-self-hosted matrix cell are advisory and excluded from the aggregate release
-check. Reference changes require reviewed old/new metrics, heatmaps, provenance,
+drift fails that optional run normally. The portable tooling job is advisory;
+the self-hosted matrix runs in the separate manual/scheduled
+`foot-oracle-pinned.yml` workflow. Neither participates in release-authority CI.
+Reference changes require reviewed old/new metrics, heatmaps, provenance,
 and ADR updates where behavior changes; no command silently regenerates accepted
 references.
 

--- a/tools/foot-oracle/README.md
+++ b/tools/foot-oracle/README.md
@@ -1,7 +1,8 @@
 # Foot semantic oracle
 
-This directory defines how Splinterm will compare its Rust terminal port against
-the pinned Foot reference implementation.
+This directory retains Splinterm's optional historical differential against the
+pinned Foot reference implementation. Splinterm-owned tests and adopted fixtures
+are release authority; see [ADR 0013](../../docs/adr/0013-splinterm-owned-renderer-acceptance.md).
 
 ## Reference
 
@@ -251,7 +252,7 @@ If the compositor contributes trailing residual pixels, the runner recaptures
 Splinterm at Foot's declared logical surface size instead of translating images
 or widening comparison tolerances.
 
-The command preflights Foot, patch, font, native-library, and Cargo.lock
+The command preflights Foot, patch, font, native-library, and explicit-environment
 provenance; builds and tests patched Foot; runs all 16 manifest cases; and writes
 an aggregate `summary.json`. The clean 2026-07-19 closure run at
 `/tmp/splinterm-final-buffer-clean-retest/` passed 16/16 with zero ARGB
@@ -270,23 +271,25 @@ uses Foot's observable order for full and dirty-row paths, with a focused
 overhang regression test. The matrix additionally resolved Foot's two-thirds
 dim intensity and opaque block/one-pixel underline cursor composition.
 
-### Provenance gates
+### Provenance checks
 
-Validate repository-owned hashes and policy on every worker:
+Validate retained repository-owned hashes and reference policy:
 
 ```bash
 python tools/foot-oracle/check-provenance.py --portable
 ```
 
 On the declared Omarchy reference host, omit `--portable` to require exact OS,
-architecture, native/Rust versions, all six resolved font files/indexes/hashes,
-active fontconfig fingerprint, environment, patches, and Cargo.lock. CI uses
-`--ci-host`: unsupported workers print `UNSUPPORTED_ORACLE_HOST` and exit 77;
-a supported worker with any drift fails normally. The optional self-hosted
-`splinterm-oracle` job runs a strict default matrix cell and uploads its failure
-directory. Reference changes require reviewed old/new metrics, heatmaps,
-provenance, and ADR 0004 updates where behavior changes; no command silently
-regenerates accepted references.
+architecture, native raster-library versions, all six resolved font
+files/indexes/hashes, explicit environment, and patches. Compiler version,
+Cargo.lock, and the complete ambient Fontconfig inventory are not comparison
+inputs. CI uses `--ci-host`: unsupported workers print
+`UNSUPPORTED_ORACLE_HOST` and exit 77; a supported worker with output-relevant
+drift fails that optional run normally. Both the portable tooling job and the
+self-hosted matrix cell are advisory and excluded from the aggregate release
+check. Reference changes require reviewed old/new metrics, heatmaps, provenance,
+and ADR updates where behavior changes; no command silently regenerates accepted
+references.
 
 ### Slice 3 decoration/cursor v2
 
@@ -365,5 +368,5 @@ box/emoji behavior. DP-2 was restored after capture.
 - Record intentional Splinterm divergences explicitly in the fixture.
 - Keep raw input byte-exact using lowercase hexadecimal.
 - Compare arbitrary input chunkings against the same final state.
-- Treat Foot as the authority until an accepted Splinterm ADR documents a
-  divergence.
+- Treat Foot as an optional historical differential; Splinterm-owned contracts
+  are release authority under ADR 0013.

--- a/tools/foot-oracle/check-provenance.py
+++ b/tools/foot-oracle/check-provenance.py
@@ -36,21 +36,36 @@ def sha256(path: pathlib.Path) -> str:
 
 def load_manifest() -> dict[str, Any]:
     value = json.loads(MANIFEST.read_text(encoding="utf-8"))
-    if value.get("schema") != 3:
+    if value.get("schema") != 4:
         raise ProvenanceError("unsupported provenance schema")
     for key in (
         "supported_host",
+        "policy",
         "reference",
         "build",
         "environment",
         "fonts",
-        "rust",
         "oracle",
         "default_final_buffer_profile",
         "reference_update_policy",
     ):
         if key not in value:
             raise ProvenanceError(f"provenance is missing {key}")
+    reference = value["reference"]
+    if (
+        reference.get("name") != "foot"
+        or reference.get("version") != "1.27.0"
+        or reference.get("commit")
+        != "3c5b584b0eafa772eb4376fb6eaf6643399e190e"
+    ):
+        raise ProvenanceError("historical Foot reference identity drifted")
+    policy = value["policy"]
+    if (
+        policy.get("release_authority") != "splinterm-owned"
+        or policy.get("foot_role") != "optional-historical-differential"
+        or policy.get("release_blocking") is not False
+    ):
+        raise ProvenanceError("Foot reference policy is malformed")
     if len(value["fonts"]) != 6:
         raise ProvenanceError("provenance must declare all six raster faces")
     if value["reference_update_policy"].get("silent_regeneration") is not False:
@@ -59,12 +74,6 @@ def load_manifest() -> dict[str, Any]:
 
 
 def check_repository_files(manifest: dict[str, Any]) -> None:
-    expected_lock = manifest["rust"]["cargo_lock_sha256"]
-    if sha256(ROOT / "Cargo.lock") != expected_lock:
-        raise ProvenanceError("Cargo.lock drifted from pinned provenance")
-    profile_lock = manifest["default_final_buffer_profile"]["cargo_lock_sha256"]
-    if profile_lock != expected_lock:
-        raise ProvenanceError("profile and Rust Cargo.lock identities disagree")
     for patch in manifest["oracle"]["patches"]:
         path = ROOT / patch["path"]
         if not path.is_file() or sha256(path) != patch["sha256"]:
@@ -98,37 +107,16 @@ def command_output(arguments: list[str]) -> str:
     return result.stdout.strip()
 
 
-def active_fontconfig_fingerprint() -> str:
-    home = str(pathlib.Path.home())
-    entries = []
-    for line in command_output(["fc-conflist"]).splitlines():
-        if not line.startswith("+ "):
-            continue
-        path = pathlib.Path(line[2:].split(":", 1)[0])
-        if not path.is_file():
-            raise ProvenanceError(f"active fontconfig file is missing: {path}")
-        name = str(path)
-        if name.startswith(home):
-            name = "~" + name[len(home) :]
-        entries.append({"path": name, "sha256": sha256(path)})
-    payload = json.dumps(entries, sort_keys=True, separators=(",", ":")).encode()
-    return hashlib.sha256(payload).hexdigest()
-
-
 def check_versions(manifest: dict[str, Any]) -> None:
     expected = manifest["build"]
     for package, key in (
+        ("fcft", "fcft_version"),
         ("freetype2", "freetype_version"),
         ("fontconfig", "fontconfig_version"),
         ("pixman-1", "pixman_version"),
     ):
         if command_output(["pkg-config", "--modversion", package]) != expected[key]:
             raise ProvenanceError(f"{package} version drifted")
-    rust = manifest["rust"]
-    if command_output(["rustc", "--version"]).split()[1] != rust["rustc"]:
-        raise ProvenanceError("rustc version drifted")
-    if command_output(["cargo", "--version"]).split()[1] != rust["cargo"]:
-        raise ProvenanceError("cargo version drifted")
 
 
 def check_fonts(manifest: dict[str, Any]) -> None:
@@ -151,8 +139,6 @@ def check_fonts(manifest: dict[str, Any]) -> None:
 
 def check_environment(manifest: dict[str, Any]) -> None:
     expected = manifest["environment"]
-    if active_fontconfig_fingerprint() != expected["fontconfig_active_config_sha256"]:
-        raise ProvenanceError("active fontconfig configuration drifted")
     for name, value in expected["variables"].items():
         actual = os.environ.get(name)
         if actual is not None and actual.startswith(str(pathlib.Path.home())):
@@ -183,7 +169,11 @@ def main() -> int:
     except (OSError, ValueError, KeyError, ProvenanceError) as error:
         print(f"provenance error: {error}", file=sys.stderr)
         return 1
-    print("Foot oracle provenance: portable metadata valid" if args.portable else "Foot oracle provenance: pinned host exact")
+    print(
+        "Historical Foot reference metadata: portable inputs valid"
+        if args.portable
+        else "Historical Foot differential: output-relevant host inputs valid"
+    )
     return 0
 
 

--- a/tools/foot-oracle/check-provenance.py
+++ b/tools/foot-oracle/check-provenance.py
@@ -68,6 +68,9 @@ def load_manifest() -> dict[str, Any]:
         raise ProvenanceError("Foot reference policy is malformed")
     if len(value["fonts"]) != 6:
         raise ProvenanceError("provenance must declare all six raster faces")
+    raster_keys = {"hintstyle", "hinting", "antialias", "rgba", "lcdfilter"}
+    if any(set(font.get("fontconfig_raster", {})) != raster_keys for font in value["fonts"]):
+        raise ProvenanceError("every raster face must pin resolved Fontconfig options")
     if value["reference_update_policy"].get("silent_regeneration") is not False:
         raise ProvenanceError("silent reference regeneration must remain disabled")
     return value
@@ -122,9 +125,14 @@ def check_versions(manifest: dict[str, Any]) -> None:
 def check_fonts(manifest: dict[str, Any]) -> None:
     for font in manifest["fonts"]:
         output = command_output(
-            ["fc-match", "-f", "%{file}\n%{index}\n", font["pattern"]]
+            [
+                "fc-match",
+                "-f",
+                "%{file}\n%{index}\n%{hintstyle}\n%{hinting}\n%{antialias}\n%{rgba}\n%{lcdfilter}\n",
+                font["pattern"],
+            ]
         ).splitlines()
-        if len(output) < 2:
+        if len(output) < 7:
             raise ProvenanceError(f"fontconfig did not resolve {font['role']}")
         path = pathlib.Path(output[0])
         try:
@@ -133,6 +141,13 @@ def check_fonts(manifest: dict[str, Any]) -> None:
             raise ProvenanceError(f"invalid face index for {font['role']}") from error
         if str(path) != font["file"] or index != font["index"]:
             raise ProvenanceError(f"resolved {font['role']} face drifted")
+        option_names = ("hintstyle", "hinting", "antialias", "rgba", "lcdfilter")
+        actual_raster = dict(zip(option_names, output[2:7], strict=True))
+        if actual_raster != font["fontconfig_raster"]:
+            raise ProvenanceError(
+                f"resolved {font['role']} Fontconfig raster options drifted: "
+                f"expected {font['fontconfig_raster']}, got {actual_raster}"
+            )
         if not path.is_file() or sha256(path) != font["sha256"]:
             raise ProvenanceError(f"resolved {font['role']} font bytes drifted")
 

--- a/tools/foot-oracle/check-provenance.py
+++ b/tools/foot-oracle/check-provenance.py
@@ -122,34 +122,60 @@ def check_versions(manifest: dict[str, Any]) -> None:
             raise ProvenanceError(f"{package} version drifted")
 
 
+def matrix_font_patterns(manifest: dict[str, Any], font: dict[str, Any]) -> list[str]:
+    patterns = [font["pattern"]]
+    matrix = manifest.get("oracle", {}).get("font_matrix")
+    if matrix is None:
+        return patterns
+    sizes = {
+        logical_size * scale / 120
+        for logical_size in matrix["logical_sizes_px"]
+        for scale in matrix["scales_120"]
+    }
+    base_pattern = font["pattern"]
+    if font["role"] == "cjk":
+        base_pattern = base_pattern.split(":style=", 1)[0]
+    patterns.extend(f"{base_pattern}:pixelsize={size:g}" for size in sorted(sizes))
+    return patterns
+
+
 def check_fonts(manifest: dict[str, Any]) -> None:
     for font in manifest["fonts"]:
-        output = command_output(
-            [
-                "fc-match",
-                "-f",
-                "%{file}\n%{index}\n%{hintstyle}\n%{hinting}\n%{antialias}\n%{rgba}\n%{lcdfilter}\n",
-                font["pattern"],
-            ]
-        ).splitlines()
-        if len(output) < 7:
-            raise ProvenanceError(f"fontconfig did not resolve {font['role']}")
-        path = pathlib.Path(output[0])
-        try:
-            index = int(output[1])
-        except ValueError as error:
-            raise ProvenanceError(f"invalid face index for {font['role']}") from error
-        if str(path) != font["file"] or index != font["index"]:
-            raise ProvenanceError(f"resolved {font['role']} face drifted")
-        option_names = ("hintstyle", "hinting", "antialias", "rgba", "lcdfilter")
-        actual_raster = dict(zip(option_names, output[2:7], strict=True))
-        if actual_raster != font["fontconfig_raster"]:
-            raise ProvenanceError(
-                f"resolved {font['role']} Fontconfig raster options drifted: "
-                f"expected {font['fontconfig_raster']}, got {actual_raster}"
-            )
-        if not path.is_file() or sha256(path) != font["sha256"]:
-            raise ProvenanceError(f"resolved {font['role']} font bytes drifted")
+        for pattern in matrix_font_patterns(manifest, font):
+            output = command_output(
+                [
+                    "fc-match",
+                    "-f",
+                    "%{file}\n%{index}\n%{hintstyle}\n%{hinting}\n%{antialias}\n%{rgba}\n%{lcdfilter}\n",
+                    pattern,
+                ]
+            ).splitlines()
+            if len(output) < 7:
+                raise ProvenanceError(
+                    f"fontconfig did not resolve {font['role']} for {pattern!r}"
+                )
+            path = pathlib.Path(output[0])
+            try:
+                index = int(output[1])
+            except ValueError as error:
+                raise ProvenanceError(
+                    f"invalid face index for {font['role']} at {pattern!r}"
+                ) from error
+            if str(path) != font["file"] or index != font["index"]:
+                raise ProvenanceError(
+                    f"resolved {font['role']} face drifted for {pattern!r}"
+                )
+            option_names = ("hintstyle", "hinting", "antialias", "rgba", "lcdfilter")
+            actual_raster = dict(zip(option_names, output[2:7], strict=True))
+            if actual_raster != font["fontconfig_raster"]:
+                raise ProvenanceError(
+                    f"resolved {font['role']} Fontconfig raster options drifted for "
+                    f"{pattern!r}: expected {font['fontconfig_raster']}, got {actual_raster}"
+                )
+            if not path.is_file() or sha256(path) != font["sha256"]:
+                raise ProvenanceError(
+                    f"resolved {font['role']} font bytes drifted for {pattern!r}"
+                )
 
 
 def check_environment(manifest: dict[str, Any]) -> None:

--- a/tools/foot-oracle/provenance.json
+++ b/tools/foot-oracle/provenance.json
@@ -1,5 +1,16 @@
 {
-  "schema": 3,
+  "schema": 4,
+  "policy": {
+    "release_authority": "splinterm-owned",
+    "foot_role": "optional-historical-differential",
+    "release_blocking": false,
+    "checked_host_inputs": [
+      "Foot commit and adapter patches",
+      "resolved font files, face indexes, and file hashes",
+      "Fontconfig, FreeType, fcft, and pixman versions",
+      "renderer policy and explicit environment variables"
+    ]
+  },
   "supported_host": {
     "os_release_id": "omarchy",
     "architecture": "x86_64",
@@ -41,7 +52,6 @@
     }
   },
   "environment": {
-    "fontconfig_active_config_sha256": "83c4161f1282866b60ff280c04c1a073125dab9ce2b780610059671ffc78bdf6",
     "variables": {
       "FONTCONFIG_FILE": null,
       "FONTCONFIG_PATH": null,
@@ -56,18 +66,6 @@
     {"role": "cjk", "pattern": "Noto Sans CJK JP:style=Regular", "file": "/usr/share/fonts/noto-cjk/NotoSansCJK-Regular.ttc", "index": 0, "sha256": "b76b0433203017ca80401b2ee0dd69350349871c4b19d504c34dbdd80541690a"},
     {"role": "emoji", "pattern": "Noto Color Emoji", "file": "/usr/share/fonts/noto/NotoColorEmoji.ttf", "index": 0, "sha256": "72a635cb3d2f3524c51620cdde406b217204e8a6a06c6a096ff8ed4b5fd6e27b"}
   ],
-  "rust": {
-    "rustc": "1.91.0",
-    "cargo": "1.91.0",
-    "cargo_lock_sha256": "bc500f38cb03c929cfc557521f4ea85840f0e7cff2a2590debb4b86fa120e4db",
-    "dependencies": {
-      "fontdb": "0.23.0",
-      "freetype-rs": "0.38.0",
-      "memmap2": "0.9.11",
-      "pixman-sys": "0.1.0",
-      "swash": "0.2.10"
-    }
-  },
   "oracle": {
     "semantic_runner": "tools/foot-oracle/run-fixtures.py",
     "final_buffer_runner": "tools/foot-oracle/run-final-buffer-comparison.py",
@@ -111,8 +109,7 @@
       "bottom": 12
     },
     "foreground": "ebebeb",
-    "background": "0e1216",
-    "cargo_lock_sha256": "bc500f38cb03c929cfc557521f4ea85840f0e7cff2a2590debb4b86fa120e4db"
+    "background": "0e1216"
   },
   "semantic_fixture_schema": "fixtures/terminal/v1/schema.md",
   "final_buffer_schema": "tools/foot-oracle/final-buffer-schema.md",
@@ -122,7 +119,7 @@
       "old and new structured metrics",
       "old and new mismatch heatmaps",
       "provenance diff",
-      "ADR 0004 tolerance or renderer decision when behavior changes"
+      "ADR 0004/0013 renderer-contract decision when behavior changes"
     ]
   }
 }

--- a/tools/foot-oracle/provenance.json
+++ b/tools/foot-oracle/provenance.json
@@ -59,12 +59,12 @@
     }
   },
   "fonts": [
-    {"role": "regular", "pattern": "JetBrains Mono Nerd Font:style=Regular", "file": "/usr/share/fonts/TTF/JetBrainsMonoNerdFont-Regular.ttf", "index": 0, "sha256": "0ec29a68b539ece7078fc714cebff0c0accb2f4948f8f7963d9f5e86633b12d9"},
-    {"role": "bold", "pattern": "JetBrains Mono Nerd Font:style=Bold", "file": "/usr/share/fonts/TTF/JetBrainsMonoNerdFont-Bold.ttf", "index": 0, "sha256": "e82e27a7f37c9a0a13cc4e417503a149c6a0280586930772d2ebed803159c864"},
-    {"role": "italic", "pattern": "JetBrains Mono Nerd Font:style=Italic", "file": "/usr/share/fonts/TTF/JetBrainsMonoNerdFont-Italic.ttf", "index": 0, "sha256": "981133a258ef4c62769a7a7214a4b455ac1c63923784a70f50c48977b67f7025"},
-    {"role": "bold-italic", "pattern": "JetBrains Mono Nerd Font:style=Bold Italic", "file": "/usr/share/fonts/TTF/JetBrainsMonoNerdFont-BoldItalic.ttf", "index": 0, "sha256": "961222be7bce59f310b41a3e158368d5ea22a47a0ac31defd57caac9b9e82cb0"},
-    {"role": "cjk", "pattern": "Noto Sans CJK JP:style=Regular", "file": "/usr/share/fonts/noto-cjk/NotoSansCJK-Regular.ttc", "index": 0, "sha256": "b76b0433203017ca80401b2ee0dd69350349871c4b19d504c34dbdd80541690a"},
-    {"role": "emoji", "pattern": "Noto Color Emoji", "file": "/usr/share/fonts/noto/NotoColorEmoji.ttf", "index": 0, "sha256": "72a635cb3d2f3524c51620cdde406b217204e8a6a06c6a096ff8ed4b5fd6e27b"}
+    {"role": "regular", "pattern": "JetBrains Mono Nerd Font:style=Regular", "file": "/usr/share/fonts/TTF/JetBrainsMonoNerdFont-Regular.ttf", "index": 0, "sha256": "0ec29a68b539ece7078fc714cebff0c0accb2f4948f8f7963d9f5e86633b12d9", "fontconfig_raster": {"hintstyle": "1", "hinting": "True", "antialias": "True", "rgba": "", "lcdfilter": "1"}},
+    {"role": "bold", "pattern": "JetBrains Mono Nerd Font:style=Bold", "file": "/usr/share/fonts/TTF/JetBrainsMonoNerdFont-Bold.ttf", "index": 0, "sha256": "e82e27a7f37c9a0a13cc4e417503a149c6a0280586930772d2ebed803159c864", "fontconfig_raster": {"hintstyle": "1", "hinting": "True", "antialias": "True", "rgba": "", "lcdfilter": "1"}},
+    {"role": "italic", "pattern": "JetBrains Mono Nerd Font:style=Italic", "file": "/usr/share/fonts/TTF/JetBrainsMonoNerdFont-Italic.ttf", "index": 0, "sha256": "981133a258ef4c62769a7a7214a4b455ac1c63923784a70f50c48977b67f7025", "fontconfig_raster": {"hintstyle": "1", "hinting": "True", "antialias": "True", "rgba": "", "lcdfilter": "1"}},
+    {"role": "bold-italic", "pattern": "JetBrains Mono Nerd Font:style=Bold Italic", "file": "/usr/share/fonts/TTF/JetBrainsMonoNerdFont-BoldItalic.ttf", "index": 0, "sha256": "961222be7bce59f310b41a3e158368d5ea22a47a0ac31defd57caac9b9e82cb0", "fontconfig_raster": {"hintstyle": "1", "hinting": "True", "antialias": "True", "rgba": "", "lcdfilter": "1"}},
+    {"role": "cjk", "pattern": "Noto Sans CJK JP:style=Regular", "file": "/usr/share/fonts/noto-cjk/NotoSansCJK-Regular.ttc", "index": 0, "sha256": "b76b0433203017ca80401b2ee0dd69350349871c4b19d504c34dbdd80541690a", "fontconfig_raster": {"hintstyle": "1", "hinting": "True", "antialias": "True", "rgba": "", "lcdfilter": "1"}},
+    {"role": "emoji", "pattern": "Noto Color Emoji", "file": "/usr/share/fonts/noto/NotoColorEmoji.ttf", "index": 0, "sha256": "72a635cb3d2f3524c51620cdde406b217204e8a6a06c6a096ff8ed4b5fd6e27b", "fontconfig_raster": {"hintstyle": "1", "hinting": "True", "antialias": "False", "rgba": "", "lcdfilter": "1"}}
   ],
   "oracle": {
     "semantic_runner": "tools/foot-oracle/run-fixtures.py",

--- a/tools/foot-oracle/run-final-buffer-comparison.py
+++ b/tools/foot-oracle/run-final-buffer-comparison.py
@@ -191,7 +191,7 @@ def preflight_provenance(manifest: dict[str, Any]) -> dict[str, Any]:
         [
             "fc-match",
             "-f",
-            "%{file}\\n%{index}\\n",
+            "%{file}\\n%{index}\\n%{hintstyle}\\n%{hinting}\\n%{antialias}\\n%{rgba}\\n%{lcdfilter}\\n",
             profile["font_pattern"],
         ],
         capture_output=True,
@@ -199,13 +199,19 @@ def preflight_provenance(manifest: dict[str, Any]) -> dict[str, Any]:
     if font_match.returncode:
         raise ValueError("fc-match failed during provenance preflight")
     lines = font_match.stdout.splitlines()
+    if len(lines) < 7:
+        raise ValueError("resolved primary font metadata is incomplete")
     if (
-        len(lines) < 2
-        or lines[0] != profile["font_file"]
+        lines[0] != profile["font_file"]
         or int(lines[1]) != profile["font_index"]
         or sha256(Path(lines[0])) != profile["font_sha256"]
     ):
         raise ValueError("resolved primary font drifted from pinned provenance")
+    option_names = ("hintstyle", "hinting", "antialias", "rgba", "lcdfilter")
+    actual_raster = dict(zip(option_names, lines[2:7], strict=True))
+    regular = next(font for font in provenance["fonts"] if font["role"] == "regular")
+    if actual_raster != regular["fontconfig_raster"]:
+        raise ValueError("resolved primary Fontconfig raster options drifted")
     check_native_versions(provenance)
     expected_profile = {
         "font": manifest["profile"]["font"],

--- a/tools/foot-oracle/run-final-buffer-comparison.py
+++ b/tools/foot-oracle/run-final-buffer-comparison.py
@@ -163,7 +163,7 @@ def sha256(path: Path) -> str:
 def preflight_provenance(manifest: dict[str, Any]) -> dict[str, Any]:
     provenance_path = ROOT / "tools/foot-oracle/provenance.json"
     provenance = json.loads(provenance_path.read_text(encoding="utf-8"))
-    if provenance.get("schema") != 3:
+    if provenance.get("schema") != 4:
         raise ValueError("unsupported oracle provenance schema")
     source = Path(os.environ.get("FOOT_SOURCE", Path.home() / "Playground/foot"))
     revision = run(["git", "-C", str(source), "rev-parse", "HEAD"], capture_output=True)
@@ -175,8 +175,6 @@ def preflight_provenance(manifest: dict[str, Any]) -> dict[str, Any]:
         if sha256(path) != patch["sha256"]:
             raise ValueError(f"oracle patch hash drift: {patch['path']}")
     profile = provenance["default_final_buffer_profile"]
-    if sha256(ROOT / "Cargo.lock") != profile["cargo_lock_sha256"]:
-        raise ValueError("Cargo.lock drifted from final-buffer provenance")
     font_match = run(
         [
             "fc-match",

--- a/tools/foot-oracle/run-final-buffer-comparison.py
+++ b/tools/foot-oracle/run-final-buffer-comparison.py
@@ -172,11 +172,22 @@ def check_native_versions(provenance: dict[str, Any]) -> None:
             raise ValueError(f"{package} version drifted from pinned provenance")
 
 
+def check_environment(provenance: dict[str, Any]) -> None:
+    for name, expected in provenance["environment"]["variables"].items():
+        actual = os.environ.get(name)
+        home = str(Path.home())
+        if actual is not None and actual.startswith(home):
+            actual = "~" + actual[len(home) :]
+        if actual != expected:
+            raise ValueError(f"environment variable drifted: {name}")
+
+
 def preflight_provenance(manifest: dict[str, Any]) -> dict[str, Any]:
     provenance_path = ROOT / "tools/foot-oracle/provenance.json"
     provenance = json.loads(provenance_path.read_text(encoding="utf-8"))
     if provenance.get("schema") != 4:
         raise ValueError("unsupported oracle provenance schema")
+    check_environment(provenance)
     source = Path(os.environ.get("FOOT_SOURCE", Path.home() / "Playground/foot"))
     revision = run(["git", "-C", str(source), "rev-parse", "HEAD"], capture_output=True)
     expected_revision = provenance["reference"]["commit"]

--- a/tools/foot-oracle/run-final-buffer-comparison.py
+++ b/tools/foot-oracle/run-final-buffer-comparison.py
@@ -160,6 +160,18 @@ def sha256(path: Path) -> str:
     return digest.hexdigest()
 
 
+def check_native_versions(provenance: dict[str, Any]) -> None:
+    for package, key in (
+        ("fcft", "fcft_version"),
+        ("freetype2", "freetype_version"),
+        ("fontconfig", "fontconfig_version"),
+        ("pixman-1", "pixman_version"),
+    ):
+        version = run(["pkg-config", "--modversion", package], capture_output=True)
+        if version.returncode or version.stdout.strip() != provenance["build"][key]:
+            raise ValueError(f"{package} version drifted from pinned provenance")
+
+
 def preflight_provenance(manifest: dict[str, Any]) -> dict[str, Any]:
     provenance_path = ROOT / "tools/foot-oracle/provenance.json"
     provenance = json.loads(provenance_path.read_text(encoding="utf-8"))
@@ -194,14 +206,7 @@ def preflight_provenance(manifest: dict[str, Any]) -> dict[str, Any]:
         or sha256(Path(lines[0])) != profile["font_sha256"]
     ):
         raise ValueError("resolved primary font drifted from pinned provenance")
-    for package, key in (
-        ("freetype2", "freetype_version"),
-        ("fontconfig", "fontconfig_version"),
-        ("pixman-1", "pixman_version"),
-    ):
-        version = run(["pkg-config", "--modversion", package], capture_output=True)
-        if version.returncode or version.stdout.strip() != provenance["build"][key]:
-            raise ValueError(f"{package} version drifted from pinned provenance")
+    check_native_versions(provenance)
     expected_profile = {
         "font": manifest["profile"]["font"],
         "font_size": manifest["profile"]["font_size"],

--- a/tools/foot-oracle/test_capture_foot_sixel.py
+++ b/tools/foot-oracle/test_capture_foot_sixel.py
@@ -1,0 +1,55 @@
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "tools/image-spike/capture_foot_sixel.py"
+
+
+def load_capture():
+    name = "capture_foot_sixel"
+    spec = importlib.util.spec_from_file_location(name, SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_sixel_provenance_requires_strict_schema_v4_host_check(monkeypatch):
+    capture = load_capture()
+
+    def reject():
+        raise RuntimeError("environment variable drifted: FONTCONFIG_FILE")
+
+    monkeypatch.setattr(capture, "require_pinned_host", reject)
+    with pytest.raises(RuntimeError, match="environment variable drifted"):
+        capture.sixel_provenance()
+
+
+def test_strict_host_check_runs_shared_provenance_validator(monkeypatch):
+    capture = load_capture()
+    calls = []
+
+    def run(command, **kwargs):
+        calls.append((command, kwargs))
+        return subprocess.CompletedProcess(command, 1, "", "raster options drifted")
+
+    monkeypatch.setattr(capture.subprocess, "run", run)
+    with pytest.raises(RuntimeError, match="raster options drifted"):
+        capture.require_pinned_host()
+    assert calls == [
+        (
+            [sys.executable, str(capture.PROVENANCE_CHECK)],
+            {
+                "cwd": ROOT,
+                "text": True,
+                "capture_output": True,
+                "check": False,
+            },
+        )
+    ]

--- a/tools/foot-oracle/test_check_provenance.py
+++ b/tools/foot-oracle/test_check_provenance.py
@@ -115,9 +115,12 @@ def test_matrix_patterns_match_size_qualified_fallback_resolvers():
     ) == ["Noto Color Emoji", "Noto Color Emoji:pixelsize=15"]
 
 
-def test_size_qualified_fontconfig_raster_drift_is_rejected(monkeypatch):
+def test_size_qualified_fontconfig_raster_drift_is_rejected(monkeypatch, tmp_path):
     checker = load_checker()
-    font = checker.load_manifest()["fonts"][0]
+    font = dict(checker.load_manifest()["fonts"][0])
+    font_path = tmp_path / "font.ttf"
+    font_path.write_bytes(b"pinned font")
+    font["file"] = str(font_path)
     seen_patterns = []
 
     def output(arguments):

--- a/tools/foot-oracle/test_check_provenance.py
+++ b/tools/foot-oracle/test_check_provenance.py
@@ -79,6 +79,19 @@ def test_host_checks_ignore_rust_and_ambient_fontconfig_inventory(monkeypatch):
     assert "fontconfig_active_config_sha256" not in manifest["environment"]
 
 
+def test_fontconfig_raster_option_drift_is_rejected(monkeypatch):
+    checker = load_checker()
+    manifest = checker.load_manifest()
+    font = manifest["fonts"][0]
+    monkeypatch.setattr(
+        checker,
+        "command_output",
+        lambda _arguments: f"{font['file']}\n{font['index']}\n3\nTrue\nTrue\n\n1",
+    )
+    with pytest.raises(checker.ProvenanceError, match="Fontconfig raster options drifted"):
+        checker.check_fonts({"fonts": [font]})
+
+
 def test_non_reference_worker_is_an_explicit_unsupported_host(monkeypatch):
     checker = load_checker()
     manifest = checker.load_manifest()

--- a/tools/foot-oracle/test_check_provenance.py
+++ b/tools/foot-oracle/test_check_provenance.py
@@ -92,6 +92,75 @@ def test_fontconfig_raster_option_drift_is_rejected(monkeypatch):
         checker.check_fonts({"fonts": [font]})
 
 
+def test_matrix_patterns_match_size_qualified_fallback_resolvers():
+    checker = load_checker()
+    manifest = {
+        "oracle": {
+            "font_matrix": {
+                "logical_sizes_px": [12],
+                "scales_120": [150],
+            }
+        }
+    }
+    assert checker.matrix_font_patterns(
+        manifest,
+        {
+            "role": "cjk",
+            "pattern": "Noto Sans CJK JP:style=Regular",
+        },
+    ) == ["Noto Sans CJK JP:style=Regular", "Noto Sans CJK JP:pixelsize=15"]
+    assert checker.matrix_font_patterns(
+        manifest,
+        {"role": "emoji", "pattern": "Noto Color Emoji"},
+    ) == ["Noto Color Emoji", "Noto Color Emoji:pixelsize=15"]
+
+
+def test_size_qualified_fontconfig_raster_drift_is_rejected(monkeypatch):
+    checker = load_checker()
+    font = checker.load_manifest()["fonts"][0]
+    seen_patterns = []
+
+    def output(arguments):
+        pattern = arguments[-1]
+        seen_patterns.append(pattern)
+        raster = dict(font["fontconfig_raster"])
+        if pattern.endswith(":pixelsize=7.5"):
+            raster["hintstyle"] = "999"
+        return "\n".join(
+            [
+                font["file"],
+                str(font["index"]),
+                raster["hintstyle"],
+                raster["hinting"],
+                raster["antialias"],
+                raster["rgba"],
+                raster["lcdfilter"],
+            ]
+        )
+
+    monkeypatch.setattr(checker, "command_output", output)
+    monkeypatch.setattr(checker, "sha256", lambda _path: font["sha256"])
+    manifest = {
+        "fonts": [font],
+        "oracle": {
+            "font_matrix": {
+                "logical_sizes_px": [6],
+                "scales_120": [120, 150],
+            }
+        },
+    }
+    with pytest.raises(
+        checker.ProvenanceError,
+        match=r"Fontconfig raster options drifted.*pixelsize=7\.5",
+    ):
+        checker.check_fonts(manifest)
+    assert seen_patterns == [
+        font["pattern"],
+        f"{font['pattern']}:pixelsize=6",
+        f"{font['pattern']}:pixelsize=7.5",
+    ]
+
+
 def test_non_reference_worker_is_an_explicit_unsupported_host(monkeypatch):
     checker = load_checker()
     manifest = checker.load_manifest()

--- a/tools/foot-oracle/test_check_provenance.py
+++ b/tools/foot-oracle/test_check_provenance.py
@@ -27,7 +27,7 @@ def test_portable_provenance_accepts_repository_owned_inputs():
         check=False,
     )
     assert result.returncode == 0, result.stderr
-    assert "portable metadata valid" in result.stdout
+    assert "portable inputs valid" in result.stdout
 
 
 def test_manifest_declares_complete_faces_and_review_policy():
@@ -43,6 +43,40 @@ def test_manifest_declares_complete_faces_and_review_policy():
     }
     assert manifest["reference_update_policy"]["silent_regeneration"] is False
     assert len(manifest["reference_update_policy"]["required_review"]) >= 4
+
+
+def test_patch_drift_remains_rejected(monkeypatch):
+    checker = load_checker()
+    manifest = checker.load_manifest()
+    monkeypatch.setattr(checker, "sha256", lambda _path: "0" * 64)
+    with pytest.raises(checker.ProvenanceError, match="oracle patch drifted"):
+        checker.check_repository_files(manifest)
+
+
+def test_host_checks_ignore_rust_and_ambient_fontconfig_inventory(monkeypatch):
+    checker = load_checker()
+    manifest = checker.load_manifest()
+    commands = []
+
+    def output(arguments):
+        commands.append(arguments)
+        return {
+            "fcft": manifest["build"]["fcft_version"],
+            "freetype2": manifest["build"]["freetype_version"],
+            "fontconfig": manifest["build"]["fontconfig_version"],
+            "pixman-1": manifest["build"]["pixman_version"],
+        }[arguments[-1]]
+
+    monkeypatch.setattr(checker, "command_output", output)
+    checker.check_versions(manifest)
+    assert commands == [
+        ["pkg-config", "--modversion", "fcft"],
+        ["pkg-config", "--modversion", "freetype2"],
+        ["pkg-config", "--modversion", "fontconfig"],
+        ["pkg-config", "--modversion", "pixman-1"],
+    ]
+    assert "rust" not in manifest
+    assert "fontconfig_active_config_sha256" not in manifest["environment"]
 
 
 def test_non_reference_worker_is_an_explicit_unsupported_host(monkeypatch):

--- a/tools/foot-oracle/test_run_final_buffer_comparison.py
+++ b/tools/foot-oracle/test_run_final_buffer_comparison.py
@@ -82,6 +82,31 @@ def test_manifest_rejects_duplicate_ids_and_bad_cursor(tmp_path):
         MODULE.load_manifest(write_manifest(tmp_path, value))
 
 
+def test_native_preflight_rejects_mislabeled_fcft_evidence(monkeypatch):
+    provenance = {
+        "build": {
+            "fcft_version": "3.3.3",
+            "freetype_version": "26.6.20",
+            "fontconfig_version": "2.18.2",
+            "pixman_version": "0.46.4",
+        }
+    }
+
+    def fake_run(command, **_kwargs):
+        package = command[-1]
+        actual = {
+            "fcft": "3.3.4",
+            "freetype2": "26.6.20",
+            "fontconfig": "2.18.2",
+            "pixman-1": "0.46.4",
+        }[package]
+        return subprocess.CompletedProcess(command, 0, stdout=f"{actual}\n", stderr="")
+
+    monkeypatch.setattr(MODULE, "run", fake_run)
+    with pytest.raises(ValueError, match="fcft version drifted"):
+        MODULE.check_native_versions(provenance)
+
+
 def test_workspace_safety_requires_inactive_workspace_8_on_dp2(monkeypatch):
     responses = {
         "monitors all": [

--- a/tools/foot-oracle/test_run_final_buffer_comparison.py
+++ b/tools/foot-oracle/test_run_final_buffer_comparison.py
@@ -107,6 +107,23 @@ def test_native_preflight_rejects_mislabeled_fcft_evidence(monkeypatch):
         MODULE.check_native_versions(provenance)
 
 
+def test_direct_preflight_rejects_explicit_environment_drift(monkeypatch):
+    provenance = {
+        "environment": {
+            "variables": {
+                "FONTCONFIG_FILE": None,
+                "FONTCONFIG_PATH": None,
+                "XDG_CONFIG_HOME": "~/.config",
+            }
+        }
+    }
+    monkeypatch.setenv("FONTCONFIG_FILE", "/tmp/unpinned-fonts.conf")
+    monkeypatch.delenv("FONTCONFIG_PATH", raising=False)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(Path.home() / ".config"))
+    with pytest.raises(ValueError, match="environment variable drifted: FONTCONFIG_FILE"):
+        MODULE.check_environment(provenance)
+
+
 def test_workspace_safety_requires_inactive_workspace_8_on_dp2(monkeypatch):
     responses = {
         "monitors all": [

--- a/tools/image-spike/capture_foot_sixel.py
+++ b/tools/image-spike/capture_foot_sixel.py
@@ -17,6 +17,7 @@ from typing import Any
 ROOT = pathlib.Path(__file__).resolve().parents[2]
 FIXTURES = ROOT / "fixtures/terminal-images/v1/protocol-fixtures/sixel-v1.json"
 ORACLE_PATH = ROOT / "tools/foot-oracle/run-final-buffer-comparison.py"
+PROVENANCE_CHECK = ROOT / "tools/foot-oracle/check-provenance.py"
 BUILD = pathlib.Path("/tmp/splinterm-foot-oracle-build")
 
 
@@ -45,9 +46,23 @@ def file_sha256(path: pathlib.Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()
 
 
+def require_pinned_host() -> None:
+    result = subprocess.run(
+        [sys.executable, str(PROVENANCE_CHECK)],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or "no diagnostic"
+        raise RuntimeError(f"pinned Foot oracle prerequisite check failed: {detail}")
+
+
 def sixel_provenance() -> dict[str, Any]:
     """Validate output-relevant inputs for the optional Foot differential."""
 
+    require_pinned_host()
     path = ROOT / "tools/foot-oracle/provenance.json"
     provenance = json.loads(path.read_text(encoding="utf-8"))
     if provenance.get("schema") != 4:

--- a/tools/image-spike/capture_foot_sixel.py
+++ b/tools/image-spike/capture_foot_sixel.py
@@ -46,11 +46,11 @@ def file_sha256(path: pathlib.Path) -> str:
 
 
 def sixel_provenance() -> dict[str, Any]:
-    """Validate Foot-only authority without the unrelated Rust lockfile lane."""
+    """Validate output-relevant inputs for the optional Foot differential."""
 
     path = ROOT / "tools/foot-oracle/provenance.json"
     provenance = json.loads(path.read_text(encoding="utf-8"))
-    if provenance.get("schema") != 3:
+    if provenance.get("schema") != 4:
         raise RuntimeError("unsupported oracle provenance schema")
     source = pathlib.Path(os.environ.get("FOOT_SOURCE", pathlib.Path.home() / "Playground/foot"))
     revision = subprocess.run(

--- a/tools/release/test_release_candidate_workflow.py
+++ b/tools/release/test_release_candidate_workflow.py
@@ -53,14 +53,21 @@ class ReleaseCandidateWorkflowTests(unittest.TestCase):
 
     def test_foot_jobs_are_advisory_and_source_contracts_remain_mandatory(self) -> None:
         ci = (ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")
+        pinned = (ROOT / ".github/workflows/foot-oracle-pinned.yml").read_text(
+            encoding="utf-8"
+        )
         mandatory = ci[ci.index("  check:") : ci.index("  foot-reference:")]
-        foot = ci[ci.index("  foot-reference:") : ci.index("  oracle:")]
-        oracle = ci[ci.index("  oracle:") :]
+        foot = ci[ci.index("  foot-reference:") :]
         self.assertIn("generate-semantic-fixture-vectors.py --check", mandatory)
         self.assertIn("validate-contract-fixtures.py", mandatory)
         self.assertNotIn("check-provenance.py", mandatory)
+        self.assertNotIn("self-hosted", ci)
         self.assertIn("continue-on-error: true", foot)
-        self.assertIn("continue-on-error: true", oracle)
+        self.assertIn("workflow_dispatch:", pinned)
+        self.assertIn("schedule:", pinned)
+        self.assertIn("runs-on: [self-hosted, linux, x64, splinterm-oracle]", pinned)
+        self.assertNotIn("\n  push:", pinned)
+        self.assertNotIn("\n  pull_request:", pinned)
 
     def test_candidate_builds_once_and_retains_review_artifact(self) -> None:
         workflow = WORKFLOW.read_text(encoding="utf-8")

--- a/tools/release/test_release_candidate_workflow.py
+++ b/tools/release/test_release_candidate_workflow.py
@@ -60,6 +60,10 @@ class ReleaseCandidateWorkflowTests(unittest.TestCase):
         foot = ci[ci.index("  foot-reference:") :]
         self.assertIn("generate-semantic-fixture-vectors.py --check", mandatory)
         self.assertIn("validate-contract-fixtures.py", mandatory)
+        self.assertIn(
+            "python -m pytest -q tools/foot-oracle/test_run_final_buffer_comparison.py",
+            mandatory,
+        )
         self.assertNotIn("check-provenance.py", mandatory)
         self.assertNotIn("self-hosted", ci)
         self.assertIn("continue-on-error: true", foot)

--- a/tools/release/test_release_candidate_workflow.py
+++ b/tools/release/test_release_candidate_workflow.py
@@ -45,13 +45,22 @@ class ReleaseCandidateWorkflowTests(unittest.TestCase):
             'git config --global --add safe.directory "$GITHUB_WORKSPACE"', workflow
         )
         self.assertIn("useradd --create-home validator", workflow)
-        provenance = workflow.index(
-            "runuser -u validator -- python tools/foot-oracle/check-provenance.py --portable"
-        )
         candidate_check = workflow.index("prepare-candidate.py check")
-        self.assertLess(provenance, candidate_check)
+        self.assertGreater(candidate_check, workflow.index("useradd --create-home validator"))
+        self.assertNotIn("tools/foot-oracle/check-provenance.py", workflow)
         self.assertIn("runuser -u validator -- python -m unittest", workflow)
         self.assertNotIn("safe.directory '*'", workflow)
+
+    def test_foot_jobs_are_advisory_and_source_contracts_remain_mandatory(self) -> None:
+        ci = (ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")
+        mandatory = ci[ci.index("  check:") : ci.index("  foot-reference:")]
+        foot = ci[ci.index("  foot-reference:") : ci.index("  oracle:")]
+        oracle = ci[ci.index("  oracle:") :]
+        self.assertIn("generate-semantic-fixture-vectors.py --check", mandatory)
+        self.assertIn("validate-contract-fixtures.py", mandatory)
+        self.assertNotIn("check-provenance.py", mandatory)
+        self.assertIn("continue-on-error: true", foot)
+        self.assertIn("continue-on-error: true", oracle)
 
     def test_candidate_builds_once_and_retains_review_artifact(self) -> None:
         workflow = WORKFLOW.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- port the Splinterm-owned renderer acceptance policy onto the RC2 maintenance line
- keep RC2's consolidated mandatory check native to the maintenance branch
- move Foot provenance/tooling and pinned-host comparisons to advisory jobs
- remove Foot provenance from candidate construction
- retain pinned Foot fixtures, patches, exact comparators, and zero-tolerance evidence unchanged
- record the passed packaged live-font and invalid-candidate rollback acceptance

This policy-only successor does not modify shipped Rust code.

## Validation
- 55 maintenance release/package unit tests (1 expected skip)
- 104 Foot-tool and benchmark tests
- semantic vector, adopted fixture, and automation contract validators
- portable historical Foot metadata validation
- Python compileall
- `cargo fmt --all --check`
- actionlint
- `git diff --check`
- fresh independent read-only review: ACCEPT, no findings

## Residual risk
Optional Foot jobs still consume CI resources when enabled, but cannot affect mandatory CI, candidate, or promotion authority.
