### PR TITLE
Prepare 0.1.0 RC3 stabilization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,7 @@ jobs:
             tools/automation/test_dojo_picker.py \
             tools/package/test_release_manifest.py \
             tools/package/test_installer_safety.py \
+            tools/package/test_validate_mcp_package.py \
             tools/release/test_prepare_candidate.py \
             tools/release/test_promote_release.py \
             tools/release/test_release_candidate_workflow.py \

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1400,7 +1400,7 @@ dependencies = [
 
 [[package]]
 name = "splinterd"
-version = "0.1.0-rc.2"
+version = "0.1.0-rc.3"
 dependencies = [
  "anyhow",
  "libc",
@@ -1425,7 +1425,7 @@ dependencies = [
 
 [[package]]
 name = "splinterm"
-version = "0.1.0-rc.2"
+version = "0.1.0-rc.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -1455,7 +1455,7 @@ dependencies = [
 
 [[package]]
 name = "splinterm-automation-client"
-version = "0.1.0-rc.2"
+version = "0.1.0-rc.3"
 dependencies = [
  "anyhow",
  "rustix",
@@ -1471,7 +1471,7 @@ dependencies = [
 
 [[package]]
 name = "splinterm-core"
-version = "0.1.0-rc.2"
+version = "0.1.0-rc.3"
 dependencies = [
  "serde",
  "serde_json",
@@ -1481,7 +1481,7 @@ dependencies = [
 
 [[package]]
 name = "splinterm-filemap"
-version = "0.1.0-rc.2"
+version = "0.1.0-rc.3"
 dependencies = [
  "memmap2",
  "rustix",
@@ -1489,7 +1489,7 @@ dependencies = [
 
 [[package]]
 name = "splinterm-freetype"
-version = "0.1.0-rc.2"
+version = "0.1.0-rc.3"
 dependencies = [
  "freetype-rs",
  "splinterm-filemap",
@@ -1500,7 +1500,7 @@ dependencies = [
 
 [[package]]
 name = "splinterm-graphical-relay"
-version = "0.1.0-rc.2"
+version = "0.1.0-rc.3"
 dependencies = [
  "anyhow",
  "tokio",
@@ -1509,7 +1509,7 @@ dependencies = [
 
 [[package]]
 name = "splinterm-mcp"
-version = "0.1.0-rc.2"
+version = "0.1.0-rc.3"
 dependencies = [
  "anyhow",
  "rmcp",
@@ -1524,7 +1524,7 @@ dependencies = [
 
 [[package]]
 name = "splinterm-pixman"
-version = "0.1.0-rc.2"
+version = "0.1.0-rc.3"
 dependencies = [
  "libc",
  "pixman-sys",
@@ -1533,7 +1533,7 @@ dependencies = [
 
 [[package]]
 name = "splinterm-protocol"
-version = "0.1.0-rc.2"
+version = "0.1.0-rc.3"
 dependencies = [
  "base64",
  "rustix",
@@ -1546,7 +1546,7 @@ dependencies = [
 
 [[package]]
 name = "splinterm-pty"
-version = "0.1.0-rc.2"
+version = "0.1.0-rc.3"
 dependencies = [
  "rustix",
  "thiserror",
@@ -1555,7 +1555,7 @@ dependencies = [
 
 [[package]]
 name = "splinterm-relay"
-version = "0.1.0-rc.2"
+version = "0.1.0-rc.3"
 dependencies = [
  "anyhow",
  "nix",
@@ -1567,7 +1567,7 @@ dependencies = [
 
 [[package]]
 name = "splinterm-terminal"
-version = "0.1.0-rc.2"
+version = "0.1.0-rc.3"
 dependencies = [
  "base64",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.1.0-rc.2"
+version = "0.1.0-rc.3"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT"

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,8 +1,8 @@
-# Splinterm 0.1.0 RC3 — Stabilization (unreleased)
+# Splinterm 0.1.0 RC3 — Stabilization
 
 RC3 retains the RC2 feature set and fixes bounded loading, font observation, and
-connection cleanup. It is prepared locally; RC2 remains the public release until
-RC3 passes exact-source/package acceptance and human-approved publication.
+connection cleanup. This is a prerelease for continued testing before 0.1.0
+stable.
 
 ## RC3 fixes
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,30 @@
+# Splinterm 0.1.0 RC3 — Stabilization (unreleased)
+
+RC3 retains the RC2 feature set and fixes bounded loading, font observation, and
+connection cleanup. It is prepared locally; RC2 remains the public release until
+RC3 passes exact-source/package acceptance and human-approved publication.
+
+## RC3 fixes
+
+- Unchanged Fontconfig sources no longer trigger repeated staging when an
+  incompatible bold or italic face falls back to the regular face. Source and
+  renderer fingerprints remain separate, preserving RC2's resolution-race fix.
+- Policy files that are FIFOs are rejected without waiting for a writer.
+- Revoking another automation connection no longer discards a partially received
+  request header or body.
+- Abnormal connection exits remove their topology subscriptions immediately,
+  without waiting for another topology mutation.
+- Relay close and session cancellation interrupt blocked writes and reclaim
+  per-channel queues. Remote EOF still delivers already-received bytes in order
+  to slow consumers; pending drains remain charged against channel admission.
+
+Upgrades retain the documented 0.1 daemon-lifetime boundary: replacing/restarting
+an incompatible daemon ends its child processes. Use the external-terminal
+upgrade and rollback workflow in [packaging](docs/packaging.md). No live-session
+handoff or new compatibility guarantee is introduced by RC3.
+
+---
+
 # Splinterm 0.1.0 RC2 — Font Reload Closure
 
 This is the second release candidate for Splinterm 0.1.0. It retains the complete

--- a/crates/splinterd/src/main.rs
+++ b/crates/splinterd/src/main.rs
@@ -1337,8 +1337,7 @@ async fn serve_client(stream: UnixStream, state: Arc<DaemonState>) -> Result<()>
         tokio::select! {
             result = authenticated => result,
             exited = peer_monitor.exited() => {
-                exited?;
-                Err(anyhow::anyhow!("socket peer exited"))
+                exited.and_then(|()| Err(anyhow::anyhow!("socket peer exited")))
             }
         }
     } else {
@@ -1467,6 +1466,11 @@ async fn append_preset_leaf_audit(state: &DaemonState, splint_id: SplintId, succ
 }
 
 async fn cleanup_connection(state: &DaemonState, connection_id: u64) {
+    state
+        .topology_hub
+        .lock()
+        .await
+        .remove_connections(&HashSet::from([connection_id]));
     retire_transient_lair_for_owner(state, connection_id).await;
     state
         .automation_connections
@@ -1730,11 +1734,17 @@ async fn serve_authenticated(
                 }
                 break;
             }
-            revoked = connection_revocations.recv(), if connection_revocation_disconnects(role) => match revoked {
-                Ok(revoked) if revoked == connection_id => break,
-                Ok(_) | Err(broadcast::error::RecvError::Lagged(_)) => continue,
-                Err(broadcast::error::RecvError::Closed) => break,
-            },
+            // Filtering inside this future keeps read_exact's partial header/body alive
+            // when a different connection is revoked.
+            () = async {
+                loop {
+                    match connection_revocations.recv().await {
+                        Ok(revoked) if revoked == connection_id => break,
+                        Ok(_) | Err(broadcast::error::RecvError::Lagged(_)) => {}
+                        Err(broadcast::error::RecvError::Closed) => break,
+                    }
+                }
+            }, if connection_revocation_disconnects(role) => break,
             frame = read_optional_frame(&mut reader) => frame?,
         };
         let Some(frame) = frame else { break };
@@ -8376,6 +8386,234 @@ fn try_admit_connection(connections: &Arc<Semaphore>) -> Option<tokio::sync::Own
 mod tests {
     use super::*;
     use std::time::{SystemTime, UNIX_EPOCH};
+
+    async fn exercise_fragmented_authenticated_read(split: usize, reload: bool) {
+        time::timeout(Duration::from_secs(2), async {
+            let state = test_state(false);
+            let peer = PeerIdentity::for_test();
+            let (mut client, server) = UnixStream::pair().unwrap();
+            // A cloned descriptor lets the test observe consumption, not just elapsed time.
+            let observer = server.into_std().unwrap();
+            let server = UnixStream::from_std(observer.try_clone().unwrap()).unwrap();
+            let (reader, _writer) = server.into_split();
+            let (outbound, mut responses) = mpsc::channel(4);
+            let (control, mut controls) = mpsc::channel(4);
+            let (_closed, writer_closed) = watch::channel(false);
+            let task_state = state.clone();
+            let task = tokio::spawn(async move {
+                Box::pin(serve_authenticated(
+                    reader,
+                    &task_state,
+                    &peer,
+                    41,
+                    &outbound,
+                    &control,
+                    writer_closed,
+                ))
+                .await
+            });
+            client
+                .write_all(
+                    &splinterm_protocol::encode_frame(&ClientFrame::Hello {
+                        minimum_version: PROTOCOL_VERSION,
+                        maximum_version: PROTOCOL_VERSION,
+                        role: ClientRole::Automation,
+                    })
+                    .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert!(matches!(
+                controls.recv().await,
+                Some(ServerFrame::Hello { .. })
+            ));
+            let frame =
+                splinterm_protocol::encode_frame(&ClientFrame::Cancel { request_id: 7 }).unwrap();
+            client.write_all(&frame[..split]).await.unwrap();
+            while rustix::io::ioctl_fionread(&observer).unwrap() != 0 {
+                tokio::task::yield_now().await;
+            }
+            // Ensure the unrelated broadcast was consumed while the frame is partial.
+            state.connection_revocations.send(99).unwrap();
+            while !state.connection_revocations.is_empty() {
+                tokio::task::yield_now().await;
+            }
+            client.write_all(&frame[split..]).await.unwrap();
+            assert!(matches!(
+                responses.recv().await.unwrap().frame,
+                ServerFrame::Error {
+                    request_id: Some(7),
+                    ..
+                }
+            ));
+            // Leave another body incomplete: targeted teardown must still interrupt it.
+            client.write_all(&frame[..5]).await.unwrap();
+            while rustix::io::ioctl_fionread(&observer).unwrap() != 0 {
+                tokio::task::yield_now().await;
+            }
+            if reload {
+                state.policy_reloads.send(1).unwrap();
+                assert!(matches!(
+                    controls.recv().await,
+                    Some(ServerFrame::Error { .. })
+                ));
+            } else {
+                state.connection_revocations.send(41).unwrap();
+            }
+            task.await.unwrap().unwrap();
+        })
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn fragmented_header_survives_unrelated_revocation_and_targeted_revoke_ends_read() {
+        exercise_fragmented_authenticated_read(2, false).await;
+    }
+
+    #[tokio::test]
+    async fn fragmented_body_survives_unrelated_revocation_and_policy_reload_ends_read() {
+        exercise_fragmented_authenticated_read(6, true).await;
+    }
+
+    #[tokio::test]
+    async fn cleanup_connection_removes_only_its_topology_subscriptions() {
+        time::timeout(Duration::from_secs(1), async {
+            let state = test_state(false);
+            let mut first = state.topology_hub.lock().await.subscribe(1, 41);
+            let mut second = state.topology_hub.lock().await.subscribe(2, 41);
+            let mut sibling = state.topology_hub.lock().await.subscribe(3, 42);
+            cleanup_connection(&state, 41).await;
+            assert_eq!(state.topology_hub.lock().await.subscribers.len(), 1);
+            assert!(first.changes.recv().await.is_none());
+            assert!(second.changes.recv().await.is_none());
+            assert!(matches!(
+                sibling.changes.try_recv(),
+                Err(mpsc::error::TryRecvError::Empty)
+            ));
+            cleanup_connection(&state, 41).await;
+            assert_eq!(state.topology_hub.lock().await.subscribers.len(), 1);
+        })
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn cancelled_authenticated_future_still_allows_owner_topology_cleanup() {
+        time::timeout(Duration::from_secs(2), async {
+            let state = test_state(true);
+            let peer = PeerIdentity::for_test();
+            let (mut client, server) = UnixStream::pair().unwrap();
+            let (reader, _writer) = server.into_split();
+            let (outbound, mut responses) = mpsc::channel(4);
+            let (control, mut controls) = mpsc::channel(4);
+            let (_closed, writer_closed) = watch::channel(false);
+            let task_state = state.clone();
+            let task = tokio::spawn(async move {
+                Box::pin(serve_authenticated(
+                    reader,
+                    &task_state,
+                    &peer,
+                    41,
+                    &outbound,
+                    &control,
+                    writer_closed,
+                ))
+                .await
+            });
+            for frame in [
+                ClientFrame::Hello {
+                    minimum_version: PROTOCOL_VERSION,
+                    maximum_version: PROTOCOL_VERSION,
+                    role: ClientRole::Automation,
+                },
+                ClientFrame::Request {
+                    request_id: 1,
+                    diagnostic_correlation: None,
+                    request: Request::SubscribeTopology,
+                },
+            ] {
+                client
+                    .write_all(&splinterm_protocol::encode_frame(&frame).unwrap())
+                    .await
+                    .unwrap();
+            }
+            assert!(matches!(
+                controls.recv().await,
+                Some(ServerFrame::Hello { .. })
+            ));
+            assert!(matches!(
+                responses.recv().await.unwrap().frame,
+                ServerFrame::Response {
+                    result: Response::TopologySubscribed { .. },
+                    ..
+                }
+            ));
+            let _sibling = state.topology_hub.lock().await.subscribe(u64::MAX, 42);
+            // Peer-monitor completion drops this future rather than running its epilogue.
+            task.abort();
+            assert!(task.await.unwrap_err().is_cancelled());
+            assert_eq!(state.topology_hub.lock().await.subscribers.len(), 2);
+            cleanup_connection(&state, 41).await;
+            let hub = state.topology_hub.lock().await;
+            assert_eq!(hub.subscribers.len(), 1);
+            assert!(hub.subscribers.contains_key(&u64::MAX));
+        })
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn malformed_frame_runs_owner_topology_cleanup() {
+        time::timeout(Duration::from_secs(2), async {
+            let state = test_state(true);
+            let (mut client, server) = UnixStream::pair().unwrap();
+            let task = tokio::spawn(serve_client(server, state.clone()));
+            for frame in [
+                ClientFrame::Hello {
+                    minimum_version: PROTOCOL_VERSION,
+                    maximum_version: PROTOCOL_VERSION,
+                    role: ClientRole::Automation,
+                },
+                ClientFrame::Request {
+                    request_id: 1,
+                    diagnostic_correlation: None,
+                    request: Request::SubscribeTopology,
+                },
+            ] {
+                client
+                    .write_all(&splinterm_protocol::encode_frame(&frame).unwrap())
+                    .await
+                    .unwrap();
+                let mut length = [0; 4];
+                client.read_exact(&mut length).await.unwrap();
+                let mut body = vec![0; u32::from_be_bytes(length) as usize];
+                client.read_exact(&mut body).await.unwrap();
+                let reply: ServerFrame = serde_json::from_slice(&body).unwrap();
+                assert!(matches!(
+                    reply,
+                    ServerFrame::Hello { .. }
+                        | ServerFrame::Response {
+                            result: Response::TopologySubscribed { .. },
+                            ..
+                        }
+                ));
+            }
+            assert_eq!(state.topology_hub.lock().await.subscribers.len(), 1);
+            let _sibling = state
+                .topology_hub
+                .lock()
+                .await
+                .subscribe(u64::MAX, u64::MAX);
+            client.write_all(&[0; 4]).await.unwrap();
+            assert!(task.await.unwrap().is_err());
+            let hub = state.topology_hub.lock().await;
+            assert_eq!(hub.subscribers.len(), 1);
+            assert!(hub.subscribers.contains_key(&u64::MAX));
+        })
+        .await
+        .unwrap();
+    }
 
     #[test]
     fn packaged_workload_cgroup_argument_is_exact() {

--- a/crates/splinterd/src/policy.rs
+++ b/crates/splinterd/src/policy.rs
@@ -593,10 +593,12 @@ fn open_without_symlinks(path: &Path) -> Result<File> {
         )
         .with_context(|| format!("cannot open policy directory component {component:?}"))?;
     }
+    // Inspect the opened descriptor before reading it. A FIFO must not block
+    // this open indefinitely before the regular-file validation can reject it.
     let descriptor = rustix::fs::openat(
         &directory,
         *file_name,
-        OFlags::RDONLY | OFlags::NOFOLLOW | OFlags::CLOEXEC,
+        OFlags::RDONLY | OFlags::NOFOLLOW | OFlags::CLOEXEC | OFlags::NONBLOCK,
         Mode::empty(),
     )
     .context("cannot open policy file")?;
@@ -774,6 +776,52 @@ mod tests {
         assert_eq!(document.rules.len(), 1);
         assert_eq!(document.rules[0].id, "reader");
         fs::remove_file(path).unwrap();
+    }
+
+    #[test]
+    fn fifo_policy_is_rejected_without_waiting_for_a_writer() {
+        const CHILD_PATH: &str = "SPLINTERM_POLICY_FIFO_TEST_PATH";
+        if let Some(path) = std::env::var_os(CHILD_PATH) {
+            let error = inspect_file(Path::new(&path)).unwrap_err();
+            assert!(error.to_string().contains("regular file"));
+            return;
+        }
+
+        let path = test_path("fifo");
+        rustix::fs::mknodat(
+            rustix::fs::CWD,
+            &path,
+            rustix::fs::FileType::Fifo,
+            Mode::RUSR | Mode::WUSR,
+            0,
+        )
+        .unwrap();
+        let mut child = std::process::Command::new(std::env::current_exe().unwrap())
+            .args([
+                "--exact",
+                "policy::tests::fifo_policy_is_rejected_without_waiting_for_a_writer",
+                "--nocapture",
+            ])
+            .env(CHILD_PATH, &path)
+            .spawn()
+            .unwrap();
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(3);
+        let status = loop {
+            if let Some(status) = child.try_wait().unwrap() {
+                break Some(status);
+            }
+            if std::time::Instant::now() >= deadline {
+                child.kill().unwrap();
+                child.wait().unwrap();
+                break None;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        };
+        fs::remove_file(path).unwrap();
+        assert!(
+            status.is_some_and(|status| status.success()),
+            "policy loader blocked or failed"
+        );
     }
 
     #[test]

--- a/crates/splinterm-graphical-relay/src/client.rs
+++ b/crates/splinterm-graphical-relay/src/client.rs
@@ -32,7 +32,6 @@ struct IncomingData {
 enum IncomingCommand {
     Data(IncomingData),
     HalfClose,
-    Close,
 }
 
 #[derive(Debug)]
@@ -40,6 +39,18 @@ struct Route {
     opened: Option<oneshot::Sender<Result<(), String>>>,
     incoming: mpsc::Sender<IncomingCommand>,
     incoming_bytes: Arc<Semaphore>,
+    outgoing_cancellation: CancellationToken,
+    incoming_cancellation: CancellationToken,
+    data_outbound: FairDataChannel,
+}
+
+impl Drop for Route {
+    fn drop(&mut self) {
+        // Removing a remote route is ordered incoming EOF, not cancellation:
+        // dropping its sender drains queued bytes under the retained channel slot.
+        self.outgoing_cancellation.cancel();
+        self.data_outbound.discard();
+    }
 }
 
 #[derive(Debug)]
@@ -47,6 +58,7 @@ struct ClientState {
     control_outbound: mpsc::Sender<Frame>,
     data_outbound: FairDataSender,
     incoming_session_bytes: Arc<Semaphore>,
+    channel_slots: Arc<Semaphore>,
     routes: Mutex<HashMap<u32, Route>>,
     allocator: Mutex<ChannelIdAllocator>,
     failure: Mutex<Option<String>>,
@@ -69,13 +81,13 @@ impl ClientState {
         }
         *failure = Some(reason.clone());
         self.cancellation.cancel();
+        self.channel_slots.close();
         drop(failure);
         if let Ok(mut routes) = self.routes.lock() {
             for (_, mut route) in routes.drain() {
                 if let Some(opened) = route.opened.take() {
                     let _ = opened.send(Err(reason.clone()));
                 }
-                let _ = route.incoming.try_send(IncomingCommand::Close);
             }
         }
     }
@@ -84,12 +96,12 @@ impl ClientState {
         if let Ok(mut routes) = self.routes.lock()
             && let Some(mut route) = routes.remove(&channel_id)
         {
+            route.incoming_cancellation.cancel();
             if let Some(opened) = route.opened.take() {
                 let _ = opened.send(Err(
                     "graphical relay channel closed while opening".to_owned()
                 ));
             }
-            let _ = route.incoming.try_send(IncomingCommand::Close);
         }
     }
 }
@@ -162,6 +174,7 @@ impl ClientMultiplexer {
             control_outbound,
             data_outbound,
             incoming_session_bytes: Arc::new(Semaphore::new(MAX_SESSION_QUEUED_BYTES)),
+            channel_slots: Arc::new(Semaphore::new(MAX_LOGICAL_CHANNELS)),
             routes: Mutex::new(HashMap::new()),
             allocator: Mutex::new(ChannelIdAllocator::default()),
             failure: Mutex::new(None),
@@ -170,30 +183,31 @@ impl ClientMultiplexer {
 
         let writer_state = state.clone();
         tokio::spawn(async move {
-            loop {
-                tokio::select! {
-                    biased;
-                    () = writer_state.cancellation.cancelled() => {
-                        let _ = writer.shutdown().await;
-                        return;
-                    },
-                    frame = control_rx.recv() => if let Some(frame) = frame
-                        && let Err(error) = write_frame(&mut writer, &frame).await
-                    {
-                        writer_state.fail(format!("graphical relay write failed: {error}"));
-                        return;
-                    },
-                    data = data_rx.recv() => if let Some(data) = data
-                        && let Err(error) = write_data_frame(
-                            &mut writer,
-                            data.channel_id(),
-                            data.bytes(),
-                        ).await
-                    {
-                        writer_state.fail(format!("graphical relay write failed: {error}"));
-                        return;
-                    },
-                }
+            // Cancellation covers physical writes too, not only queue selection.
+            tokio::select! {
+                biased;
+                () = writer_state.cancellation.cancelled() => {}
+                () = async {
+                    loop {
+                        let result = tokio::select! {
+                            biased;
+                            frame = control_rx.recv() => match frame {
+                                Some(frame) => write_frame(&mut writer, &frame).await,
+                                None => return,
+                            },
+                            data = data_rx.recv() => match data {
+                                Some(data) => write_data_frame(
+                                    &mut writer, data.channel_id(), data.bytes(),
+                                ).await,
+                                None => return,
+                            },
+                        };
+                        if let Err(error) = result {
+                            writer_state.fail(format!("graphical relay write failed: {error}"));
+                            return;
+                        }
+                    }
+                } => {}
             }
         });
 
@@ -232,12 +246,22 @@ impl ClientMultiplexer {
     /// # Errors
     ///
     /// Returns an error when the session has failed, the identity space is
-    /// exhausted, or the remote relay rejects the channel.
+    /// exhausted, the local channel limit is reached (including pending incoming
+    /// drains), or the remote relay rejects the channel.
     pub async fn open_channel(&self) -> Result<LogicalChannel> {
         let state = &self.handle.state;
         if let Some(reason) = state.failure() {
             bail!(reason);
         }
+        // Remote EOF may leave ordered incoming data waiting on a slow consumer.
+        // Admission remains charged until both that pump and the application end.
+        let channel_slot = Arc::new(
+            state
+                .channel_slots
+                .clone()
+                .try_acquire_owned()
+                .map_err(|_| anyhow::anyhow!("graphical relay logical channel limit reached"))?,
+        );
         let channel_id = state
             .allocator
             .lock()
@@ -247,6 +271,9 @@ impl ClientMultiplexer {
         let (bridge_reader, bridge_writer) = tokio::io::split(bridge);
         let (incoming, incoming_rx) = mpsc::channel(CHANNEL_QUEUE_FRAMES);
         let (opened_tx, opened_rx) = oneshot::channel();
+        let outgoing_cancellation = state.cancellation.child_token();
+        let incoming_cancellation = state.cancellation.child_token();
+        let data_outbound = state.data_outbound.channel(channel_id);
         state
             .routes
             .lock()
@@ -257,6 +284,9 @@ impl ClientMultiplexer {
                     opened: Some(opened_tx),
                     incoming,
                     incoming_bytes: Arc::new(Semaphore::new(MAX_INCOMING_CHANNEL_QUEUED_BYTES)),
+                    outgoing_cancellation: outgoing_cancellation.clone(),
+                    incoming_cancellation: incoming_cancellation.clone(),
+                    data_outbound: data_outbound.clone(),
                 },
             );
         let mut opening = OpeningGuard {
@@ -269,18 +299,24 @@ impl ClientMultiplexer {
             bridge_writer,
             incoming_rx,
             state.clone(),
+            incoming_cancellation.clone(),
+            channel_slot.clone(),
         ));
-        if state
-            .control_outbound
-            .send(Frame::OpenChannel { channel_id })
-            .await
-            .is_err()
-        {
-            state.close_channel(channel_id);
-            opening.disarm();
-            bail!("graphical relay writer is unavailable");
-        }
-        let admission = opened_rx.await;
+        let admission = tokio::select! {
+            biased;
+            // Honor an acknowledgement already delivered before transport EOF.
+            admission = async {
+                if state.control_outbound.send(Frame::OpenChannel { channel_id }).await.is_err() {
+                    state.close_channel(channel_id);
+                }
+                opened_rx.await
+            } => admission,
+            () = state.cancellation.cancelled() => {
+                state.close_channel(channel_id);
+                opening.disarm();
+                bail!(state.failure().unwrap_or_else(|| "graphical relay session cancelled".to_owned()));
+            }
+        };
         opening.disarm();
         match admission {
             Ok(Ok(())) => {}
@@ -292,21 +328,22 @@ impl ClientMultiplexer {
                     .unwrap_or_else(|| "graphical relay channel admission was cancelled".to_owned())
             ),
         }
-        let data_outbound = state.data_outbound.channel(channel_id);
-        let outgoing_data = data_outbound.clone();
-        let outgoing_state = state.clone();
-        let (outgoing_finished, outgoing_completion) = oneshot::channel();
-        tokio::spawn(async move {
-            run_outgoing_channel(channel_id, bridge_reader, outgoing_data, outgoing_state).await;
-            let _ = outgoing_finished.send(());
-        });
+        tokio::spawn(run_outgoing_channel(
+            channel_id,
+            bridge_reader,
+            data_outbound.clone(),
+            state.clone(),
+            outgoing_cancellation,
+            channel_slot.clone(),
+        ));
         Ok(LogicalChannel {
             stream: application,
             guard: Arc::new(ChannelGuard {
                 channel_id,
                 handle: self.handle.clone(),
                 data_outbound,
-                outgoing_completion: Some(outgoing_completion),
+                incoming_cancellation,
+                _channel_slot: channel_slot,
             }),
         })
     }
@@ -348,7 +385,6 @@ fn dispatch_frame(state: &Arc<ClientState>, frame: Frame) -> std::result::Result
             let _ = opened.send(Err(format!(
                 "remote graphical relay rejected channel: {reason}"
             )));
-            let _ = route.incoming.try_send(IncomingCommand::Close);
         }
         Frame::Data { channel_id, bytes } => {
             send_incoming_data(state, channel_id, bytes)?;
@@ -462,7 +498,6 @@ fn close_remote_channel(state: &ClientState, channel_id: u32) -> std::result::Re
             "graphical relay channel closed while opening".to_owned()
         ));
     }
-    let _ = route.incoming.try_send(IncomingCommand::Close);
     Ok(())
 }
 
@@ -471,37 +506,45 @@ async fn run_incoming_channel(
     mut writer: tokio::io::WriteHalf<DuplexStream>,
     mut incoming: mpsc::Receiver<IncomingCommand>,
     state: Arc<ClientState>,
+    cancellation: CancellationToken,
+    _channel_slot: Arc<OwnedSemaphorePermit>,
 ) {
-    let mut half_closed = false;
-    loop {
-        let command = tokio::select! {
-            () = state.cancellation.cancelled() => break,
-            command = incoming.recv() => command,
-        };
-        match command {
-            Some(IncomingCommand::Data(data)) if !half_closed => {
-                if writer.write_all(&data.bytes).await.is_err() {
-                    let _ = state
-                        .control_outbound
-                        .try_send(Frame::CloseChannel { channel_id });
-                    state.close_channel(channel_id);
+    let pump = async {
+        let mut half_closed = false;
+        loop {
+            match incoming.recv().await {
+                Some(IncomingCommand::Data(data)) if !half_closed => {
+                    if writer.write_all(&data.bytes).await.is_err() {
+                        let _ = state
+                            .control_outbound
+                            .try_send(Frame::CloseChannel { channel_id });
+                        state.close_channel(channel_id);
+                        break;
+                    }
+                }
+                Some(IncomingCommand::HalfClose) if !half_closed => {
+                    half_closed = true;
+                    let _ = writer.shutdown().await;
+                }
+                None => {
+                    let _ = writer.shutdown().await;
+                    break;
+                }
+                Some(IncomingCommand::Data(_) | IncomingCommand::HalfClose) => {
+                    state.fail("remote graphical relay sent data after channel half-close");
                     break;
                 }
             }
-            Some(IncomingCommand::HalfClose) if !half_closed => {
-                half_closed = true;
-                let _ = writer.shutdown().await;
-            }
-            Some(IncomingCommand::Close) | None => {
-                let _ = writer.shutdown().await;
-                break;
-            }
-            Some(IncomingCommand::Data(_) | IncomingCommand::HalfClose) => {
-                state.fail("remote graphical relay sent data after channel half-close");
-                break;
-            }
         }
+    };
+    tokio::select! {
+        biased;
+        () = cancellation.cancelled() => {}
+        () = pump => {}
     }
+    // The outgoing read half can still own the duplex stream. Explicit shutdown
+    // exposes EOF to the application without waiting for that half to disappear.
+    let _ = writer.shutdown().await;
 }
 
 async fn run_outgoing_channel(
@@ -509,47 +552,54 @@ async fn run_outgoing_channel(
     mut reader: tokio::io::ReadHalf<DuplexStream>,
     data_outbound: FairDataChannel,
     state: Arc<ClientState>,
+    cancellation: CancellationToken,
+    _channel_slot: Arc<OwnedSemaphorePermit>,
 ) {
-    let mut buffer = vec![0_u8; MAX_DATA_BYTES];
-    loop {
-        let permit = tokio::select! {
-            () = state.cancellation.cancelled() => return,
-            permit = data_outbound.reserve() => match permit {
+    let pump = async {
+        let mut buffer = vec![0_u8; MAX_DATA_BYTES];
+        loop {
+            let permit = match data_outbound.reserve().await {
                 Ok(permit) => permit,
                 Err(error) => {
-                    state.fail(format!("graphical relay byte reservation failed: {error}"));
+                    if !cancellation.is_cancelled() {
+                        state.fail(format!("graphical relay byte reservation failed: {error}"));
+                    }
                     return;
                 }
-            },
-        };
-        let read = tokio::select! {
-            () = state.cancellation.cancelled() => return,
-            read = reader.read(&mut buffer) => read,
-        };
-        match read {
-            Ok(0) => {
-                drop(permit);
-                let _ = data_outbound.drain().await;
-                let _ = state
-                    .control_outbound
-                    .send(Frame::HalfClose { channel_id })
-                    .await;
-                return;
-            }
-            Ok(count) => {
-                if let Err(error) = permit.send(buffer[..count].to_vec()) {
-                    state.fail(format!("graphical relay data queue failed: {error}"));
+            };
+            let read = reader.read(&mut buffer).await;
+            match read {
+                Ok(0) => {
+                    drop(permit);
+                    let _ = data_outbound.drain().await;
+                    let _ = state
+                        .control_outbound
+                        .send(Frame::HalfClose { channel_id })
+                        .await;
                     return;
                 }
-            }
-            Err(error) => {
-                drop(permit);
-                state.fail(format!(
-                    "logical graphical relay channel read failed: {error}"
-                ));
-                return;
+                Ok(count) => {
+                    if let Err(error) = permit.send(buffer[..count].to_vec()) {
+                        if !cancellation.is_cancelled() {
+                            state.fail(format!("graphical relay data queue failed: {error}"));
+                        }
+                        return;
+                    }
+                }
+                Err(error) => {
+                    drop(permit);
+                    state.fail(format!(
+                        "logical graphical relay channel read failed: {error}"
+                    ));
+                    return;
+                }
             }
         }
+    };
+    tokio::select! {
+        biased;
+        () = cancellation.cancelled() => {}
+        () = pump => {}
     }
 }
 
@@ -558,42 +608,33 @@ struct ChannelGuard {
     channel_id: u32,
     handle: Arc<ClientHandle>,
     data_outbound: FairDataChannel,
-    outgoing_completion: Option<oneshot::Receiver<()>>,
+    incoming_cancellation: CancellationToken,
+    _channel_slot: Arc<OwnedSemaphorePermit>,
 }
 
 impl Drop for ChannelGuard {
     fn drop(&mut self) {
         let state = &self.handle.state;
         state.close_channel(self.channel_id);
-        let channel_id = self.channel_id;
-        let handle = self.handle.clone();
-        let data_outbound = self.data_outbound.clone();
-        let outgoing_completion = self.outgoing_completion.take();
-        let Ok(runtime) = tokio::runtime::Handle::try_current() else {
-            state.fail("graphical relay channel closed outside an async runtime");
-            return;
-        };
-        runtime.spawn(async move {
-            if let Some(completion) = outgoing_completion {
-                let _ = completion.await;
-            }
-            let _ = data_outbound.drain().await;
-            if handle
-                .state
-                .control_outbound
-                .send(Frame::CloseChannel { channel_id })
-                .await
-                .is_err()
-            {
-                handle
-                    .state
-                    .fail("graphical relay control output queue closed");
-            }
-        });
+        self.incoming_cancellation.cancel();
+        self.data_outbound.discard();
+        if state
+            .control_outbound
+            .try_send(Frame::CloseChannel {
+                channel_id: self.channel_id,
+            })
+            .is_err()
+        {
+            state.fail("graphical relay control output queue closed or full");
+        }
     }
 }
 
 /// One logical full-duplex byte channel over a graphical relay session.
+///
+/// Dropping the channel performs a full close and can discard buffered writes.
+/// Shut down its write side and drain its response first when ordered completion
+/// is required.
 #[derive(Debug)]
 pub struct LogicalChannel {
     stream: DuplexStream,
@@ -650,6 +691,299 @@ mod tests {
     use tokio::{io::AsyncReadExt as _, time};
 
     use super::*;
+
+    async fn test_client(capacity: usize) -> (ClientMultiplexer, DuplexStream) {
+        let (transport, mut server) = tokio::io::duplex(capacity);
+        let (reader, writer) = tokio::io::split(transport);
+        let negotiation = tokio::spawn(ClientMultiplexer::negotiate(reader, writer));
+        assert_eq!(read_frame(&mut server).await.unwrap(), Some(Frame::Hello));
+        write_frame(&mut server, &Frame::HelloAck).await.unwrap();
+        (negotiation.await.unwrap().unwrap(), server)
+    }
+
+    async fn test_open(client: &ClientMultiplexer, server: &mut DuplexStream) -> LogicalChannel {
+        let opening_client = client.clone();
+        let opening = tokio::spawn(async move { opening_client.open_channel().await.unwrap() });
+        let channel_id = loop {
+            match read_frame(server).await.unwrap() {
+                Some(Frame::OpenChannel { channel_id }) => break channel_id,
+                Some(Frame::CloseChannel { .. } | Frame::HalfClose { .. }) => {}
+                other => panic!("unexpected admission frame: {other:?}"),
+            }
+        };
+        write_frame(server, &Frame::ChannelOpened { channel_id })
+            .await
+            .unwrap();
+        opening.await.unwrap()
+    }
+
+    #[tokio::test]
+    async fn outgoing_half_close_follows_all_data_and_keeps_incoming_reply_open() {
+        time::timeout(Duration::from_secs(2), async {
+            let (client, mut server) = test_client(4 * MAX_DATA_BYTES).await;
+            let mut channel = test_open(&client, &mut server).await;
+            let expected = vec![0xaa; 2 * MAX_DATA_BYTES + 7];
+            channel.write_all(&expected).await.unwrap();
+            channel.shutdown().await.unwrap();
+            let channel_id = channel.channel_id();
+            let mut received = Vec::new();
+            loop {
+                match read_frame(&mut server).await.unwrap() {
+                    Some(Frame::Data {
+                        channel_id: id,
+                        bytes,
+                    }) => {
+                        assert_eq!(id, channel_id);
+                        received.extend(bytes);
+                    }
+                    Some(Frame::HalfClose { channel_id: id }) => {
+                        assert_eq!(id, channel_id);
+                        break;
+                    }
+                    other => panic!("unexpected half-close frame: {other:?}"),
+                }
+            }
+            assert_eq!(received, expected);
+            write_frame(
+                &mut server,
+                &Frame::Data {
+                    channel_id,
+                    bytes: b"reply".to_vec(),
+                },
+            )
+            .await
+            .unwrap();
+            write_frame(&mut server, &Frame::CloseChannel { channel_id })
+                .await
+                .unwrap();
+            let mut reply = Vec::new();
+            channel.read_to_end(&mut reply).await.unwrap();
+            assert_eq!(reply, b"reply");
+            assert_eq!(client.terminal_failure(), None);
+        })
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn remote_close_preserves_tail_for_consumer_delayed_beyond_teardown_grace() {
+        time::timeout(Duration::from_secs(2), async {
+            let (client, mut server) = test_client(4 * MAX_DATA_BYTES).await;
+            let mut channel = test_open(&client, &mut server).await;
+            let channel_id = channel.channel_id();
+            for byte in [0xaa, 0xbb] {
+                write_frame(
+                    &mut server,
+                    &Frame::Data {
+                        channel_id,
+                        bytes: vec![byte; MAX_DATA_BYTES],
+                    },
+                )
+                .await
+                .unwrap();
+            }
+            write_frame(&mut server, &Frame::CloseChannel { channel_id })
+                .await
+                .unwrap();
+            while client
+                .handle
+                .state
+                .routes
+                .lock()
+                .unwrap()
+                .contains_key(&channel_id)
+            {
+                tokio::task::yield_now().await;
+            }
+            time::sleep(Duration::from_millis(150)).await;
+            assert_eq!(
+                client.handle.state.channel_slots.available_permits(),
+                MAX_LOGICAL_CHANNELS - 1
+            );
+            let mut received = Vec::new();
+            channel.read_to_end(&mut received).await.unwrap();
+            assert_eq!(
+                received,
+                [vec![0xaa; MAX_DATA_BYTES], vec![0xbb; MAX_DATA_BYTES]].concat()
+            );
+            assert_eq!(client.terminal_failure(), None);
+            drop(channel);
+            assert_eq!(
+                client.handle.state.channel_slots.available_permits(),
+                MAX_LOGICAL_CHANNELS
+            );
+        })
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn pending_remote_closed_drains_hold_local_admission_until_local_drop() {
+        time::timeout(Duration::from_secs(10), async {
+            let (client, mut server) = test_client(64 * 1024).await;
+            let state = &client.handle.state;
+            let mut channels = Vec::new();
+            for _ in 0..MAX_LOGICAL_CHANNELS {
+                let channel = test_open(&client, &mut server).await;
+                let channel_id = channel.channel_id();
+                send_incoming_data(state, channel_id, vec![0xaa; MAX_DATA_BYTES]).unwrap();
+                send_incoming_data(state, channel_id, vec![0xbb]).unwrap();
+                close_remote_channel(state, channel_id).unwrap();
+                channels.push(channel);
+            }
+            assert!(state.routes.lock().unwrap().is_empty());
+            assert_eq!(state.channel_slots.available_permits(), 0);
+            assert!(
+                client
+                    .open_channel()
+                    .await
+                    .unwrap_err()
+                    .to_string()
+                    .contains("channel limit")
+            );
+            drop(channels.pop());
+            while state.channel_slots.available_permits() == 0 {
+                tokio::task::yield_now().await;
+            }
+            let reopened = test_open(&client, &mut server).await;
+            assert_eq!(state.channel_slots.available_permits(), 0);
+            drop(reopened);
+            drop(channels);
+            while state.channel_slots.available_permits() != MAX_LOGICAL_CHANNELS {
+                tokio::task::yield_now().await;
+            }
+            assert_eq!(
+                state.incoming_session_bytes.available_permits(),
+                MAX_SESSION_QUEUED_BYTES
+            );
+            assert_eq!(client.terminal_failure(), None);
+        })
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn session_cancel_interrupts_physical_writer_and_outgoing_drain() {
+        time::timeout(Duration::from_secs(2), async {
+            let (client, mut server) = test_client(64).await;
+            let mut channel = test_open(&client, &mut server).await;
+            channel
+                .write_all(&vec![0xaa; MAX_DATA_BYTES])
+                .await
+                .unwrap();
+            channel.shutdown().await.unwrap();
+            // Consuming one header byte proves the physical frame write has begun.
+            assert_eq!(server.read(&mut [0; 1]).await.unwrap(), 1);
+            let state = client.handle.state.clone();
+            let weak = Arc::downgrade(&state);
+            state.fail("test cancellation");
+            drop(channel);
+            drop(client);
+            drop(state);
+            while weak.strong_count() != 0 {
+                tokio::task::yield_now().await;
+            }
+            let mut pending = Vec::new();
+            server.read_to_end(&mut pending).await.unwrap();
+            assert!(pending.len() < MAX_DATA_BYTES);
+        })
+        .await
+        .unwrap();
+    }
+
+    async fn blocked_incoming_teardown(session: bool) {
+        time::timeout(Duration::from_secs(2), async {
+            let (control_outbound, _control_rx) = mpsc::channel(4);
+            let (data_outbound, _data_rx) = fair_data_queue();
+            let state = Arc::new(ClientState {
+                control_outbound,
+                data_outbound,
+                incoming_session_bytes: Arc::new(Semaphore::new(MAX_SESSION_QUEUED_BYTES)),
+                channel_slots: Arc::new(Semaphore::new(MAX_LOGICAL_CHANNELS)),
+                routes: Mutex::new(HashMap::new()),
+                allocator: Mutex::new(ChannelIdAllocator::default()),
+                failure: Mutex::new(None),
+                cancellation: CancellationToken::new(),
+            });
+            let (mut application, bridge) = tokio::io::duplex(1);
+            // Retain the other half: dropping the incoming half alone does not signal EOF.
+            let (_bridge_reader, bridge_writer) = tokio::io::split(bridge);
+            let (incoming, incoming_rx) = mpsc::channel(CHANNEL_QUEUE_FRAMES);
+            let incoming_bytes = Arc::new(Semaphore::new(MAX_INCOMING_CHANNEL_QUEUED_BYTES));
+            let cancellation = state.cancellation.child_token();
+            state.routes.lock().unwrap().insert(
+                1,
+                Route {
+                    opened: None,
+                    incoming: incoming.clone(),
+                    incoming_bytes: incoming_bytes.clone(),
+                    outgoing_cancellation: state.cancellation.child_token(),
+                    incoming_cancellation: cancellation.clone(),
+                    data_outbound: state.data_outbound.channel(1),
+                },
+            );
+            let (sibling, _sibling_rx) = mpsc::channel(1);
+            state.routes.lock().unwrap().insert(
+                2,
+                Route {
+                    opened: None,
+                    incoming: sibling,
+                    outgoing_cancellation: state.cancellation.child_token(),
+                    incoming_cancellation: state.cancellation.child_token(),
+                    data_outbound: state.data_outbound.channel(2),
+                    incoming_bytes: Arc::new(Semaphore::new(MAX_INCOMING_CHANNEL_QUEUED_BYTES)),
+                },
+            );
+            send_incoming_data(&state, 1, vec![0xaa; MAX_DATA_BYTES]).unwrap();
+            let task = tokio::spawn(run_incoming_channel(
+                1,
+                bridge_writer,
+                incoming_rx,
+                state.clone(),
+                cancellation.clone(),
+                Arc::new(state.channel_slots.clone().try_acquire_owned().unwrap()),
+            ));
+            while incoming.capacity() != CHANNEL_QUEUE_FRAMES {
+                tokio::task::yield_now().await;
+            }
+            assert_eq!(
+                incoming_bytes.available_permits(),
+                MAX_INCOMING_CHANNEL_QUEUED_BYTES - MAX_DATA_BYTES
+            );
+            if session {
+                state.fail("test cancellation");
+            } else {
+                close_remote_channel(&state, 1).unwrap();
+                // Ordered remote EOF retains a bounded drain; local close interrupts it.
+                assert!(!task.is_finished());
+                cancellation.cancel();
+            }
+            task.await.unwrap();
+            assert_eq!(
+                incoming_bytes.available_permits(),
+                MAX_INCOMING_CHANNEL_QUEUED_BYTES
+            );
+            let mut received = Vec::new();
+            application.read_to_end(&mut received).await.unwrap();
+            assert_eq!(received, vec![0xaa]);
+            if !session {
+                assert!(state.routes.lock().unwrap().contains_key(&2));
+                assert!(!state.cancellation.is_cancelled());
+            }
+        })
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn incoming_channel_local_close_interrupts_remote_closed_blocked_consumer() {
+        blocked_incoming_teardown(false).await;
+    }
+
+    #[tokio::test]
+    async fn incoming_channel_session_cancel_interrupts_blocked_consumer() {
+        blocked_incoming_teardown(true).await;
+    }
 
     #[tokio::test]
     async fn one_negotiation_routes_multiple_independent_channels() {

--- a/crates/splinterm-graphical-relay/src/fair_queue.rs
+++ b/crates/splinterm-graphical-relay/src/fair_queue.rs
@@ -93,6 +93,16 @@ pub struct FairDataChannel {
 }
 
 impl FairDataChannel {
+    /// Closes this producer and discards only its queued frames on full close.
+    /// An in-flight physical frame retains its permits until its write completes.
+    pub fn discard(&self) {
+        if let Ok(mut state) = self.shared.state.lock() {
+            self.channel_bytes.close();
+            state.channels.remove(&self.channel_id);
+            state.ready.retain(|id| *id != self.channel_id);
+        }
+    }
+
     /// Waits until every prior frame for this channel has completed its physical write.
     ///
     /// # Errors
@@ -174,8 +184,8 @@ impl FairDataPermit {
             .state
             .lock()
             .map_err(|_| anyhow::anyhow!("fair data queue is poisoned"))?;
-        if state.receiver_closed {
-            bail!("fair data receiver is closed");
+        if state.receiver_closed || self.channel_bytes.semaphore().is_closed() {
+            bail!("fair data receiver or channel is closed");
         }
         let queue = state.channels.entry(self.channel_id).or_default();
         let was_empty = queue.is_empty();
@@ -260,6 +270,42 @@ pub fn fair_data_queue() -> (FairDataSender, FairDataReceiver) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn discard_reclaims_only_closed_channel_queue_and_rejects_late_permits() {
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            let (sender, mut receiver) = fair_data_queue();
+            let closed = sender.channel(1);
+            let sibling = sender.channel(2);
+            closed.reserve().await.unwrap().send(vec![1]).unwrap();
+            closed.reserve().await.unwrap().send(vec![2]).unwrap();
+            let late = closed.reserve().await.unwrap();
+            sibling.reserve().await.unwrap().send(vec![3]).unwrap();
+            let in_flight = receiver.recv().await.unwrap();
+            assert_eq!(in_flight.channel_id(), 1);
+            closed.discard();
+            assert!(late.send(vec![4]).is_err());
+            assert!(closed.reserve().await.is_err());
+            // Only the physical in-flight frame and the sibling still own byte permits.
+            assert_eq!(
+                sender.shared.session_bytes.available_permits(),
+                MAX_SESSION_QUEUED_BYTES - 2 * MAX_DATA_BYTES
+            );
+            let preserved = receiver.recv().await.unwrap();
+            assert_eq!(preserved.channel_id(), 2);
+            assert_eq!(preserved.bytes(), &[3]);
+            drop(preserved);
+            drop(in_flight);
+            assert_eq!(
+                sender.shared.session_bytes.available_permits(),
+                MAX_SESSION_QUEUED_BYTES
+            );
+            sibling.reserve().await.unwrap().send(vec![5]).unwrap();
+            assert_eq!(receiver.recv().await.unwrap().bytes(), &[5]);
+        })
+        .await
+        .unwrap();
+    }
 
     #[tokio::test]
     async fn scheduler_round_robins_channels_and_holds_byte_permits_until_receive() {

--- a/crates/splinterm-relay/src/lib.rs
+++ b/crates/splinterm-relay/src/lib.rs
@@ -397,19 +397,6 @@ async fn monitor_daemon_peer(
     }
 }
 
-async fn finish_channel(
-    channel_id: u32,
-    control_outbound: &mpsc::Sender<GraphicalFrame>,
-    events: &mpsc::Sender<GraphicalEvent>,
-) {
-    let _ = control_outbound
-        .send(GraphicalFrame::CloseChannel { channel_id })
-        .await;
-    let _ = events
-        .send(GraphicalEvent::ChannelFinished(channel_id))
-        .await;
-}
-
 async fn apply_channel_command(
     command: Option<ChannelCommand>,
     upstream_open: &mut bool,
@@ -452,57 +439,63 @@ async fn run_graphical_channel(
     output: ChannelOutput,
     cancellation: CancellationToken,
 ) {
-    let mut daemon_reader = daemon_reader;
-    let mut daemon_writer = daemon_writer;
-    let mut read_buffer = vec![0_u8; MAX_DATA_BYTES];
-    let mut upstream_open = true;
-    'channel: loop {
-        let permit = tokio::select! {
-            () = cancellation.cancelled() => break,
-            command = commands.recv() => {
+    // Both pumps are scoped here: either direction ending drops the other future,
+    // including a blocked write, before any potentially blocked output drain.
+    {
+        let events = &output.events;
+        let upstream = async move {
+            let mut daemon_writer = daemon_writer;
+            let mut upstream_open = true;
+            loop {
                 if !apply_channel_command(
-                    command,
+                    commands.recv().await,
                     &mut upstream_open,
                     &mut daemon_writer,
-                    &output.events,
-                ).await {
+                    events,
+                )
+                .await
+                {
                     break;
                 }
-                continue 'channel;
             }
-            permit = output.data.reserve() => match permit {
-                Ok(permit) => permit,
-                Err(_) => break,
-            },
         };
-        let read = tokio::select! {
-            () = cancellation.cancelled() => break,
-            command = commands.recv() => {
-                drop(permit);
-                if !apply_channel_command(
-                    command,
-                    &mut upstream_open,
-                    &mut daemon_writer,
-                    &output.events,
-                ).await {
+        let downstream = async {
+            let mut daemon_reader = daemon_reader;
+            let mut read_buffer = vec![0_u8; MAX_DATA_BYTES];
+            loop {
+                let Ok(permit) = output.data.reserve().await else {
                     break;
+                };
+                match daemon_reader.read(&mut read_buffer).await {
+                    Ok(0) | Err(_) => break,
+                    Ok(count) => {
+                        if permit.send(read_buffer[..count].to_vec()).is_err() {
+                            break;
+                        }
+                    }
                 }
-                continue 'channel;
             }
-            read = daemon_reader.read(&mut read_buffer) => read,
         };
-        match read {
-            Ok(0) | Err(_) => break,
-            Ok(count) => {
-                if permit.send(read_buffer[..count].to_vec()).is_err() {
-                    break;
-                }
-            }
+        tokio::select! {
+            biased;
+            () = cancellation.cancelled() => {}
+            () = upstream => {}
+            () = downstream => {}
         }
     }
+    tokio::select! {
+        biased;
+        () = cancellation.cancelled() => { output.data.discard(); }
+        () = async {
+            let _ = output.data.drain().await;
+            let _ = output.control.send(GraphicalFrame::CloseChannel { channel_id }).await;
+        } => {}
+    }
     cancellation.cancel();
-    let _ = output.data.drain().await;
-    finish_channel(channel_id, &output.control, &output.events).await;
+    let _ = output
+        .events
+        .send(GraphicalEvent::ChannelFinished(channel_id))
+        .await;
 }
 
 async fn run_graphical_input_reader<R>(
@@ -646,12 +639,14 @@ where
                             break;
                         }
                         last_channel_id = channel_id;
+                        // Never block this coordinator on physical-output backpressure;
+                        // it must remain able to process close and session-failure events.
                         if channels.len() >= MAX_LOGICAL_CHANNELS {
-                            if control_tx.send(GraphicalFrame::ChannelRejected {
+                            if control_tx.try_send(GraphicalFrame::ChannelRejected {
                                 channel_id,
                                 reason: "graphical relay logical channel limit reached".to_owned(),
-                            }).await.is_err() {
-                                terminal_error = Some("graphical relay output closed".to_owned());
+                            }).is_err() {
+                                terminal_error = Some("graphical relay output queue closed or full".to_owned());
                                 break;
                             }
                             continue;
@@ -669,11 +664,10 @@ where
                                 // Queue the admission acknowledgement before either channel task
                                 // can emit data or a daemon-lifetime failure.
                                 if control_tx
-                                    .send(GraphicalFrame::ChannelOpened { channel_id })
-                                    .await
+                                    .try_send(GraphicalFrame::ChannelOpened { channel_id })
                                     .is_err()
                                 {
-                                    terminal_error = Some("graphical relay output closed".to_owned());
+                                    terminal_error = Some("graphical relay output queue closed or full".to_owned());
                                     break;
                                 }
                                 tokio::spawn(monitor_daemon_peer(
@@ -695,11 +689,11 @@ where
                                 ));
                             }
                             Err(error) => {
-                                if control_tx.send(GraphicalFrame::ChannelRejected {
+                                if control_tx.try_send(GraphicalFrame::ChannelRejected {
                                     channel_id,
                                     reason: bounded_reason(&error),
-                                }).await.is_err() {
-                                    terminal_error = Some("graphical relay output closed".to_owned());
+                                }).is_err() {
+                                    terminal_error = Some("graphical relay output queue closed or full".to_owned());
                                     break;
                                 }
                             }
@@ -731,7 +725,8 @@ where
                         }
                     }
                     GraphicalFrame::CloseChannel { channel_id } => {
-                        if let Some(channel) = channels.remove(&channel_id) {
+                        if let Some(channel) = channels.get(&channel_id) {
+                            // Keep admission charged until the pumps release their socket.
                             let _ = channel.commands.try_send(ChannelCommand::Close);
                             channel.cancellation.cancel();
                         } else if channel_id > last_channel_id {
@@ -812,6 +807,210 @@ mod tests {
     };
 
     use super::*;
+
+    #[tokio::test]
+    async fn graphical_channel_half_close_preserves_order_and_drains_daemon_reply() {
+        time::timeout(Duration::from_secs(2), async {
+            let (stream, mut daemon) = UnixStream::pair().unwrap();
+            let (reader, writer) = stream.into_split();
+            let (commands, command_rx) = mpsc::channel(CHANNEL_QUEUE_FRAMES);
+            commands
+                .send(ChannelCommand::Data(b"first".to_vec()))
+                .await
+                .unwrap();
+            commands
+                .send(ChannelCommand::Data(b"second".to_vec()))
+                .await
+                .unwrap();
+            commands.send(ChannelCommand::HalfClose).await.unwrap();
+            let (control, mut control_rx) = mpsc::channel(1);
+            let (events, mut event_rx) = mpsc::channel(1);
+            let (data, mut data_rx) = fair_data_queue();
+            let task = tokio::spawn(run_graphical_channel(
+                1,
+                reader,
+                writer,
+                command_rx,
+                ChannelOutput {
+                    control,
+                    data: data.channel(1),
+                    events,
+                },
+                CancellationToken::new(),
+            ));
+            let mut request = Vec::new();
+            daemon.read_to_end(&mut request).await.unwrap();
+            assert_eq!(request, b"firstsecond");
+            daemon.write_all(b"reply").await.unwrap();
+            daemon.shutdown().await.unwrap();
+            let reply = data_rx.recv().await.unwrap();
+            assert_eq!(reply.bytes(), b"reply");
+            assert!(matches!(
+                control_rx.try_recv(),
+                Err(mpsc::error::TryRecvError::Empty)
+            ));
+            drop(reply);
+            assert_eq!(
+                control_rx.recv().await,
+                Some(GraphicalFrame::CloseChannel { channel_id: 1 })
+            );
+            task.await.unwrap();
+            assert!(matches!(
+                event_rx.recv().await,
+                Some(GraphicalEvent::ChannelFinished(1))
+            ));
+        })
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn graphical_channel_close_interrupts_full_control_queue() {
+        time::timeout(Duration::from_secs(2), async {
+            let (stream, mut daemon) = UnixStream::pair().unwrap();
+            let (reader, writer) = stream.into_split();
+            let (_commands, command_rx) = mpsc::channel(CHANNEL_QUEUE_FRAMES);
+            let (control, _control_rx) = mpsc::channel(1);
+            control.send(GraphicalFrame::HelloAck).await.unwrap();
+            let (events, mut event_rx) = mpsc::channel(1);
+            let (data, _data_rx) = fair_data_queue();
+            let cancellation = CancellationToken::new();
+            let task = tokio::spawn(run_graphical_channel(
+                1,
+                reader,
+                writer,
+                command_rx,
+                ChannelOutput {
+                    control,
+                    data: data.channel(1),
+                    events,
+                },
+                cancellation.clone(),
+            ));
+            daemon.shutdown().await.unwrap();
+            assert_eq!(daemon.read(&mut [0; 1]).await.unwrap(), 0);
+            cancellation.cancel();
+            task.await.unwrap();
+            assert!(matches!(
+                event_rx.recv().await,
+                Some(GraphicalEvent::ChannelFinished(1))
+            ));
+        })
+        .await
+        .unwrap();
+    }
+
+    async fn saturated_graphical_writer_teardown(cancel: bool) {
+        time::timeout(Duration::from_secs(2), async {
+            let (stream, mut daemon) = UnixStream::pair().unwrap();
+            // Saturate the kernel send buffer before starting the pump.
+            stream.writable().await.unwrap();
+            let mut buffered = 0;
+            loop {
+                match stream.try_write(&[0x55; MAX_DATA_BYTES]) {
+                    Ok(count) => buffered += count,
+                    Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => break,
+                    Err(error) => panic!("{error}"),
+                }
+            }
+            assert!(buffered > 0);
+            let (reader, writer) = stream.into_split();
+            let (commands, command_rx) = mpsc::channel(CHANNEL_QUEUE_FRAMES);
+            commands
+                .send(ChannelCommand::Data(vec![0xaa; MAX_DATA_BYTES]))
+                .await
+                .unwrap();
+            let (control, mut control_rx) = mpsc::channel(4);
+            let (events, mut event_rx) = mpsc::channel(4);
+            let (data, _data_rx) = fair_data_queue();
+            let cancellation = CancellationToken::new();
+            let task = tokio::spawn(run_graphical_channel(
+                1,
+                reader,
+                writer,
+                command_rx,
+                ChannelOutput {
+                    control,
+                    data: data.channel(1),
+                    events,
+                },
+                cancellation.clone(),
+            ));
+            while commands.capacity() != CHANNEL_QUEUE_FRAMES {
+                tokio::task::yield_now().await;
+            }
+            if cancel {
+                cancellation.cancel();
+            } else {
+                daemon.shutdown().await.unwrap();
+            }
+            task.await.unwrap();
+            assert!(matches!(
+                event_rx.recv().await,
+                Some(GraphicalEvent::ChannelFinished(1))
+            ));
+            if !cancel {
+                assert_eq!(
+                    control_rx.recv().await,
+                    Some(GraphicalFrame::CloseChannel { channel_id: 1 })
+                );
+            }
+            let mut received = Vec::new();
+            daemon.read_to_end(&mut received).await.unwrap();
+            assert_eq!(received.len(), buffered);
+        })
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn graphical_channel_cancels_saturated_daemon_writer() {
+        saturated_graphical_writer_teardown(true).await;
+    }
+
+    #[tokio::test]
+    async fn graphical_channel_daemon_eof_ends_saturated_writer() {
+        saturated_graphical_writer_teardown(false).await;
+    }
+
+    #[tokio::test]
+    async fn graphical_channel_close_interrupts_blocked_output_drain() {
+        time::timeout(Duration::from_secs(2), async {
+            let (stream, mut daemon) = UnixStream::pair().unwrap();
+            let (reader, writer) = stream.into_split();
+            let (_commands, command_rx) = mpsc::channel(CHANNEL_QUEUE_FRAMES);
+            let (control, _control_rx) = mpsc::channel(1);
+            let (events, mut event_rx) = mpsc::channel(1);
+            let (data, mut data_rx) = fair_data_queue();
+            let cancellation = CancellationToken::new();
+            let task = tokio::spawn(run_graphical_channel(
+                1,
+                reader,
+                writer,
+                command_rx,
+                ChannelOutput {
+                    control,
+                    data: data.channel(1),
+                    events,
+                },
+                cancellation.clone(),
+            ));
+            daemon.write_all(b"pending output").await.unwrap();
+            let in_flight = data_rx.recv().await.unwrap();
+            daemon.shutdown().await.unwrap();
+            // Socket lifetime must not depend on the physical output writer draining.
+            assert_eq!(daemon.read(&mut [0; 1]).await.unwrap(), 0);
+            cancellation.cancel();
+            task.await.unwrap();
+            assert!(matches!(
+                event_rx.recv().await,
+                Some(GraphicalEvent::ChannelFinished(1))
+            ));
+            drop(in_flight);
+        })
+        .await
+        .unwrap();
+    }
 
     fn validated_pair() -> (ValidatedConnection, UnixStream) {
         let (stream, peer) = UnixStream::pair().unwrap();

--- a/crates/splinterm/src/app/font_watch.rs
+++ b/crates/splinterm/src/app/font_watch.rs
@@ -23,9 +23,9 @@ struct FontReloadState<F> {
 }
 
 impl<F: Clone + Eq> FontReloadState<F> {
-    fn new(current: F) -> Self {
+    fn new(source: F, current: F) -> Self {
         Self {
-            observed: None,
+            observed: Some(source),
             current,
         }
     }
@@ -42,8 +42,8 @@ impl<F: Clone + Eq> FontReloadState<F> {
         self.observed = None;
     }
 
-    fn accept(&mut self, fingerprint: F) -> bool {
-        self.observed = Some(fingerprint.clone());
+    fn accept(&mut self, source: F, fingerprint: F) -> bool {
+        self.observed = Some(source);
         if self.current == fingerprint {
             return false;
         }
@@ -112,7 +112,10 @@ pub(in crate::app) async fn watch_font(
     if authority != FontAuthority::NativeOmarchy {
         return;
     }
-    let mut state = FontReloadState::new(current.fingerprint().clone());
+    let mut state = FontReloadState::new(
+        current.source_fingerprint().clone(),
+        current.fingerprint().clone(),
+    );
     let mut diagnostics = FontReloadDiagnostics::default();
     let mut retry_after = None;
     // Startup already staged `current`; defer the first ambient Fontconfig
@@ -141,7 +144,10 @@ pub(in crate::app) async fn watch_font(
         match stage(pattern.clone(), authority).await {
             Ok(generation) => {
                 let generation = Arc::new(generation);
-                if !state.accept(generation.fingerprint().clone()) {
+                if !state.accept(
+                    generation.source_fingerprint().clone(),
+                    generation.fingerprint().clone(),
+                ) {
                     diagnostics.accepted();
                     continue;
                 }
@@ -172,33 +178,65 @@ mod tests {
 
     #[test]
     fn reload_state_coalesces_probes_and_publishes_only_changed_candidates() {
-        let mut state = FontReloadState::new(1_u8);
-        assert!(state.observe(1));
-        assert!(!state.accept(1));
+        let mut state = FontReloadState::new(1_u8, 1);
+        assert!(!state.observe(1));
+        assert!(!state.accept(1, 1));
         assert!(!state.observe(1));
         assert!(state.observe(2));
-        assert!(state.accept(2));
-        assert!(!state.accept(2));
+        assert!(state.accept(2, 2));
+        assert!(!state.accept(2, 2));
         assert!(state.observe(1));
-        assert!(state.accept(1));
+        assert!(state.accept(1, 1));
     }
 
     #[test]
     fn accepted_staging_replaces_a_divergent_probe_fingerprint() {
-        let mut state = FontReloadState::new(1_u8);
+        let mut state = FontReloadState::new(1_u8, 1);
         assert!(state.observe(2));
-        assert!(state.accept(3));
+        assert!(state.accept(3, 3));
         assert!(state.observe(2));
-        assert!(state.accept(2));
+        assert!(state.accept(2, 2));
     }
 
     #[test]
     fn failed_staging_retries_the_same_observed_fingerprint() {
-        let mut state = FontReloadState::new(1_u8);
+        let mut state = FontReloadState::new(1_u8, 1);
         assert!(state.observe(2));
         state.reject_observed();
         assert!(state.observe(2));
-        assert!(state.accept(2));
+        assert!(state.accept(2, 2));
+    }
+
+    #[test]
+    fn substituted_styles_do_not_restage_unchanged_sources() {
+        let mut state = FontReloadState::new(1_u8, 1);
+        assert!(state.observe(2));
+        // Source 2 legitimately resolves to the already accepted regular face.
+        assert!(!state.accept(2, 1));
+        for _ in 0..10 {
+            assert!(!state.observe(2));
+        }
+        assert!(state.observe(3));
+        assert!(state.accept(3, 4));
+        assert!(!state.observe(3));
+    }
+
+    #[test]
+    fn staged_source_wins_over_an_earlier_probe_even_with_style_substitution() {
+        let mut state = FontReloadState::new(1_u8, 1);
+        assert!(state.observe(2));
+        // Resolution raced to 3, whose styles reduce to renderer fingerprint 1.
+        assert!(!state.accept(3, 1));
+        assert!(!state.observe(3));
+        // Returning to 2 must not be lost, even though it triggered the last stage.
+        assert!(state.observe(2));
+        assert!(state.accept(2, 4));
+    }
+
+    #[test]
+    fn startup_with_substituted_styles_skips_unchanged_first_probe() {
+        let mut state = FontReloadState::new(2_u8, 1);
+        assert!(!state.observe(2));
     }
 
     #[test]

--- a/crates/splinterm/src/renderer/fonts.rs
+++ b/crates/splinterm/src/renderer/fonts.rs
@@ -259,6 +259,7 @@ pub struct FontFingerprint {
 pub struct FontGeneration {
     pub(super) id: u64,
     pub(super) fingerprint: FontFingerprint,
+    source_fingerprint: FontFingerprint,
     pub(super) faces: Vec<FontFace>,
 }
 
@@ -269,10 +270,17 @@ impl FontGeneration {
         self.id
     }
 
-    /// Returns the stable effective source fingerprint.
+    /// Returns the stable fingerprint of the faces accepted for rendering.
     #[must_use]
     pub const fn fingerprint(&self) -> &FontFingerprint {
         &self.fingerprint
+    }
+
+    /// Returns the probed source identities used to stage this generation,
+    /// before incompatible styles were replaced by their regular face.
+    #[must_use]
+    pub const fn source_fingerprint(&self) -> &FontFingerprint {
+        &self.source_fingerprint
     }
 }
 
@@ -1680,17 +1688,8 @@ fn probe_primary_style_source(
 /// Returns an error when Fontconfig output or selected source metadata is invalid.
 #[doc(hidden)]
 pub fn probe_live_font_sources(pattern: &str, authority: FontAuthority) -> Result<FontFingerprint> {
-    let regular = resolve_face_source(
-        "primary regular",
-        pattern,
-        expected_primary_family_fragment(pattern),
-    )?;
-    let [bold_request, italic_request, bold_italic_request] = PRIMARY_STYLE_REQUESTS;
-    let mut sources = Vec::from([
-        regular.clone(),
-        probe_primary_style_source(&regular, bold_request),
-        probe_primary_style_source(&regular, italic_request),
-        probe_primary_style_source(&regular, bold_italic_request),
+    let mut sources = Vec::from(resolve_primary_sources(pattern)?);
+    sources.extend([
         resolve_face_source("CJK fallback", CJK_FONT, "noto sans cjk")?,
         resolve_face_source("emoji fallback", EMOJI_FONT, "noto color emoji")?,
     ]);
@@ -1748,9 +1747,9 @@ fn resolve_primary_style(
     regular: &FontFace,
     request: PrimaryStyleRequest,
     regular_advance: f32,
+    source: ResolvedFaceSource,
 ) -> FontFace {
-    let pattern = primary_style_pattern(&regular.family, request);
-    let resolved = resolve_face(request.label, &pattern, &regular.family).and_then(|candidate| {
+    let resolved = stage_face(source).and_then(|candidate| {
         let candidate_advance = face_advance(&candidate, BASE_FONT_SIZE)?;
         if let Some(reason) = style_candidate_rejection(
             regular,
@@ -1783,19 +1782,29 @@ fn expected_primary_family_fragment(pattern: &str) -> &'static str {
     }
 }
 
-fn resolve_primary_faces_exact(pattern: &str) -> Result<[FontFace; 4]> {
-    let regular = resolve_face(
+fn resolve_primary_sources(pattern: &str) -> Result<[ResolvedFaceSource; 4]> {
+    let regular = resolve_face_source(
         "primary regular",
         pattern,
         expected_primary_family_fragment(pattern),
     )?;
+    let [bold, italic, bold_italic] =
+        PRIMARY_STYLE_REQUESTS.map(|request| probe_primary_style_source(&regular, request));
+    Ok([regular, bold, italic, bold_italic])
+}
+
+fn resolve_primary_faces_exact(pattern: &str) -> Result<([FontFace; 4], [ResolvedFaceSource; 4])> {
+    let sources = resolve_primary_sources(pattern)?;
+    let [regular, bold, italic, bold_italic] = sources.clone();
+    let regular = stage_face(regular)?;
     let regular_advance = face_advance(&regular, BASE_FONT_SIZE)
         .context("selected primary regular face is unusable")?;
     let [bold_request, italic_request, bold_italic_request] = PRIMARY_STYLE_REQUESTS;
-    let bold = resolve_primary_style(&regular, bold_request, regular_advance);
-    let italic = resolve_primary_style(&regular, italic_request, regular_advance);
-    let bold_italic = resolve_primary_style(&regular, bold_italic_request, regular_advance);
-    Ok([regular, bold, italic, bold_italic])
+    let bold = resolve_primary_style(&regular, bold_request, regular_advance, bold);
+    let italic = resolve_primary_style(&regular, italic_request, regular_advance, italic);
+    let bold_italic =
+        resolve_primary_style(&regular, bold_italic_request, regular_advance, bold_italic);
+    Ok(([regular, bold, italic, bold_italic], sources))
 }
 
 fn resolve_startup_primary_with<T>(
@@ -1823,6 +1832,7 @@ fn resolve_startup_primary_with<T>(
 
 fn resolve_primary_faces(pattern: &str, authority: FontAuthority) -> Result<[FontFace; 4]> {
     resolve_startup_primary_with(pattern, authority, resolve_primary_faces_exact)
+        .map(|(faces, _)| faces)
 }
 
 fn resolve_font_candidate(
@@ -1830,30 +1840,53 @@ fn resolve_font_candidate(
     authority: FontAuthority,
     startup: bool,
 ) -> Result<FontGeneration> {
-    let [regular, bold, italic, bold_italic] = if startup {
-        resolve_primary_faces(pattern, authority)?
+    let (primary_faces, primary_sources) = if startup {
+        resolve_startup_primary_with(pattern, authority, resolve_primary_faces_exact)?
     } else {
         resolve_primary_faces_exact(pattern)?
     };
     let id = NEXT_FONT_GENERATION_ID.fetch_add(1, Ordering::Relaxed);
-    let mut faces = Vec::from([
-        regular,
-        bold,
-        italic,
-        bold_italic,
-        resolve_face("CJK fallback", CJK_FONT, "noto sans cjk")?,
-        resolve_face("emoji fallback", EMOJI_FONT, "noto color emoji")?,
-    ]);
+    let cjk = resolve_face_source("CJK fallback", CJK_FONT, "noto sans cjk")?;
+    let emoji = resolve_face_source("emoji fallback", EMOJI_FONT, "noto color emoji")?;
+    let mut faces = Vec::from(primary_faces);
+    faces.extend([stage_face(cjk.clone())?, stage_face(emoji.clone())?]);
+    let mut sources = Vec::from(primary_sources);
+    sources.extend([cjk, emoji]);
+    // Resolve fallback order once, then exclude the respective source/render
+    // selections. A rejected primary style can still be a fallback candidate.
+    let fallback_sources = resolve_fallback_sources(pattern, &HashSet::new())?;
+    let source_excluded = sources
+        .iter()
+        .map(|source| (source.path.clone(), source.index))
+        .collect::<HashSet<_>>();
+    sources.extend(
+        fallback_sources
+            .iter()
+            .filter(|source| !source_excluded.contains(&(source.path.clone(), source.index)))
+            .cloned(),
+    );
+    let source_fingerprint = FontFingerprint {
+        pattern: pattern.to_owned(),
+        authority,
+        faces: sources
+            .iter()
+            .map(ResolvedFaceSource::fingerprint)
+            .collect(),
+    };
     let excluded = faces
         .iter()
         .map(|face| (face.path.clone(), face.index))
         .collect::<HashSet<_>>();
-    let fallback_sources = resolve_fallback_sources(pattern, &excluded)?;
+    faces.extend(
+        fallback_sources
+            .into_iter()
+            .filter(|source| !excluded.contains(&(source.path.clone(), source.index)))
+            .map(unstaged_fallback_face),
+    );
     eprintln!(
         "Resolved {} ordered Fontconfig fallback faces",
-        fallback_sources.len()
+        faces.len() - 6
     );
-    faces.extend(fallback_sources.into_iter().map(unstaged_fallback_face));
     for face in &mut faces {
         face.generation_id = id;
     }
@@ -1865,6 +1898,7 @@ fn resolve_font_candidate(
     Ok(FontGeneration {
         id,
         fingerprint,
+        source_fingerprint,
         faces,
     })
 }
@@ -1890,7 +1924,13 @@ fn stage_font_generation(
 ) -> Result<FontGeneration> {
     stage_stable_with(|| {
         let generation = resolve_font_candidate(pattern, authority, startup)?;
-        Ok((generation.fingerprint.clone(), generation))
+        Ok((
+            (
+                generation.source_fingerprint.clone(),
+                generation.fingerprint.clone(),
+            ),
+            generation,
+        ))
     })
 }
 
@@ -2434,6 +2474,33 @@ mod tests {
     }
 
     #[test]
+    fn stable_staging_checks_sources_even_when_rendered_faces_match() {
+        let mut candidates = [((1_u8, 7_u8), "first"), ((2, 7), "second")].into_iter();
+        assert!(stage_stable_with(|| Ok(candidates.next().unwrap())).is_err());
+        let mut candidates = [((1_u8, 7_u8), "first"), ((1, 8), "second")].into_iter();
+        assert!(stage_stable_with(|| Ok(candidates.next().unwrap())).is_err());
+        let mut candidates = [((1_u8, 7_u8), "first"), ((1, 7), "second")].into_iter();
+        assert_eq!(
+            stage_stable_with(|| Ok(candidates.next().unwrap())).unwrap(),
+            "second"
+        );
+    }
+
+    #[test]
+    #[ignore = "requires host Fontconfig, DejaVu Sans, CJK and emoji fonts"]
+    fn rejected_style_sources_match_the_probe_not_the_rendered_faces() {
+        let pattern = "DejaVu Sans";
+        let authority = FontAuthority::NativeOmarchy;
+        let probe = probe_live_font_sources(pattern, authority).unwrap();
+        let generation = stage_live_font_generation(pattern, authority).unwrap();
+        assert_eq!(&probe, generation.source_fingerprint());
+        assert_ne!(&probe, generation.fingerprint());
+        let again = stage_live_font_generation(pattern, authority).unwrap();
+        assert_eq!(generation.source_fingerprint(), again.source_fingerprint());
+        assert_eq!(generation.fingerprint(), again.fingerprint());
+    }
+
+    #[test]
     #[ignore = "manual host resource timing; requires fontconfig and installed fonts"]
     fn repeated_live_staging_is_fd_bounded() {
         let options = renderer_options();
@@ -2457,7 +2524,7 @@ mod tests {
         let options = renderer_options();
         let probe = probe_live_font_sources(&options.font, options.font_authority).unwrap();
         let staged = stage_live_font_generation(&options.font, options.font_authority).unwrap();
-        assert_eq!(probe, staged.fingerprint);
+        assert_eq!(probe, staged.source_fingerprint);
     }
 
     #[test]

--- a/crates/splinterm/src/wayland.rs
+++ b/crates/splinterm/src/wayland.rs
@@ -11005,7 +11005,7 @@ mod tests {
                 .any(|case| { matches!(case.mode, ReducerBenchMode::InactiveBatch) })
         );
         for case in smoke {
-            assert!(measure_reducer_bench_case(case) > 0);
+            std::hint::black_box(measure_reducer_bench_case(case));
         }
     }
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,6 +1,6 @@
 # Current product status
 
-- **Current public version tag:** `v0.1.0-rc.1`
+- **Current public version tag:** `v0.1.0-rc.2`
 
 This document is the repository authority for Splinterm's current maturity,
 validated product scope, availability, and release gates. The [product roadmap](product-roadmap.md)
@@ -50,9 +50,25 @@ not current compatibility promises. Headless `splinterd` does not require a
 graphical environment, but its packaged and remote workflows remain beta
 interfaces on the documented platform.
 
-## 0.1.0 RC2 candidate preparation
+## 0.1.0 RC3 preparation (unreleased)
 
-This source branch retains RC1 and closes two review findings in live native
+RC3 is a maintenance stabilization candidate, not a new feature release. It
+separates probed font-source identity from accepted renderer faces, rejects FIFO
+policy files without blocking, preserves fragmented requests across unrelated
+revocations, and cleans up topology subscriptions on abnormal connection exit.
+Relay cancellation interrupts blocked writes while ordered remote EOF retains
+queued response bytes for slow consumers under the logical-channel limit.
+
+RC2 remains the public release. RC3 requires exact-source validation, independent
+review, and guarded installed-package acceptance before candidate construction
+and human-approved publication. Local preparation does not publish a release or
+update installed packages. See [release automation](release-automation.md).
+
+## 0.1.0 RC2 release
+
+[`v0.1.0-rc.2`](https://github.com/OldJobobo/splinterm/releases/tag/v0.1.0-rc.2)
+was published on 2026-09-04 from `b7f735e2257a6ae4f595e0f111f90c28279f5711`.
+It retains RC1 and closes two review findings in live native
 Omarchy font synchronization. Accepted staging now replaces a divergent probe
 fingerprint so a later generation cannot be skipped, and cached FreeType faces
 share their immutable staged mappings instead of copying an entire font file per
@@ -62,14 +78,13 @@ monospace family rather than requiring one host-specific family.
 Focused and complete non-graphical validation and independent source review
 passed. The exact RC2 implementation package at `d26cee9` passed guarded live
 valid-font replacement and invalid-candidate rollback acceptance without
-replacing the Window, daemon, shell, or Splint incarnation. Candidate
-construction and publication remain separate release boundaries. Foot is an
-optional historical differential and does not block either boundary.
+replacing the Window, daemon, shell, or Splint incarnation. Foot remains an
+optional historical differential rather than release authority.
 
 ## 0.1.0 RC1 release
 
 [`v0.1.0-rc.1`](https://github.com/OldJobobo/splinterm/releases/tag/v0.1.0-rc.1)
-is the current public prerelease. It freezes the 0.1 feature line on the complete
+was the first 0.1.0 release candidate. It freezes the 0.1 feature line on the complete
 Beta 3 baseline and adds live native Omarchy font following, bounded Omarchy Gum
 palette refresh for newly created Splints, Sixel capability negotiation for Yazi,
 and legacy generated-Dojo name normalization. Its release target is

--- a/packaging/PKGBUILD
+++ b/packaging/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: OldJobobo
 pkgbase=splinterm
 pkgname=('splinterm' 'splinterm-mcp')
-pkgver=0.1.0rc.2
+pkgver=0.1.0rc.3
 pkgrel=1
 arch=('x86_64')
 url='https://github.com/oldjobobo/splinterm'

--- a/packaging/PKGBUILD
+++ b/packaging/PKGBUILD
@@ -32,6 +32,7 @@ check() {
   python -m unittest tools/automation/test_dojo_picker.py
   python -m unittest tools/package/test_installer_safety.py
   python -m unittest tools/package/test_omarchy_screensaver_integration.py
+  python -m unittest tools/package/test_validate_mcp_package.py
   python -m unittest tools/package/test_workload_units.py
 }
 

--- a/packaging/aur-bin/.SRCINFO
+++ b/packaging/aur-bin/.SRCINFO
@@ -1,15 +1,15 @@
 pkgbase = splinterm-bin
-	pkgver = 0.1.0rc.2
+	pkgver = 0.1.0rc.3
 	pkgrel = 1
 	url = https://github.com/oldjobobo/splinterm
 	arch = x86_64
 	license = MIT
-	noextract = splinterm-0.1.0rc.2-x86_64.pkg.tar.zst
-	noextract = splinterm-mcp-0.1.0rc.2-x86_64.pkg.tar.zst
+	noextract = splinterm-0.1.0rc.3-x86_64.pkg.tar.zst
+	noextract = splinterm-mcp-0.1.0rc.3-x86_64.pkg.tar.zst
 	options = !strip
 	options = !debug
-	source = splinterm-0.1.0rc.2-x86_64.pkg.tar.zst::https://github.com/OldJobobo/splinterm/releases/download/v0.1.0-rc.2/splinterm-11742b60cb5b502cdadb60a582b9c3c838120d2b-x86_64.pkg.tar.zst
-	source = splinterm-mcp-0.1.0rc.2-x86_64.pkg.tar.zst::https://github.com/OldJobobo/splinterm/releases/download/v0.1.0-rc.2/splinterm-mcp-11742b60cb5b502cdadb60a582b9c3c838120d2b-x86_64.pkg.tar.zst
+	source = splinterm-0.1.0rc.3-x86_64.pkg.tar.zst::https://github.com/OldJobobo/splinterm/releases/download/v0.1.0-rc.3/splinterm-11742b60cb5b502cdadb60a582b9c3c838120d2b-x86_64.pkg.tar.zst
+	source = splinterm-mcp-0.1.0rc.3-x86_64.pkg.tar.zst::https://github.com/OldJobobo/splinterm/releases/download/v0.1.0-rc.3/splinterm-mcp-11742b60cb5b502cdadb60a582b9c3c838120d2b-x86_64.pkg.tar.zst
 	sha256sums = 1a7f2a31c04dfc87495740938a3e8410f2a464f99c382a0f5d563045d8798cfb
 	sha256sums = e53a2b567619d6d8058522c4e18ef077e3b575cc99889d26cc1a18d65647ead0
 
@@ -31,13 +31,13 @@ pkgname = splinterm-bin
 	depends = xdg-terminal-exec
 	optdepends = fcitx5: Wayland text-input support
 	optdepends = splinterm-mcp-bin: explicitly configured MCP stdio adapter
-	provides = splinterm=0.1.0rc.2-1
+	provides = splinterm=0.1.0rc.3-1
 	conflicts = splinterm
 
 pkgname = splinterm-mcp-bin
 	pkgdesc = Policy-scoped MCP stdio adapter for Splinterm (prebuilt binary)
-	depends = splinterm=0.1.0rc.2-1
+	depends = splinterm=0.1.0rc.3-1
 	depends = gcc-libs
 	depends = glibc
-	provides = splinterm-mcp=0.1.0rc.2-1
+	provides = splinterm-mcp=0.1.0rc.3-1
 	conflicts = splinterm-mcp

--- a/packaging/aur-bin/PKGBUILD
+++ b/packaging/aur-bin/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: OldJobobo
 pkgbase=splinterm-bin
 pkgname=('splinterm-bin' 'splinterm-mcp-bin')
-pkgver=0.1.0rc.2
+pkgver=0.1.0rc.3
 pkgrel=1
 _commit=11742b60cb5b502cdadb60a582b9c3c838120d2b
 arch=('x86_64')
@@ -9,8 +9,8 @@ url='https://github.com/oldjobobo/splinterm'
 license=('MIT')
 options=('!strip' '!debug')
 source=(
-  "splinterm-$pkgver-$CARCH.pkg.tar.zst::https://github.com/OldJobobo/splinterm/releases/download/v0.1.0-rc.2/splinterm-$_commit-$CARCH.pkg.tar.zst"
-  "splinterm-mcp-$pkgver-$CARCH.pkg.tar.zst::https://github.com/OldJobobo/splinterm/releases/download/v0.1.0-rc.2/splinterm-mcp-$_commit-$CARCH.pkg.tar.zst"
+  "splinterm-$pkgver-$CARCH.pkg.tar.zst::https://github.com/OldJobobo/splinterm/releases/download/v0.1.0-rc.3/splinterm-$_commit-$CARCH.pkg.tar.zst"
+  "splinterm-mcp-$pkgver-$CARCH.pkg.tar.zst::https://github.com/OldJobobo/splinterm/releases/download/v0.1.0-rc.3/splinterm-mcp-$_commit-$CARCH.pkg.tar.zst"
 )
 noextract=(
   "splinterm-$pkgver-$CARCH.pkg.tar.zst"

--- a/packaging/aur/.SRCINFO
+++ b/packaging/aur/.SRCINFO
@@ -1,5 +1,5 @@
 pkgbase = splinterm
-	pkgver = 0.1.0rc.2
+	pkgver = 0.1.0rc.3
 	pkgrel = 1
 	url = https://github.com/oldjobobo/splinterm
 	arch = x86_64
@@ -19,7 +19,7 @@ pkgbase = splinterm
 	makedepends = ttf-jetbrains-mono-nerd
 	makedepends = wayland
 	makedepends = xdg-terminal-exec
-	source = https://github.com/OldJobobo/splinterm/releases/download/v0.1.0-rc.2/splinterm-0.1.0-rc.2.tar.gz
+	source = https://github.com/OldJobobo/splinterm/releases/download/v0.1.0-rc.3/splinterm-0.1.0-rc.3.tar.gz
 	sha256sums = d59bf82a5e2218112613d4a69adb20ce2b6cd8c133cc9b14da8fbfa1de4d0644
 
 pkgname = splinterm
@@ -43,6 +43,6 @@ pkgname = splinterm
 
 pkgname = splinterm-mcp
 	pkgdesc = Policy-scoped MCP stdio adapter for Splinterm
-	depends = splinterm=0.1.0rc.2-1
+	depends = splinterm=0.1.0rc.3-1
 	depends = gcc-libs
 	depends = glibc

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -1,8 +1,8 @@
 # Maintainer: OldJobobo
 pkgbase=splinterm
 pkgname=('splinterm' 'splinterm-mcp')
-pkgver=0.1.0rc.2
-_upstream_ver=0.1.0-rc.2
+pkgver=0.1.0rc.3
+_upstream_ver=0.1.0-rc.3
 pkgrel=1
 arch=('x86_64')
 url='https://github.com/oldjobobo/splinterm'

--- a/packaging/release-state.json
+++ b/packaging/release-state.json
@@ -1,4 +1,4 @@
 {
   "schema": 1,
-  "current_version_tag": "v0.1.0-rc.1"
+  "current_version_tag": "v0.1.0-rc.2"
 }

--- a/tools/package/test_validate_mcp_package.py
+++ b/tools/package/test_validate_mcp_package.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Regression tests for the extracted MCP package validator host."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+
+MODULE_PATH = Path(__file__).with_name("validate-mcp-package.py")
+SPEC = importlib.util.spec_from_file_location("validate_mcp_package", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+validate_mcp_package = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(validate_mcp_package)
+
+
+class McpHostTests(unittest.TestCase):
+    def fake_server(self, payload: bytes) -> Path:
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        script = Path(temporary.name) / "fake-mcp-server"
+        script.write_text(
+            f"#!{sys.executable}\n"
+            "import os\n"
+            "import sys\n"
+            "sys.stdin.buffer.readline()\n"
+            f"os.write(1, {payload!r})\n"
+            "for _ in sys.stdin.buffer:\n"
+            "    pass\n",
+            encoding="utf-8",
+        )
+        script.chmod(0o755)
+        return script
+
+    def test_receive_preserves_a_coalesced_second_frame(self) -> None:
+        payload = (
+            b'{"jsonrpc":"2.0","id":1,"result":{}}\n'
+            b'{"jsonrpc":"2.0","method":"notifications/resources/updated",'
+            b'"params":{"uri":"splinterm://topology"}}\n'
+        )
+        host = validate_mcp_package.McpHost(self.fake_server(payload), os.environ.copy())
+        try:
+            host.send({"jsonrpc": "2.0", "id": 1, "method": "initialize"})
+            self.assertEqual(host.receive(1)["id"], 1)
+            self.assertEqual(
+                host.receive(1)["method"],
+                "notifications/resources/updated",
+            )
+        finally:
+            host.close()
+
+    def test_receive_rejects_an_oversized_buffered_line(self) -> None:
+        host = validate_mcp_package.McpHost(self.fake_server(b""), os.environ.copy())
+        try:
+            with mock.patch.object(
+                validate_mcp_package,
+                "MAXIMUM_MCP_RESPONSE_BYTES",
+                32,
+            ):
+                host.buffer.extend(b"x" * 32 + b"\n")
+                with self.assertRaisesRegex(AssertionError, "line limit"):
+                    host.receive(1)
+        finally:
+            host.close()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/package/validate-mcp-package.py
+++ b/tools/package/validate-mcp-package.py
@@ -15,6 +15,9 @@ import tempfile
 import time
 
 
+MAXIMUM_MCP_RESPONSE_BYTES = 16 * 1024 * 1024
+
+
 class McpHost:
     def __init__(self, executable: Path, environment: dict[str, str]):
         self.process = subprocess.Popen(
@@ -23,25 +26,41 @@ class McpHost:
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
-            text=True,
-            bufsize=1,
+            bufsize=0,
         )
         assert self.process.stdin is not None and self.process.stdout is not None
+        self.buffer = bytearray()
         self.next_id = 1
         self.notifications: list[dict[str, object]] = []
 
     def send(self, document: dict[str, object]) -> None:
         assert self.process.stdin is not None
-        self.process.stdin.write(json.dumps(document, separators=(",", ":")) + "\n")
-        self.process.stdin.flush()
+        payload = (json.dumps(document, separators=(",", ":")) + "\n").encode()
+        assert self.process.stdin.write(payload) == len(payload)
 
     def receive(self, timeout: float = 15) -> dict[str, object]:
         assert self.process.stdout is not None
-        ready, _, _ = select.select([self.process.stdout], [], [], timeout)
-        assert ready, "timed out reading MCP response"
-        line = self.process.stdout.readline()
-        assert line, "MCP server closed stdout"
-        return json.loads(line)
+        deadline = time.monotonic() + timeout
+        while b"\n" not in self.buffer:
+            remaining = deadline - time.monotonic()
+            assert remaining > 0, "timed out reading MCP response"
+            ready, _, _ = select.select([self.process.stdout], [], [], remaining)
+            assert ready, "timed out reading MCP response"
+            chunk = os.read(self.process.stdout.fileno(), 64 * 1024)
+            assert chunk, "MCP server closed stdout"
+            self.buffer.extend(chunk)
+            if b"\n" not in self.buffer:
+                assert (
+                    len(self.buffer) < MAXIMUM_MCP_RESPONSE_BYTES
+                ), "MCP response exceeds line limit"
+        line, _, remainder = self.buffer.partition(b"\n")
+        assert (
+            len(line) + 1 <= MAXIMUM_MCP_RESPONSE_BYTES
+        ), "MCP response exceeds line limit"
+        self.buffer = bytearray(remainder)
+        document = json.loads(line)
+        assert isinstance(document, dict), "MCP response is not an object"
+        return document
 
     def request(self, method: str, params: dict[str, object] | None = None) -> dict[str, object]:
         request_id = self.next_id
@@ -68,20 +87,28 @@ class McpHost:
         })
         assert "error" not in response, response
         self.send({"jsonrpc": "2.0", "method": "notifications/initialized"})
-        return response["result"]
+        result = response["result"]
+        assert isinstance(result, dict), "MCP initialize result is not an object"
+        return result
 
     def tool(self, name: str, arguments: dict[str, object]) -> dict[str, object]:
         response = self.request("tools/call", {"name": name, "arguments": arguments})
         assert "error" not in response, response
-        return response["result"]
+        result = response["result"]
+        assert isinstance(result, dict), "MCP tool result is not an object"
+        return result
 
     def close(self) -> None:
         if self.process.stdin is not None and not self.process.stdin.closed:
             self.process.stdin.close()
         self.process.wait(timeout=15)
+        stderr = self.process.stderr.read() if self.process.stderr else b""
+        if self.process.stdout is not None:
+            self.process.stdout.close()
+        if self.process.stderr is not None:
+            self.process.stderr.close()
         assert self.process.returncode == 0
-        stderr = self.process.stderr.read() if self.process.stderr else ""
-        assert not stderr, stderr
+        assert not stderr, stderr.decode(errors="replace")
 
 
 def write_policy(path: Path, executable: Path, scopes: list[str], resources: list[dict[str, object]]) -> None:

--- a/tools/release/test_prepare_candidate.py
+++ b/tools/release/test_prepare_candidate.py
@@ -140,7 +140,7 @@ class PrepareCandidateTests(unittest.TestCase):
         commit = MODULE.run(["git", "rev-parse", "HEAD"])
         with self.assertRaisesRegex(ValueError, "release tag already exists"):
             MODULE.validate_candidate(
-                "OldJobobo/splinterm", commit, version, "v0.1.0-rc.1"
+                "OldJobobo/splinterm", commit, version, "v0.1.0-rc.2"
             )
 
     def test_mismatched_version_fails_before_build(self) -> None:
@@ -157,11 +157,11 @@ class PrepareCandidateTests(unittest.TestCase):
         release_tag = "v9.9.9-rc.2"
         with mock.patch.object(MODULE, "run", return_value="a" * 40):
             self.assertEqual(
-                MODULE.validate_previous_version_tag("v0.1.0-rc.1", release_tag),
-                "v0.1.0-rc.1",
+                MODULE.validate_previous_version_tag("v0.1.0-rc.2", release_tag),
+                "v0.1.0-rc.2",
             )
         with self.assertRaisesRegex(ValueError, "v-prefixed SemVer"):
-            MODULE.validate_previous_version_tag("0.1.0-rc.1", release_tag)
+            MODULE.validate_previous_version_tag("0.1.0-rc.2", release_tag)
         with self.assertRaisesRegex(ValueError, "must differ"):
             MODULE.validate_previous_version_tag(release_tag, release_tag)
         with self.assertRaisesRegex(ValueError, "current public release"):
@@ -170,10 +170,10 @@ class PrepareCandidateTests(unittest.TestCase):
             mock.patch.object(MODULE, "run", side_effect=ValueError("missing tag")),
             self.assertRaisesRegex(ValueError, "missing tag"),
         ):
-            MODULE.validate_previous_version_tag("v0.1.0-rc.1", release_tag)
+            MODULE.validate_previous_version_tag("v0.1.0-rc.2", release_tag)
 
     def test_public_release_state_is_closed_and_versioned(self) -> None:
-        self.assertEqual(MODULE.current_public_release_tag(), "v0.1.0-rc.1")
+        self.assertEqual(MODULE.current_public_release_tag(), "v0.1.0-rc.2")
         state = json.loads(
             (ROOT / "packaging/release-state.json").read_text(encoding="utf-8")
         )
@@ -181,7 +181,7 @@ class PrepareCandidateTests(unittest.TestCase):
         self.assertEqual(state["schema"], 1)
         status = (ROOT / "docs/status.md").read_text(encoding="utf-8")
         self.assertEqual(
-            status.count("**Current public version tag:** `v0.1.0-rc.1`"), 1
+            status.count("**Current public version tag:** `v0.1.0-rc.2`"), 1
         )
 
     def test_release_notes_are_read_from_the_exact_candidate_commit(self) -> None:

--- a/tools/release/test_promote_release.py
+++ b/tools/release/test_promote_release.py
@@ -22,7 +22,7 @@ RUN_ID = 12345
 
 class CandidateFixture:
     def __init__(
-        self, root: Path, previous_version_tag: str = "v0.1.0-rc.1"
+        self, root: Path, previous_version_tag: str = "v0.1.0-rc.2"
     ) -> None:
         self.root = root
         self.assets = MODULE.expected_assets(COMMIT, VERSION)


### PR DESCRIPTION
## Summary

Prepare 0.1.0-rc.3 as a maintenance stabilization candidate, retaining RC2 features:
- Reject FIFO policy files without blocking.
- Keep observed font sources separate from accepted renderer faces, preserving staging-race protection.
- Preserve partial request reads across unrelated revocations and clean up owner subscriptions on every connection exit.
- Make relay cancellation/teardown bounded while preserving ordered remote-EOF tails and channel admission.
- Correct buffered MCP package-validator reads and remove an invalid positive-duration benchmark smoke assertion.
- Align version/package metadata and release notes; RC2 remains the recorded public predecessor until publication.

## Validation and review

- Independent security/transport and font/release reviews: accepted, no findings.
- Separately approved validator and timing-test follow-up reviews: accepted, no findings.
- Publication release-note wording independently reviewed: accepted, no findings.
- Full source workspace tests on Rust1.88 and1.97:1191passed,0failed,9ignored; strict Clippy and formatting passed.
- Exact37948f3 guest package build passed full embedded checks:1191Rust tests, package Python regressions, extracted MCP runtime/package validation. Guest build uses stable Rust1.98.
- Guarded installed-package VM acceptance passed: input, ANSI/bold/CJK/emoji rendering, panes, tabs, resize, reopen preserving daemon/Splint identities. Private test resources cleaned; desktop restored.
- Publication tip411c3ba differs from VM-accepted37948f3 only in RELEASE_NOTES.md. Package/release Python tests51passed,1expected absent-tag skip,5subtests passed; diff check clean.

## Residual boundaries

Bounded VM acceptance is not an exhaustive font/theme/scale/remote matrix. Nine default ignored Rust tests remain; Foot is advisory. Official candidate artifacts will be built by the read-only candidate workflow after merged-commit CI, then independently verified and promoted through the protected release environment. AUR distribution follows public asset verification. No package installation on the workstation.

Earlier failing package runs are retained as evidence: MCP buffered reads and zero-duration smoke assumptions were diagnosed, fixed and reviewed, not bypassed. Main forward ports are a separate milestone.
