### PR TITLE
Centralize audit operation names

### DIFF
--- a/crates/splinterm-automation-client/src/lib.rs
+++ b/crates/splinterm-automation-client/src/lib.rs
@@ -27,14 +27,14 @@ use sha2::{Digest, Sha256};
 use splinterm_core::{DojoId, LairId, LayoutNode, SplintId, TopologyRevision};
 use splinterm_filemap::ReadOnlyFileMap;
 use splinterm_protocol::{
-    AccessGrant, AccessScope, AuditDecision, AuditOperation, AuditOutcome, AuditPage,
-    AutomationScope, ClientFrame, ClientRole, ControlStatus, ControlTransferOutcome, ErrorCode,
-    ImageContentMetadata, ImageContentRequest, ImageTransferMode, MAX_CWD_BYTES, MAX_FRAME_BYTES,
-    MAX_IMAGE_CHUNK_BYTES, MAX_IMAGE_CHUNK_WINDOW, MAX_TERMINAL_TRANSACTION_BYTES,
-    PROTOCOL_VERSION, PersistentAuthorizationStatus, Request, Response, RestoreLeafResult,
-    ScrollbackPage, SearchPage, ServerFrame, ServerFrameTransactionAssembler, ServerLimits,
-    SplintLifecycle, SplintRuntimeSummary, TerminalRow, TerminalSnapshot, TerminalUpdate,
-    TopologyChangeKind, TopologySnapshot, encode_frame, image_content_socket_path,
+    AccessGrant, AccessScope, AuditDecision, AuditOutcome, AuditPage, AutomationScope, ClientFrame,
+    ClientRole, ControlStatus, ControlTransferOutcome, ErrorCode, ImageContentMetadata,
+    ImageContentRequest, ImageTransferMode, MAX_CWD_BYTES, MAX_FRAME_BYTES, MAX_IMAGE_CHUNK_BYTES,
+    MAX_IMAGE_CHUNK_WINDOW, MAX_TERMINAL_TRANSACTION_BYTES, PROTOCOL_VERSION,
+    PersistentAuthorizationStatus, Request, Response, RestoreLeafResult, ScrollbackPage,
+    SearchPage, ServerFrame, ServerFrameTransactionAssembler, ServerLimits, SplintLifecycle,
+    SplintRuntimeSummary, TerminalRow, TerminalSnapshot, TerminalUpdate, TopologyChangeKind,
+    TopologySnapshot, encode_frame, image_content_socket_path,
 };
 use tokio::{
     io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt},
@@ -1381,55 +1381,6 @@ pub fn authorization_status_envelope(
     )
 }
 
-fn audit_operation_name(operation: AuditOperation) -> &'static str {
-    match operation {
-        AuditOperation::Ping => "ping",
-        AuditOperation::RequestAccess => "request_access",
-        AuditOperation::RequestLairAccess => "request_lair_access",
-        AuditOperation::AuthorizationStatus => "authorization_status",
-        AuditOperation::RevokeAccess => "revoke_access",
-        AuditOperation::ListLairs => "list_lairs",
-        AuditOperation::InspectTopology => "inspect_topology",
-        AuditOperation::SubscribeTopology => "subscribe_topology",
-        AuditOperation::InspectSplint => "inspect_splint",
-        AuditOperation::ReadGraphicalFocus => "read_graphical_focus",
-        AuditOperation::PublishGraphicalFocus => "publish_graphical_focus",
-        AuditOperation::CreateLair => "create_lair",
-        AuditOperation::SplitSplint => "split_splint",
-        AuditOperation::RelaunchSplint => "relaunch_splint",
-        AuditOperation::RestoreSplint => "restore_splint",
-        AuditOperation::RestoreDojo => "restore_dojo",
-        AuditOperation::RestoreLair => "restore_lair",
-        AuditOperation::SetLairRetention => "set_lair_retention",
-        AuditOperation::CloseSplint => "close_splint",
-        AuditOperation::SetSplitRatio => "set_split_ratio",
-        AuditOperation::NewDojo => "new_dojo",
-        AuditOperation::MaterializePreset => "materialize_preset",
-        AuditOperation::CloseDojo => "close_dojo",
-        AuditOperation::TerminateLair => "terminate_lair",
-        AuditOperation::RenameLair => "rename_lair",
-        AuditOperation::RenameDojo => "rename_dojo",
-        AuditOperation::SetDojoDefaultFocus => "set_dojo_default_focus",
-        AuditOperation::RenameSplint => "rename_splint",
-        AuditOperation::Attach => "attach",
-        AuditOperation::ScrollbackPage => "scrollback_page",
-        AuditOperation::SearchScrollback => "search_scrollback",
-        AuditOperation::AcquireControl => "acquire_control",
-        AuditOperation::SubscribeControl => "subscribe_control",
-        AuditOperation::RequestControlTransfer => "request_control_transfer",
-        AuditOperation::DecideControlTransfer => "decide_control_transfer",
-        AuditOperation::ForceControlTransfer => "force_control_transfer",
-        AuditOperation::ReleaseControl => "release_control",
-        AuditOperation::Input => "input",
-        AuditOperation::Resize => "resize",
-        AuditOperation::Detach => "detach",
-        AuditOperation::KillSplint => "kill_splint",
-        AuditOperation::ProcessExit => "process_exit",
-        AuditOperation::AuditInspect => "audit_inspect",
-        AuditOperation::PolicyReload => "policy_reload",
-    }
-}
-
 fn audit_decision_name(decision: AuditDecision) -> &'static str {
     match decision {
         AuditDecision::Allowed => "allowed",
@@ -1517,7 +1468,7 @@ fn audit_record(record: &splinterm_protocol::AuditRecord) -> Result<AuditRecordV
             device: record.peer.device,
             inode: record.peer.inode,
         },
