### PR TITLE
Move GitHub Actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     name: Fast release preflight
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Validate deterministic release state
@@ -33,7 +33,7 @@ jobs:
     needs: preflight
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       # rmcp 2.2.0's macros require Rust 1.88; keep CI on the workspace MSRV.
       - uses: dtolnay/rust-toolchain@1.88.0
         with:
@@ -52,7 +52,7 @@ jobs:
     needs: preflight
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@1.88.0
       - uses: Swatinem/rust-cache@v2
       - name: Install native dependencies
@@ -111,7 +111,7 @@ jobs:
           } 2>&1 | tee -a workspace-tests.log
       - name: Upload focused workspace failure evidence
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: workspace-test-failure-${{ github.run_id }}
           path: workspace-tests.log
@@ -123,7 +123,7 @@ jobs:
     needs: preflight
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@1.88.0
       - uses: Swatinem/rust-cache@v2
       - name: Install native dependencies
@@ -139,7 +139,7 @@ jobs:
             2>&1 | tee daemon-end-to-end.log
       - name: Upload focused daemon failure evidence
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: daemon-end-to-end-failure-${{ github.run_id }}
           path: daemon-end-to-end.log
@@ -151,7 +151,7 @@ jobs:
     needs: preflight
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@1.88.0
       - uses: Swatinem/rust-cache@v2
       - name: Install native dependencies
@@ -166,7 +166,7 @@ jobs:
             2>&1 | tee mcp-protocol.log
       - name: Upload focused MCP failure evidence
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: mcp-protocol-failure-${{ github.run_id }}
           path: mcp-protocol.log
@@ -178,7 +178,7 @@ jobs:
     needs: preflight
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Run package/release Python boundary
@@ -208,7 +208,7 @@ jobs:
             2>&1 | tee package-release-tests.log
       - name: Upload focused package/release failure evidence
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: package-release-failure-${{ github.run_id }}
           path: package-release-tests.log
@@ -220,7 +220,7 @@ jobs:
     needs: preflight
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install Python fixture dependencies
         run: python -m pip install 'jsonschema>=4.18' pillow pytest referencing
       - name: Validate source-owned contracts and benchmark reporting
@@ -235,7 +235,7 @@ jobs:
           } 2>&1 | tee renderer-contracts.log
       - name: Upload focused renderer-contract failure evidence
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: renderer-contract-failure-${{ github.run_id }}
           path: renderer-contracts.log

--- a/.github/workflows/distribute-aur.yml
+++ b/.github/workflows/distribute-aur.yml
@@ -40,7 +40,7 @@ jobs:
       tag: ${{ steps.candidate.outputs.tag }}
       publication_receipt_sha256: ${{ steps.candidate.outputs.publication_receipt_sha256 }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ github.sha }}
           persist-credentials: false
@@ -153,7 +153,7 @@ jobs:
             --release public-release.json --ref public-ref.json --downloads public-assets
 
       - name: Transfer closed drafts and receipts to protected distribution job
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: verified-aur-input-${{ inputs.candidate_run_id }}-${{ inputs.publication_run_id }}
           path: |
@@ -172,7 +172,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ github.sha }}
           persist-credentials: false
@@ -310,7 +310,7 @@ jobs:
             --output aur-distribution-receipt.json
 
       - name: Retain AUR distribution receipt
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: aur-distribution-receipt-${{ needs.verify.outputs.tag }}
           path: aur-distribution-receipt.json

--- a/.github/workflows/flake-stress.yml
+++ b/.github/workflows/flake-stress.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 180
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@1.88.0
       - uses: Swatinem/rust-cache@v2
       - name: Install native dependencies
@@ -42,7 +42,7 @@ jobs:
           done
       - name: Retain stress evidence
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: daemon-mcp-flake-stress-${{ github.run_id }}
           path: flake-stress.log

--- a/.github/workflows/foot-oracle-pinned.yml
+++ b/.github/workflows/foot-oracle-pinned.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install Python fixture dependencies
         run: python -m pip install 'jsonschema>=4.18' pillow pytest referencing
       - name: Validate retained Foot reference tooling
@@ -44,7 +44,7 @@ jobs:
           fi
       - name: Upload focused Foot-reference failure evidence
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: foot-reference-failure-${{ github.run_id }}
           path: foot-reference.log
