### PR TITLE
Isolate remaining Foot advisory workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,45 +242,6 @@ jobs:
           if-no-files-found: error
           retention-days: 14
 
-  foot-reference:
-    name: Optional historical Foot differential tooling
-    needs: preflight
-    continue-on-error: true
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install Python fixture dependencies
-        run: python -m pip install 'jsonschema>=4.18' pillow pytest referencing
-      - name: Validate retained Foot reference tooling
-        run: |
-          set -o pipefail
-          {
-            python tools/foot-oracle/check-provenance.py --portable
-            python tools/foot-oracle/validate-fixtures.py
-            python tools/foot-oracle/validate-slice3-fixtures.py
-            python tools/foot-oracle/validate-slice3-fixtures.py tools/foot-oracle/slice4-final-buffer-fixtures.json
-            python -m pytest -q tools/foot-oracle/test_*.py
-          } 2>&1 | tee foot-reference.log
-      - name: Classify host-sensitive raster support
-        run: |
-          set +e
-          python tools/foot-oracle/check-provenance.py --ci-host
-          status=$?
-          set -e
-          if [ "$status" -eq 77 ]; then
-            echo '::notice title=Unsupported raster environment::Historical Foot differentials require the declared Omarchy reference host.'
-          elif [ "$status" -ne 0 ]; then
-            exit "$status"
-          fi
-      - name: Upload focused Foot-reference failure evidence
-        if: ${{ failure() }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: foot-reference-failure-${{ github.run_id }}
-          path: foot-reference.log
-          if-no-files-found: warn
-          retention-days: 14
-
   check:
     name: check
     if: ${{ always() }}

--- a/.github/workflows/foot-oracle-pinned.yml
+++ b/.github/workflows/foot-oracle-pinned.yml
@@ -1,4 +1,4 @@
-name: Optional pinned-host Foot differential
+name: Optional Foot differentials
 
 on:
   workflow_dispatch:
@@ -13,6 +13,44 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  portable:
+    name: Portable Foot reference tooling
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Python fixture dependencies
+        run: python -m pip install 'jsonschema>=4.18' pillow pytest referencing
+      - name: Validate retained Foot reference tooling
+        run: |
+          set -o pipefail
+          {
+            python tools/foot-oracle/check-provenance.py --portable
+            python tools/foot-oracle/validate-fixtures.py
+            python tools/foot-oracle/validate-slice3-fixtures.py
+            python tools/foot-oracle/validate-slice3-fixtures.py tools/foot-oracle/slice4-final-buffer-fixtures.json
+            python -m pytest -q tools/foot-oracle/test_*.py
+          } 2>&1 | tee foot-reference.log
+      - name: Classify host-sensitive raster support
+        run: |
+          set +e
+          python tools/foot-oracle/check-provenance.py --ci-host
+          status=$?
+          set -e
+          if [ "$status" -eq 77 ]; then
+            echo '::notice title=Unsupported raster environment::Historical Foot differentials require the declared Omarchy reference host.'
+          elif [ "$status" -ne 0 ]; then
+            exit "$status"
+          fi
+      - name: Upload focused Foot-reference failure evidence
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: foot-reference-failure-${{ github.run_id }}
+          path: foot-reference.log
+          if-no-files-found: warn
+          retention-days: 14
+
   oracle:
     name: Pinned-host Foot differential
     if: ${{ vars.SPLINTERM_ORACLE_RUNNER == 'enabled' }}

--- a/docs/adr/0013-splinterm-owned-renderer-acceptance.md
+++ b/docs/adr/0013-splinterm-owned-renderer-acceptance.md
@@ -36,9 +36,9 @@ Mandatory CI and candidate construction require:
 Foot remains a pinned **optional historical differential** at commit
 `3c5b584b0eafa772eb4376fb6eaf6643399e190e`. Its fixtures, adapter patches,
 comparators, zero-tolerance policy, and accepted evidence remain intact. The
-portable tooling job and standalone pinned-host workflow may report defects,
-but their failure or unavailability does not fail the aggregate release check and does not
-block candidate construction or promotion.
+standalone portable-tooling and pinned-host jobs may report defects, but their
+failure or unavailability does not fail or hold open the aggregate release check
+and does not block candidate construction or promotion.
 
 The optional pinned-host preflight checks inputs that can directly affect the
 comparison: the Foot revision and adapter patches; resolved font paths, face

--- a/docs/release-automation.md
+++ b/docs/release-automation.md
@@ -86,12 +86,12 @@ context green.
 | `package-automation` | all four `packaging/PKGBUILD::check()` Python suites plus package/release workflow and helper tests |
 | `renderer-contracts` | adopted Splinterm semantic vectors, public contract fixtures, and correctness-report contracts |
 
-The advisory `foot-reference` job sits outside the aggregate release check and
-validates retained Foot fixtures and Python tooling on a portable worker. The
-exact pinned-host differential lives in the separate manual/scheduled
-`foot-oracle-pinned.yml` workflow, so an unavailable self-hosted runner cannot
-hold the release-authority CI workflow open. Failures or unavailable evidence
-remain signals to investigate, not automatic release vetoes.
+Portable Foot fixture/tooling validation and the exact pinned-host differential
+both live in the separate manual/scheduled `foot-oracle-pinned.yml` workflow.
+No historical Foot job runs inside release-authority CI, so a queued worker or
+hung advisory command cannot hold candidate construction open. Failures or
+unavailable evidence remain signals to investigate, not automatic release
+vetoes.
 
 Together, the split Rust commands are equivalent to
 `cargo test --frozen --workspace -- --test-threads=1`: workspace unit, binary,

--- a/tools/foot-oracle/README.md
+++ b/tools/foot-oracle/README.md
@@ -286,8 +286,8 @@ Compiler version,
 Cargo.lock, and the complete ambient Fontconfig inventory are not comparison
 inputs. CI uses `--ci-host`: unsupported workers print
 `UNSUPPORTED_ORACLE_HOST` and exit 77; a supported worker with output-relevant
-drift fails that optional run normally. The portable tooling job is advisory;
-the self-hosted matrix runs in the separate manual/scheduled
+drift fails that optional run normally. Both the portable tooling job and the
+self-hosted matrix run in the separate manual/scheduled
 `foot-oracle-pinned.yml` workflow. Neither participates in release-authority CI.
 Reference changes require reviewed old/new metrics, heatmaps, provenance,
 and ADR updates where behavior changes; no command silently regenerates accepted

--- a/tools/release/release-doctor.py
+++ b/tools/release/release-doctor.py
@@ -95,8 +95,13 @@ def check_workflows(root: Path) -> list[str]:
         "CI authority branches": ('branches: [main, "maint/0.1"]', ci),
         "CI fail-closed aggregator": ("if: ${{ always() }}", ci),
         "CI explicit dependency result checks": ("needs.preflight.result == 'success'", ci),
-        "standalone pinned Foot manual trigger": ("workflow_dispatch:", pinned_foot),
-        "standalone pinned Foot schedule": ("schedule:", pinned_foot),
+        "standalone Foot manual trigger": ("workflow_dispatch:", pinned_foot),
+        "standalone Foot schedule": ("schedule:", pinned_foot),
+        "standalone portable Foot runner": ("runs-on: ubuntu-latest", pinned_foot),
+        "standalone portable Foot validation": (
+            "python tools/foot-oracle/check-provenance.py --portable",
+            pinned_foot,
+        ),
         "standalone pinned Foot runner": (
             "runs-on: [self-hosted, linux, x64, splinterm-oracle]",
             pinned_foot,
@@ -123,16 +128,17 @@ def check_workflows(root: Path) -> list[str]:
     ]
     try:
         check = ci[ci.index("  check:") :]
-        foot = ci[ci.index("  foot-reference:") : ci.index("  check:")]
     except ValueError:
-        errors.append("CI advisory Foot or aggregate check boundary is malformed")
+        errors.append("CI aggregate check boundary is malformed")
     else:
         if "renderer-contracts" not in check:
             errors.append("CI aggregate omits Splinterm-owned renderer contracts")
-        if "foot-reference" in check:
-            errors.append("CI aggregate makes the historical Foot differential mandatory")
-        if "continue-on-error: true" not in foot:
-            errors.append("portable Foot differential is not advisory")
+    if (
+        "foot-reference" in ci
+        or "tools/foot-oracle/check-provenance.py --portable" in ci
+        or "tools/foot-oracle/test_*.py" in ci
+    ):
+        errors.append("release-authority CI includes historical Foot advisory tooling")
     if "self-hosted" in ci:
         errors.append("release-authority CI includes a self-hosted runner")
     if "\n  push:" in pinned_foot or "\n  pull_request:" in pinned_foot:

--- a/tools/release/test_ci_workflow.py
+++ b/tools/release/test_ci_workflow.py
@@ -125,24 +125,28 @@ class CiWorkflowTests(unittest.TestCase):
 
     def test_foot_differentials_are_advisory_not_release_authority(self) -> None:
         workflow = WORKFLOW.read_text(encoding="utf-8")
-        pinned = PINNED_FOOT_WORKFLOW.read_text(encoding="utf-8")
-        check = workflow[workflow.index("  check:") :]
-        foot = workflow[
-            workflow.index("  foot-reference:") : workflow.index("  check:")
-        ]
-        self.assertNotIn("foot-reference", check)
+        standalone = PINNED_FOOT_WORKFLOW.read_text(encoding="utf-8")
+        self.assertNotIn("foot-reference", workflow)
+        self.assertNotIn("tools/foot-oracle/check-provenance.py --portable", workflow)
+        self.assertNotIn("tools/foot-oracle/test_*.py", workflow)
         self.assertNotIn("self-hosted", workflow)
-        self.assertIn("continue-on-error: true", foot)
         self.assertIn("Splinterm-owned renderer", workflow)
         self.assertIn(
             "python -m pytest -q tools/foot-oracle/test_run_final_buffer_comparison.py",
             workflow,
         )
-        self.assertIn("workflow_dispatch:", pinned)
-        self.assertIn("schedule:", pinned)
-        self.assertIn("runs-on: [self-hosted, linux, x64, splinterm-oracle]", pinned)
-        self.assertNotIn("\n  push:", pinned)
-        self.assertNotIn("\n  pull_request:", pinned)
+        self.assertIn("workflow_dispatch:", standalone)
+        self.assertIn("schedule:", standalone)
+        self.assertIn("runs-on: ubuntu-latest", standalone)
+        self.assertIn(
+            "python tools/foot-oracle/check-provenance.py --portable", standalone
+        )
+        self.assertIn("python -m pytest -q tools/foot-oracle/test_*.py", standalone)
+        self.assertIn(
+            "runs-on: [self-hosted, linux, x64, splinterm-oracle]", standalone
+        )
+        self.assertNotIn("\n  push:", standalone)
+        self.assertNotIn("\n  pull_request:", standalone)
 
     def test_flake_stress_is_manual_scheduled_bounded_and_stops_on_failure(self) -> None:
         workflow = (ROOT / ".github/workflows/flake-stress.yml").read_text(

--- a/tools/release/test_release_doctor.py
+++ b/tools/release/test_release_doctor.py
@@ -47,13 +47,19 @@ class ReleaseDoctorTests(unittest.TestCase):
 
             ci = root / ".github/workflows/ci.yml"
             ci.write_text(
-                ci.read_text(encoding="utf-8").replace(
-                    "  foot-reference:\n    name: Optional historical Foot differential tooling\n    needs: preflight\n    continue-on-error: true",
-                    "  foot-reference:\n    name: Optional historical Foot differential tooling\n    needs: preflight",
-                ),
+                ci.read_text(encoding="utf-8")
+                + "\n  foot-reference:\n"
+                + "    runs-on: ubuntu-latest\n"
+                + "    steps:\n"
+                + "      - run: python tools/foot-oracle/check-provenance.py --portable\n",
                 encoding="utf-8",
             )
-            self.assertIn("not advisory", MODULE.check_workflows(root)[0])
+            self.assertTrue(
+                any(
+                    "historical Foot advisory tooling" in error
+                    for error in MODULE.check_workflows(root)
+                )
+            )
 
     def test_workflow_policy_rejects_self_hosted_runner_in_release_ci(self) -> None:
         with tempfile.TemporaryDirectory() as value:


### PR DESCRIPTION
## Summary
- remove the hosted Foot advisory job from release-authority CI
- move portable Foot tooling checks into the standalone manual/scheduled workflow alongside pinned-host diagnostics
- enforce and document that no Foot advisory can hold candidate construction open

## Validation
- `python -m unittest tools.release.test_ci_workflow tools.release.test_release_doctor tools.release.test_release_candidate_workflow`
- `python tools/release/release-doctor.py`
- `python -m pytest -q tools/foot-oracle/test_*.py`
- `python tools/foot-oracle/check-provenance.py --portable`
- `python -m compileall -q tools/release tools/foot-oracle tools/image-spike`
- `git diff --check`
- independent read-only review: ACCEPT, no findings

Local actionlint was unavailable; the pinned actionlint CI preflight remains authoritative.