-        operation: audit_operation_name(record.operation),
+        operation: record.operation.as_str(),
         resource,
         requested_scopes,
         decision: audit_decision_name(record.decision),
@@ -4669,7 +4620,7 @@ mod tests {
                     device: None,
                     inode: None,
                 },
-                operation: AuditOperation::Input,
+                operation: splinterm_protocol::AuditOperation::Input,
                 resource: Some(splinterm_protocol::AuditResource {
                     lair_id: None,
                     dojo_id: None,

--- a/crates/splinterm-mcp/src/dispatch.rs
+++ b/crates/splinterm-mcp/src/dispatch.rs
@@ -14,11 +14,11 @@ use splinterm_automation_client::{
 };
 use splinterm_core::{Axis, DojoId, LairId, LayoutNode, SplintId, SplitRatio, SplitSide};
 use splinterm_protocol::{
-    AccessGrant, AccessGrantSource, AccessScope, AuditDecision, AuditOperation, AuditOutcome,
-    AutomationLaunch, ErrorCode, MAX_SCROLLBACK_PAGE_ROWS, MAX_SEARCH_QUERY_BYTES,
-    MAX_SEARCH_RESULTS, MutationPreflight, MutationPreparation, Request, Response,
-    RestoreLeafResult, ScrollbackPage, SearchPage, SplintLifecycle, SplintRuntimeSummary,
-    TerminalProvenance, TerminalSnapshot, TopologySnapshot,
+    AccessGrant, AccessGrantSource, AccessScope, AuditDecision, AuditOutcome, AutomationLaunch,
+    ErrorCode, MAX_SCROLLBACK_PAGE_ROWS, MAX_SEARCH_QUERY_BYTES, MAX_SEARCH_RESULTS,
+    MutationPreflight, MutationPreparation, Request, Response, RestoreLeafResult, ScrollbackPage,
+    SearchPage, SplintLifecycle, SplintRuntimeSummary, TerminalProvenance, TerminalSnapshot,
+    TopologySnapshot,
 };
 use tokio_util::sync::CancellationToken;
 
@@ -1879,55 +1879,6 @@ fn decode_audit_cursor(value: &str) -> Option<u64> {
         .filter(|value| *value > 0)
 }
 
-fn audit_operation_name(operation: AuditOperation) -> &'static str {
-    match operation {
-        AuditOperation::Ping => "ping",
-        AuditOperation::RequestAccess => "request_access",
-        AuditOperation::RequestLairAccess => "request_lair_access",
-        AuditOperation::AuthorizationStatus => "authorization_status",
-        AuditOperation::RevokeAccess => "revoke_access",
-        AuditOperation::ListLairs => "list_lairs",
-        AuditOperation::InspectTopology => "inspect_topology",
-        AuditOperation::SubscribeTopology => "subscribe_topology",
-        AuditOperation::InspectSplint => "inspect_splint",
-        AuditOperation::ReadGraphicalFocus => "read_graphical_focus",
-        AuditOperation::PublishGraphicalFocus => "publish_graphical_focus",
-        AuditOperation::CreateLair => "create_lair",
-        AuditOperation::SplitSplint => "split_splint",
-        AuditOperation::RelaunchSplint => "relaunch_splint",
-        AuditOperation::RestoreSplint => "restore_splint",
-        AuditOperation::RestoreDojo => "restore_dojo",
-        AuditOperation::RestoreLair => "restore_lair",
-        AuditOperation::SetLairRetention => "set_lair_retention",
-        AuditOperation::CloseSplint => "close_splint",
-        AuditOperation::SetSplitRatio => "set_split_ratio",
-        AuditOperation::NewDojo => "new_dojo",
-        AuditOperation::MaterializePreset => "materialize_preset",
-        AuditOperation::CloseDojo => "close_dojo",
-        AuditOperation::TerminateLair => "terminate_lair",
-        AuditOperation::RenameLair => "rename_lair",
-        AuditOperation::RenameDojo => "rename_dojo",
-        AuditOperation::SetDojoDefaultFocus => "set_dojo_default_focus",
-        AuditOperation::RenameSplint => "rename_splint",
-        AuditOperation::Attach => "attach",
-        AuditOperation::ScrollbackPage => "scrollback_page",
-        AuditOperation::SearchScrollback => "search_scrollback",
-        AuditOperation::AcquireControl => "acquire_control",
-        AuditOperation::SubscribeControl => "subscribe_control",
-        AuditOperation::RequestControlTransfer => "request_control_transfer",
-        AuditOperation::DecideControlTransfer => "decide_control_transfer",
-        AuditOperation::ForceControlTransfer => "force_control_transfer",
-        AuditOperation::ReleaseControl => "release_control",
-        AuditOperation::Input => "input",
-        AuditOperation::Resize => "resize",
-        AuditOperation::Detach => "detach",
-        AuditOperation::KillSplint => "kill_splint",
-        AuditOperation::ProcessExit => "process_exit",
-        AuditOperation::AuditInspect => "audit_inspect",
-        AuditOperation::PolicyReload => "policy_reload",
-    }
-}
-
 fn audit_outcome(decision: AuditDecision, outcome: Option<AuditOutcome>) -> &'static str {
     match (decision, outcome) {
         (AuditDecision::Denied | AuditDecision::Rejected | AuditDecision::Expired, _) => "denied",
@@ -2297,7 +2248,7 @@ pub(crate) async fn dispatch(
                         .map(|record| {
                             json!({
                                 "audit_id": record.audit_id,
-                                "operation": audit_operation_name(record.operation),
+                                "operation": record.operation.as_str(),
                                 "outcome": audit_outcome(record.decision, record.outcome),
                             })
                         })

--- a/crates/splinterm-protocol/src/lib.rs
+++ b/crates/splinterm-protocol/src/lib.rs
@@ -1464,6 +1464,58 @@ pub enum AuditOperation {
     PolicyReload,
 }
 
+impl AuditOperation {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Ping => "ping",
+            Self::RequestAccess => "request_access",
+            Self::RequestLairAccess => "request_lair_access",
+            Self::AuthorizationStatus => "authorization_status",
+            Self::RevokeAccess => "revoke_access",
+            Self::ListLairs => "list_lairs",
+            Self::InspectTopology => "inspect_topology",
+            Self::SubscribeTopology => "subscribe_topology",
+            Self::InspectSplint => "inspect_splint",
+            Self::ReadGraphicalFocus => "read_graphical_focus",
+            Self::PublishGraphicalFocus => "publish_graphical_focus",
+            Self::CreateLair => "create_lair",
+            Self::SplitSplint => "split_splint",
+            Self::RelaunchSplint => "relaunch_splint",
+            Self::RestoreSplint => "restore_splint",
+            Self::RestoreDojo => "restore_dojo",
+            Self::RestoreLair => "restore_lair",
+            Self::SetLairRetention => "set_lair_retention",
+            Self::CloseSplint => "close_splint",
+            Self::SetSplitRatio => "set_split_ratio",
+            Self::NewDojo => "new_dojo",
+            Self::MaterializePreset => "materialize_preset",
+            Self::CloseDojo => "close_dojo",
+            Self::TerminateLair => "terminate_lair",
+            Self::RenameLair => "rename_lair",
+            Self::RenameDojo => "rename_dojo",
+            Self::SetDojoDefaultFocus => "set_dojo_default_focus",
+            Self::RenameSplint => "rename_splint",
+            Self::Attach => "attach",
+            Self::ScrollbackPage => "scrollback_page",
+            Self::SearchScrollback => "search_scrollback",
+            Self::AcquireControl => "acquire_control",
+            Self::SubscribeControl => "subscribe_control",
+            Self::RequestControlTransfer => "request_control_transfer",
+            Self::DecideControlTransfer => "decide_control_transfer",
+            Self::ForceControlTransfer => "force_control_transfer",
+            Self::ReleaseControl => "release_control",
+            Self::Input => "input",
+            Self::Resize => "resize",
+            Self::Detach => "detach",
+            Self::KillSplint => "kill_splint",
+            Self::ProcessExit => "process_exit",
+            Self::AuditInspect => "audit_inspect",
+            Self::PolicyReload => "policy_reload",
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum AuditDecision {
@@ -2930,6 +2982,61 @@ impl ServerFrameTransactionAssembler {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn audit_operation_name_matches_its_wire_representation() {
+        for operation in [
+            AuditOperation::Ping,
+            AuditOperation::RequestAccess,
+            AuditOperation::RequestLairAccess,
+            AuditOperation::AuthorizationStatus,
+            AuditOperation::RevokeAccess,
+            AuditOperation::ListLairs,
+            AuditOperation::InspectTopology,
+            AuditOperation::SubscribeTopology,
+            AuditOperation::InspectSplint,
+            AuditOperation::ReadGraphicalFocus,
+            AuditOperation::PublishGraphicalFocus,
+            AuditOperation::CreateLair,
+            AuditOperation::SplitSplint,
+            AuditOperation::RelaunchSplint,
+            AuditOperation::RestoreSplint,
+            AuditOperation::RestoreDojo,
+            AuditOperation::RestoreLair,
+            AuditOperation::SetLairRetention,
+            AuditOperation::CloseSplint,
+            AuditOperation::SetSplitRatio,
+            AuditOperation::NewDojo,
+            AuditOperation::MaterializePreset,
+            AuditOperation::CloseDojo,
+            AuditOperation::TerminateLair,
+            AuditOperation::RenameLair,
+            AuditOperation::RenameDojo,
+            AuditOperation::SetDojoDefaultFocus,
+            AuditOperation::RenameSplint,
+            AuditOperation::Attach,
+            AuditOperation::ScrollbackPage,
+            AuditOperation::SearchScrollback,
+            AuditOperation::AcquireControl,
+            AuditOperation::SubscribeControl,
+            AuditOperation::RequestControlTransfer,
+            AuditOperation::DecideControlTransfer,
+            AuditOperation::ForceControlTransfer,
+            AuditOperation::ReleaseControl,
+            AuditOperation::Input,
+            AuditOperation::Resize,
+            AuditOperation::Detach,
+            AuditOperation::KillSplint,
+            AuditOperation::ProcessExit,
+            AuditOperation::AuditInspect,
+            AuditOperation::PolicyReload,
+        ] {
+            assert_eq!(
+                serde_json::to_string(&operation).unwrap(),
+                format!("\"{}\"", operation.as_str())
+            );
+        }
+    }
 
     #[test]
     fn frames_are_length_prefixed_and_explicit() {


### PR DESCRIPTION
## Summary

- add canonical exhaustive `AuditOperation::as_str()` in `splinterm-protocol`
- use the canonical mapping from the automation client and MCP adapter
- remove duplicate operation-name matches and guard serde wire-name parity

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test -p splinterm-protocol audit_operation_name_matches_its_wire_representation`
- `cargo test -p splinterm-automation-client`
- `cargo test -p splinterm-mcp`
- `git diff --check origin/main...HEAD`
- fresh independent read-only review: Merge verdict OK; no P0/P1/P2 findings

## Residual risks

The full workspace test reached four host-font-dependent renderer failures. A representative failure reproduces unchanged on `origin/main`; the refactor does not touch renderer or font code.