@@ -57,14 +57,14 @@ jobs:
     runs-on: [self-hosted, linux, x64, splinterm-oracle]
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Require exact pinned-host provenance
         run: python tools/foot-oracle/check-provenance.py
       - name: Run strict default raster smoke
         run: python tools/foot-oracle/run-font-matrix.py /tmp/splinterm-oracle-ci --case regular-12px-120
       - name: Upload reviewable failure evidence
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: splinterm-oracle-failure-${{ github.run_id }}
           path: /tmp/splinterm-oracle-ci

--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -32,7 +32,7 @@ jobs:
       version: ${{ steps.candidate.outputs.version }}
       tag: ${{ steps.candidate.outputs.tag }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           persist-credentials: false
 
@@ -154,7 +154,7 @@ jobs:
           PY
 
       - name: Transfer verified candidate to protected job
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: verified-release-candidate-${{ inputs.candidate_run_id }}
           path: |
@@ -173,7 +173,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ github.sha }}
           persist-credentials: false
@@ -277,7 +277,7 @@ jobs:
             --output release-receipt.json
 
       - name: Retain durable publication receipt
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: release-receipt-${{ needs.verify.outputs.tag }}
           path: release-receipt.json

--- a/.github/workflows/recover-release.yml
+++ b/.github/workflows/recover-release.yml
@@ -34,7 +34,7 @@ jobs:
       candidate_manifest_sha256: ${{ steps.identity.outputs.candidate_manifest_sha256 }}
       promotion_record_sha256: ${{ steps.identity.outputs.promotion_record_sha256 }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ github.sha }}
           persist-credentials: false
@@ -114,7 +114,7 @@ jobs:
           cmp retained/promotion.json promotion-reverified.json
 
       - name: Transfer verified recovery input to protected job
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: verified-recovery-input-${{ inputs.promotion_run_id }}
           path: retained
@@ -130,7 +130,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ github.sha }}
           persist-credentials: false
@@ -253,7 +253,7 @@ jobs:
             --output release-receipt.json
 
       - name: Retain completed recovery receipt
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: release-receipt-${{ needs.verify.outputs.tag }}
           path: release-receipt.json

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Bootstrap Git for checkout
         run: pacman -Sy --noconfirm git
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -154,7 +154,7 @@ jobs:
           PY
 
       - name: Retain private candidate for review
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: splinterm-${{ inputs.version }}-candidate-${{ github.sha }}
           path: ${{ env.CANDIDATE_DIR }}

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -26,7 +26,7 @@ jobs:
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:
           node-version: 22

--- a/tools/release/test_release_candidate_workflow.py
+++ b/tools/release/test_release_candidate_workflow.py
@@ -75,7 +75,7 @@ class ReleaseCandidateWorkflowTests(unittest.TestCase):
         self.assertLess(build, create)
         self.assertIn("runuser -u builder -- python tools/release/prepare-candidate.py create", workflow)
         self.assertIn('--ci-attestation "$GITHUB_WORKSPACE/ci-attestation.json"', workflow)
-        self.assertIn("uses: actions/upload-artifact@v4", workflow)
+        self.assertIn("uses: actions/upload-artifact@v6", workflow)
         self.assertIn("include-hidden-files: true", workflow)
         self.assertIn("retention-days: 14", workflow)
         self.assertIn("fetch-depth: 0", workflow)


### PR DESCRIPTION
## Problem

GitHub-hosted workflow logs warn that the Node 20 action runtime is deprecated and is being forcibly upgraded. The repository still used `actions/checkout@v4` and `actions/upload-artifact@v4` across CI, advisory, site, AUR, candidate, promotion, and recovery workflows.

## Changes

- upgrade all 18 checkout references to `actions/checkout@v5`
- upgrade all 15 upload references to `actions/upload-artifact@v6`
- preserve checkout refs, credential policy, artifact names, paths, retention, hidden-file handling, and release permissions
- update the source-owned release-candidate workflow invariant to require upload-artifact v6

## Validation

- `python -m unittest tools/release/test_release_candidate_workflow.py` — 5 passed
- `python tools/release/release-doctor.py` — passed
- repository-pinned actionlint 1.7.7 — passed
- all workflow YAML parsed successfully
- action inventory and exact-diff invariant checks — passed
- `git diff --check` — passed
- independent read-only review — approved with no remaining findings

## Residual risk

`checkout@v5` and `upload-artifact@v6` require Actions Runner v2.327.1 or newer. All active jobs use GitHub-hosted runners. The conditional self-hosted Foot oracle is currently disabled: `SPLINTERM_ORACLE_RUNNER` is absent and the repository has no registered runner. Provision or upgrade that runner to v2.327.1+ before enabling the oracle job.
