### PR TITLE
Record RC3 publication and verified AUR recipes

### DIFF
--- a/docs/status.md
+++ b/docs/status.md
@@ -1,6 +1,6 @@
 # Current product status
 
-- **Current public version tag:** `v0.1.0-rc.2`
+- **Current public version tag:** `v0.1.0-rc.3`
 
 This document is the repository authority for Splinterm's current maturity,
 validated product scope, availability, and release gates. The [product roadmap](product-roadmap.md)
@@ -50,7 +50,7 @@ not current compatibility promises. Headless `splinterd` does not require a
 graphical environment, but its packaged and remote workflows remain beta
 interfaces on the documented platform.
 
-## 0.1.0 RC3 preparation (unreleased)
+## 0.1.0 RC3 release
 
 RC3 is a maintenance stabilization candidate, not a new feature release. It
 separates probed font-source identity from accepted renderer faces, rejects FIFO
@@ -59,10 +59,17 @@ revocations, and cleans up topology subscriptions on abnormal connection exit.
 Relay cancellation interrupts blocked writes while ordered remote EOF retains
 queued response bytes for slow consumers under the logical-channel limit.
 
-RC2 remains the public release. RC3 requires exact-source validation, independent
-review, and guarded installed-package acceptance before candidate construction
-and human-approved publication. Local preparation does not publish a release or
-update installed packages. See [release automation](release-automation.md).
+[`v0.1.0-rc.3`](https://github.com/OldJobobo/splinterm/releases/tag/v0.1.0-rc.3)
+was published from `2855721bf467f0d6fac0205d072d019012946158` after required CI,
+independent review, guarded installed-package VM acceptance, and protected
+human-approved promotion. The five public assets were downloaded and verified
+against the candidate manifest. Both AUR package bases,
+[`splinterm`](https://aur.archlinux.org/packages/splinterm) and
+[`splinterm-bin`](https://aur.archlinux.org/packages/splinterm-bin), publish
+`0.1.0rc.3-1` with the matching source and binary hashes. Their optional MCP
+subpackages retain the same version. See [release automation](release-automation.md).
+
+RC3 remains a prerelease for continued testing before 0.1.0 stable.
 
 ## 0.1.0 RC2 release
 

--- a/packaging/aur-bin/.SRCINFO
+++ b/packaging/aur-bin/.SRCINFO
@@ -8,10 +8,10 @@ pkgbase = splinterm-bin
 	noextract = splinterm-mcp-0.1.0rc.3-x86_64.pkg.tar.zst
 	options = !strip
 	options = !debug
-	source = splinterm-0.1.0rc.3-x86_64.pkg.tar.zst::https://github.com/OldJobobo/splinterm/releases/download/v0.1.0-rc.3/splinterm-11742b60cb5b502cdadb60a582b9c3c838120d2b-x86_64.pkg.tar.zst
-	source = splinterm-mcp-0.1.0rc.3-x86_64.pkg.tar.zst::https://github.com/OldJobobo/splinterm/releases/download/v0.1.0-rc.3/splinterm-mcp-11742b60cb5b502cdadb60a582b9c3c838120d2b-x86_64.pkg.tar.zst
-	sha256sums = 1a7f2a31c04dfc87495740938a3e8410f2a464f99c382a0f5d563045d8798cfb
-	sha256sums = e53a2b567619d6d8058522c4e18ef077e3b575cc99889d26cc1a18d65647ead0
+	source = splinterm-0.1.0rc.3-x86_64.pkg.tar.zst::https://github.com/OldJobobo/splinterm/releases/download/v0.1.0-rc.3/splinterm-2855721bf467f0d6fac0205d072d019012946158-x86_64.pkg.tar.zst
+	source = splinterm-mcp-0.1.0rc.3-x86_64.pkg.tar.zst::https://github.com/OldJobobo/splinterm/releases/download/v0.1.0-rc.3/splinterm-mcp-2855721bf467f0d6fac0205d072d019012946158-x86_64.pkg.tar.zst
+	sha256sums = 60b5cd2716d3277396d0f7e42a3edfc905206d4cf53c0e0af75702dc82e5f67f
+	sha256sums = 575ea09f20e4af3e9f6e24685b98c3e61ca8898746f45861e7122db0ca87473e
 
 pkgname = splinterm-bin
 	pkgdesc = Persistent Wayland terminal for humans and bounded automation (prebuilt binary)

--- a/packaging/aur-bin/PKGBUILD
+++ b/packaging/aur-bin/PKGBUILD
@@ -3,7 +3,7 @@ pkgbase=splinterm-bin
 pkgname=('splinterm-bin' 'splinterm-mcp-bin')
 pkgver=0.1.0rc.3
 pkgrel=1
-_commit=11742b60cb5b502cdadb60a582b9c3c838120d2b
+_commit=2855721bf467f0d6fac0205d072d019012946158
 arch=('x86_64')
 url='https://github.com/oldjobobo/splinterm'
 license=('MIT')
@@ -17,8 +17,8 @@ noextract=(
   "splinterm-mcp-$pkgver-$CARCH.pkg.tar.zst"
 )
 sha256sums=(
-  '1a7f2a31c04dfc87495740938a3e8410f2a464f99c382a0f5d563045d8798cfb'
-  'e53a2b567619d6d8058522c4e18ef077e3b575cc99889d26cc1a18d65647ead0'
+  '60b5cd2716d3277396d0f7e42a3edfc905206d4cf53c0e0af75702dc82e5f67f'
+  '575ea09f20e4af3e9f6e24685b98c3e61ca8898746f45861e7122db0ca87473e'
 )
 
 _extract_payload() {

--- a/packaging/aur/.SRCINFO
+++ b/packaging/aur/.SRCINFO
@@ -20,7 +20,7 @@ pkgbase = splinterm
 	makedepends = wayland
 	makedepends = xdg-terminal-exec
 	source = https://github.com/OldJobobo/splinterm/releases/download/v0.1.0-rc.3/splinterm-0.1.0-rc.3.tar.gz
-	sha256sums = d59bf82a5e2218112613d4a69adb20ce2b6cd8c133cc9b14da8fbfa1de4d0644
+	sha256sums = c0ccb3e29d4e47a2e905a03767b4b480e24a62ad67d1a74efa12cae4c1597767
 
 pkgname = splinterm
 	pkgdesc = Persistent Wayland terminal for humans and bounded automation

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -28,7 +28,7 @@ source=(
   "https://github.com/OldJobobo/splinterm/releases/download/v$_upstream_ver/$pkgbase-$_upstream_ver.tar.gz"
 )
 sha256sums=(
-  'd59bf82a5e2218112613d4a69adb20ce2b6cd8c133cc9b14da8fbfa1de4d0644'
+  'c0ccb3e29d4e47a2e905a03767b4b480e24a62ad67d1a74efa12cae4c1597767'
 )
 
 prepare() {

--- a/packaging/release-state.json
+++ b/packaging/release-state.json
@@ -1,4 +1,4 @@
 {
   "schema": 1,
-  "current_version_tag": "v0.1.0-rc.2"
+  "current_version_tag": "v0.1.0-rc.3"
 }

--- a/tools/release/test_prepare_candidate.py
+++ b/tools/release/test_prepare_candidate.py
@@ -157,11 +157,11 @@ class PrepareCandidateTests(unittest.TestCase):
         release_tag = "v9.9.9-rc.2"
         with mock.patch.object(MODULE, "run", return_value="a" * 40):
             self.assertEqual(
-                MODULE.validate_previous_version_tag("v0.1.0-rc.2", release_tag),
-                "v0.1.0-rc.2",
+                MODULE.validate_previous_version_tag("v0.1.0-rc.3", release_tag),
+                "v0.1.0-rc.3",
             )
         with self.assertRaisesRegex(ValueError, "v-prefixed SemVer"):
-            MODULE.validate_previous_version_tag("0.1.0-rc.2", release_tag)
+            MODULE.validate_previous_version_tag("0.1.0-rc.3", release_tag)
         with self.assertRaisesRegex(ValueError, "must differ"):
             MODULE.validate_previous_version_tag(release_tag, release_tag)
         with self.assertRaisesRegex(ValueError, "current public release"):
@@ -170,10 +170,10 @@ class PrepareCandidateTests(unittest.TestCase):
             mock.patch.object(MODULE, "run", side_effect=ValueError("missing tag")),
             self.assertRaisesRegex(ValueError, "missing tag"),
         ):
-            MODULE.validate_previous_version_tag("v0.1.0-rc.2", release_tag)
+            MODULE.validate_previous_version_tag("v0.1.0-rc.3", release_tag)
 
     def test_public_release_state_is_closed_and_versioned(self) -> None:
-        self.assertEqual(MODULE.current_public_release_tag(), "v0.1.0-rc.2")
+        self.assertEqual(MODULE.current_public_release_tag(), "v0.1.0-rc.3")
         state = json.loads(
             (ROOT / "packaging/release-state.json").read_text(encoding="utf-8")
         )
@@ -181,7 +181,7 @@ class PrepareCandidateTests(unittest.TestCase):
         self.assertEqual(state["schema"], 1)
         status = (ROOT / "docs/status.md").read_text(encoding="utf-8")
         self.assertEqual(
-            status.count("**Current public version tag:** `v0.1.0-rc.2`"), 1
+            status.count("**Current public version tag:** `v0.1.0-rc.3`"), 1
         )
 
     def test_release_notes_are_read_from_the_exact_candidate_commit(self) -> None:

--- a/tools/release/test_promote_release.py
+++ b/tools/release/test_promote_release.py
@@ -22,7 +22,7 @@ RUN_ID = 12345
 
 class CandidateFixture:
     def __init__(
-        self, root: Path, previous_version_tag: str = "v0.1.0-rc.2"
+        self, root: Path, previous_version_tag: str = "v0.1.0-rc.3"
     ) -> None:
         self.root = root
         self.assets = MODULE.expected_assets(COMMIT, VERSION)


### PR DESCRIPTION
Records published v0.1.0-rc.3 at immutable commit 2855721, synchronizes both AUR recipe copies with the verified release artifacts, and advances the current-public-release marker and future candidate test fixtures. Both AUR package bases and all four package pages now show 0.1.0rc.3-1. No product code, version tag, or published asset changes. Validation: 52 package/release tests plus 5 subtests pass; generated SRCINFO, actual diff and diff check inspected; independent bounded release-record review requested before merge.