### PR TITLE
Prepare 0.1.0 stable release

### DIFF
--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -31,6 +31,7 @@ jobs:
       commit: ${{ steps.candidate.outputs.commit }}
       version: ${{ steps.candidate.outputs.version }}
       tag: ${{ steps.candidate.outputs.tag }}
+      prerelease: ${{ steps.candidate.outputs.prerelease }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -113,11 +114,13 @@ jobs:
           with output.open("a", encoding="utf-8") as stream:
               for key in ("commit", "version", "tag"):
                   stream.write(f"{key}={promotion[key]}\n")
+              stream.write(f"prerelease={str(promotion['prerelease']).lower()}\n")
           summary = Path(os.environ["GITHUB_STEP_SUMMARY"])
           with summary.open("a", encoding="utf-8") as stream:
               stream.write(f"# Verified Splinterm {promotion['version']} candidate\n\n")
               stream.write(f"Commit: `{promotion['commit']}`  \n")
               stream.write(f"Tag to create: `{promotion['tag']}`  \n")
+              stream.write(f"Prerelease: `{promotion['prerelease']}`  \n")
               stream.write(f"Candidate run: `{promotion['candidate_run_id']}`  \n")
               stream.write(f"Manifest: `{promotion['candidate_manifest_sha256']}`\n\n")
               stream.write("The publish job now waits for approval in the protected GitHub `release` environment.\n")
@@ -231,19 +234,24 @@ jobs:
           require_absent "repos/$RELEASE_REPOSITORY/git/ref/tags/$RELEASE_TAG" tag
           require_absent "repos/$RELEASE_REPOSITORY/releases/tags/$RELEASE_TAG" release
 
-      - name: Create versioned tag and prerelease
+      - name: Create versioned tag and release
         env:
           GH_TOKEN: ${{ secrets.SPLINTERM_RELEASE_TOKEN }}
           RELEASE_TAG: ${{ needs.verify.outputs.tag }}
           RELEASE_COMMIT: ${{ needs.verify.outputs.commit }}
+          RELEASE_PRERELEASE: ${{ needs.verify.outputs.prerelease }}
         run: |
+          case "$RELEASE_PRERELEASE" in
+            true|false) ;;
+            *) printf 'invalid verified prerelease state\n' >&2; exit 1 ;;
+          esac
           gh api --method POST "repos/$RELEASE_REPOSITORY/git/refs" \
             -f ref="refs/tags/$RELEASE_TAG" \
             -f sha="$RELEASE_COMMIT"
           gh release create "$RELEASE_TAG" \
             --repo "$RELEASE_REPOSITORY" \
             --target "$RELEASE_COMMIT" \
-            --prerelease \
+            --prerelease="$RELEASE_PRERELEASE" \
             --title "Splinterm ${{ needs.verify.outputs.version }}" \
             --notes-file verified/candidate/RELEASE-NOTES.md
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1400,7 +1400,7 @@ dependencies = [
 
 [[package]]
 name = "splinterd"
-version = "0.1.0-rc.3"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "libc",
@@ -1425,7 +1425,7 @@ dependencies = [
 
 [[package]]
 name = "splinterm"
-version = "0.1.0-rc.3"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1455,7 +1455,7 @@ dependencies = [
 
 [[package]]
 name = "splinterm-automation-client"
-version = "0.1.0-rc.3"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "rustix",
@@ -1471,7 +1471,7 @@ dependencies = [
 
 [[package]]
 name = "splinterm-core"
-version = "0.1.0-rc.3"
+version = "0.1.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -1481,7 +1481,7 @@ dependencies = [
 
 [[package]]
 name = "splinterm-filemap"
-version = "0.1.0-rc.3"
+version = "0.1.0"
 dependencies = [
  "memmap2",
  "rustix",
@@ -1489,7 +1489,7 @@ dependencies = [
 
 [[package]]
 name = "splinterm-freetype"
-version = "0.1.0-rc.3"
+version = "0.1.0"
 dependencies = [
  "freetype-rs",
  "splinterm-filemap",
@@ -1500,7 +1500,7 @@ dependencies = [
 
 [[package]]
 name = "splinterm-graphical-relay"
-version = "0.1.0-rc.3"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "tokio",
@@ -1509,7 +1509,7 @@ dependencies = [
 
 [[package]]
 name = "splinterm-mcp"
-version = "0.1.0-rc.3"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "rmcp",
@@ -1524,7 +1524,7 @@ dependencies = [
 
 [[package]]
 name = "splinterm-pixman"
-version = "0.1.0-rc.3"
+version = "0.1.0"
 dependencies = [
  "libc",
  "pixman-sys",
@@ -1533,7 +1533,7 @@ dependencies = [
 
 [[package]]
 name = "splinterm-protocol"
-version = "0.1.0-rc.3"
+version = "0.1.0"
 dependencies = [
  "base64",
  "rustix",
@@ -1546,7 +1546,7 @@ dependencies = [
 
 [[package]]
 name = "splinterm-pty"
-version = "0.1.0-rc.3"
+version = "0.1.0"
 dependencies = [
  "rustix",
  "thiserror",
@@ -1555,7 +1555,7 @@ dependencies = [
 
 [[package]]
 name = "splinterm-relay"
-version = "0.1.0-rc.3"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "nix",
@@ -1567,7 +1567,7 @@ dependencies = [
 
 [[package]]
 name = "splinterm-terminal"
-version = "0.1.0-rc.3"
+version = "0.1.0"
 dependencies = [
  "base64",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.1.0-rc.3"
+version = "0.1.0"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 **A persistent, security-conscious terminal substrate for humans and bounded automation.**
 
-[Website](https://splinterm.com/) · [Documentation](https://splinterm.com/docs/) · [Beta 2 release notes draft](RELEASE_NOTES.md) · [Quickstart](https://splinterm.com/docs/quickstart/) · [Product roadmap](docs/product-roadmap.md) · [Current status](docs/status.md)
+[Website](https://splinterm.com/) · [Documentation](https://splinterm.com/docs/) · [0.1.0 release notes](RELEASE_NOTES.md) · [Quickstart](https://splinterm.com/docs/quickstart/) · [Product roadmap](docs/product-roadmap.md) · [Current status](docs/status.md)
 
 </div>
 
@@ -14,7 +14,7 @@ Splinterm combines a native Wayland terminal with a headless daemon that keeps s
 Humans use that persistent topology through native windows, tabs, and panes. Authorized tools can reach the same sessions through bounded JSON/NDJSON, SSH relay, and MCP interfaces. Splinterm is built in Rust from [Foot](https://codeberg.org/dnkl/foot)'s terminal behavior and designed first for Omarchy and Arch Linux.
 
 > [!IMPORTANT]
-> **Status: public beta.** Source, immutable versioned GitHub and AUR packages, and documentation are public. Core terminal emulation, persistent sessions, multiplexing, native Wayland presentation, Arch packaging, and bounded automation workflows are implemented and validated for the current x86_64 Omarchy/Arch Linux target. The beta may make breaking changes; broader compatibility guarantees and stable support have not been released.
+> **Splinterm 0.1 targets x86_64 Omarchy/Arch Linux.** Core terminal emulation, persistent sessions, multiplexing, native Wayland presentation, Arch packaging, and bounded automation workflows are implemented and validated on that target. Broader platform support, live daemon upgrade handoff, and a support-duration guarantee are not included. Future 0.x releases may change interfaces with documented migration.
 >
 > See the repository-authoritative [current status](docs/status.md) for the exact capability and availability boundaries.
 
@@ -53,8 +53,8 @@ Foot is Splinterm's behavioral foundation, not just visual inspiration. The term
 | Sixel, practical Kitty static images, and inline iTerm2 PNG | Documented supported subsets |
 | Arch/Omarchy package | Versioned GitHub release and AUR packages validated |
 | Public source and versioned builds | Available |
-| AUR packages | Prebuilt `splinterm-bin` and source-built `splinterm`, both `0.1.0beta1-1` |
-| Stable support and broader compatibility | Not released |
+| AUR packages | Prebuilt `splinterm-bin` and source-built `splinterm`; see [current release status](docs/status.md) |
+| Support lifetime and broader compatibility | No additional guarantee |
 | Nix and broader distributions | Planned |
 
 For limitations and release gates, read [Current status](docs/status.md). Exact image support is documented in [`docs/images.md`](docs/images.md).
@@ -69,7 +69,7 @@ yay -S splinterm-bin
 yay -S splinterm-mcp-bin
 ```
 
-The source-built alternatives are `splinterm` and `splinterm-mcp`. `paru` may be used instead of `yay`. All packages remain beta software with no stable compatibility or support-duration guarantee.
+The source-built alternatives are `splinterm` and `splinterm-mcp`. `paru` may be used instead of `yay`. Version 0.1 does not support live daemon upgrades; save your work and upgrade from an external terminal. No support-duration or broader-platform guarantee is implied.
 
 For the newest published versioned release package, use Foot or another terminal
 not owned by `splinterd`, then clone the public repository and run:

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,164 +1,67 @@
-# Splinterm 0.1.0 RC3 — Stabilization
+# Splinterm 0.1.0
 
-RC3 retains the RC2 feature set and fixes bounded loading, font observation, and
-connection cleanup. This is a prerelease for continued testing before 0.1.0
-stable.
+Splinterm's first stable release is for x86_64 Omarchy/Arch Linux with native
+Wayland under Hyprland. It carries the RC3 terminal and daemon implementation
+forward unchanged; this release updates version metadata, documentation, and
+publication tooling rather than adding product features.
 
-## RC3 fixes
+## What ships
+
+- Daemon-owned terminal sessions that survive closing a graphical Window,
+  multiplexed Splints and Dojos, saved Lairs, and explicit restore.
+- Scrollback and search, terminal images, native Wayland input, and configurable
+  terminal lifetime and presets.
+- Live Omarchy theme and default-font following. Invalid font generations retain
+  the last valid renderer, while explicit font choices remain authoritative.
+- Bounded JSON/NDJSON automation, remote graphical access, and an optional
+  policy-scoped MCP adapter. Terminal output never grants automation authority.
+- Source-built and prebuilt Arch packages, desktop integration, and a systemd
+  user service.
+
+## Stabilization included from RC3
 
 - Unchanged Fontconfig sources no longer trigger repeated staging when an
-  incompatible bold or italic face falls back to the regular face. Source and
-  renderer fingerprints remain separate, preserving RC2's resolution-race fix.
-- Policy files that are FIFOs are rejected without waiting for a writer.
-- Revoking another automation connection no longer discards a partially received
-  request header or body.
-- Abnormal connection exits remove their topology subscriptions immediately,
-  without waiting for another topology mutation.
-- Relay close and session cancellation interrupt blocked writes and reclaim
-  per-channel queues. Remote EOF still delivers already-received bytes in order
-  to slow consumers; pending drains remain charged against channel admission.
+  incompatible bold or italic face falls back to the regular face.
+- FIFO policy files are rejected without waiting for a writer.
+- Revoking another automation connection preserves partially received requests.
+- Abnormal connection exits immediately remove their topology subscriptions.
+- Relay cancellation interrupts blocked writes and reclaims queues. Remote EOF
+  still delivers buffered bytes in order to slow consumers, within channel bounds.
 
-Upgrades retain the documented 0.1 daemon-lifetime boundary: replacing/restarting
-an incompatible daemon ends its child processes. Use the external-terminal
-upgrade and rollback workflow in [packaging](docs/packaging.md). No live-session
-handoff or new compatibility guarantee is introduced by RC3.
+The release also retains the RC1/RC2 font-lifetime fixes, current Gum colors for
+new Splints, bounded Sixel previews for Yazi, and legacy generated-Dojo name
+normalization.
 
----
+## Install
 
-# Splinterm 0.1.0 RC2 — Font Reload Closure
-
-This is the second release candidate for Splinterm 0.1.0. It retains the complete
-RC1 feature line and closes two live-font correctness and resource findings found
-during RC1 review.
-
-RC2 is intended for normal daily use and soak testing on the documented target:
-x86_64 Omarchy/Arch Linux with native Wayland under Hyprland. Any later code
-change requires another release candidate before the final `v0.1.0` release.
-
-## Release validation authority
-
-Splinterm-owned semantic, renderer, contract, package, and guarded graphical
-tests are now release authority. The pinned Foot 1.27.0 harness remains an exact
-optional historical differential; its host availability or provenance drift no
-longer blocks candidate construction or promotion. Existing Foot-derived
-fixtures and zero-tolerance evidence remain unchanged.
-
-The RC2 implementation at maintenance commit `d26cee9` passed guarded packaged
-live-font replacement and invalid-candidate rollback acceptance. This policy
-change does not modify shipped Rust code.
-
-## Live-font closure fixes
-
-- A staged generation that differs from its preceding probe now becomes the
-  watcher authority, so a later return to the probed generation is not skipped.
-- Cached FreeType faces now retain shared immutable font mappings instead of
-  copying the complete font file for every generation, face, and raster size.
-- Font-generation identity and lifetime tests resolve the host's generic
-  monospace family instead of requiring JetBrains Mono to be installed.
-
-## Live Omarchy font following
-
-When `main.font` is unset, a valid change to Fontconfig's effective `monospace`
-family now replaces one complete immutable renderer generation without
-restarting the Window, daemon, shell, or applications. Explicit font patterns
-remain authoritative, and an invalid live generation retains the last valid
-family.
-
-Font changes preserve configured size and sizing policy, padding, DPI, runtime
-zoom, topology, focus, history, modal and IME state, and controller authority.
-Observer panes never acquire control solely to resize after a font change, and
-deferred font-driven resizes retry after transient command-queue backpressure.
-Fontconfig named instances in variable fonts are preserved through shaping,
-metrics, and rasterization. Ambient Fontconfig checks run at a bounded ten-second
-cadence.
-
-## Yazi uses bounded Sixel previews
-
-When Sixel is enabled, Splinterm now advertises primary device attribute `4`.
-Yazi therefore selects its Sixel image path instead of the incompatible legacy
-per-cell Kitty placement path. The capability remains conditional, and the
-existing image-content and 256-placement bounds are unchanged.
-
-## Legacy Dojo names normalize on restore
-
-Loading schema-v2, schema-v3, or schema-v4 metadata now replaces only the exact
-historical generated forms `terminal`, `terminal-<timestamp>`, and
-`terminal-<timestamp>-<pid>` with collision-free `Dojo N` names. Numeric fields
-may be zero-padded, matching names emitted by older builds. Explicit names in
-current schema metadata are preserved.
-
-## New Splints follow the current Gum palette
-
-`splinterd` is persistent, so environment variables inherited when the daemon
-started can outlive an Omarchy theme change. Before RC1, a newly created shell
-could therefore receive stale Gum colors even though Splinterm's graphical
-palette already reflected the active theme.
-
-For every new Splint, the daemon now reads the active rendered palette from:
-
-```text
-${XDG_STATE_HOME:-$HOME/.local/state}/omarchy/current/theme/gum_env.lua
-```
-
-It refreshes only Omarchy's bounded Gum environment namespace:
-
-- `GUM_*`;
-- `FOREGROUND` and `BACKGROUND`; and
-- `BORDER_FOREGROUND` and `BORDER_BACKGROUND`.
-
-A complete valid palette replaces current managed values and removes obsolete
-managed `GUM_*` entries. Unrelated environment variables remain untouched.
-Existing PTYs keep the environment with which they were created; only later
-Splints see a later valid theme.
-
-Missing, malformed, oversized, symlinked, or non-regular palette state fails
-closed. In those cases the new PTY preserves the daemon's inherited environment
-rather than receiving a partial palette.
-
-## Stabilized Beta 3 baseline
-
-RC1 retains the Beta 3 workload and interface corrections:
-
-- terminal workloads inherit the systemd user manager's task policy while
-  `splinterd.service` keeps its independent `TasksMax=2048` guard;
-- the New Dojo control sits after the final visible tab;
-- inactive tabs use semantic dividers; and
-- the strict historical unnamed initial Dojo form is presented as `Dojo 1`
-  without mutating daemon-owned topology.
-
-Persistent topology, explicit restore, scrollback and search, terminal images,
-remote graphical access, JSON/NDJSON automation, MCP, configurable terminal
-lifetime, presets, and the documented native Wayland path remain part of the
-0.1 baseline.
+Use `yay -S splinterm-bin` for the prebuilt package or `yay -S splinterm` to build
+from source. The optional MCP packages are `splinterm-mcp-bin` and `splinterm-mcp`.
+AUR distribution follows verification of the GitHub release assets. Packages and
+source are also available on this release page.
 
 ## Upgrade boundary
 
-Splinterm 0.1 does not support live daemon upgrade handoff. Upgrading RC1 to
-RC2 therefore ends active Dojos. Run the upgrade from Foot or another terminal
-that is not owned by `splinterd`:
+**Splinterm 0.1 does not support live daemon upgrade handoff.** Stopping or
+replacing the running daemon ends its child processes; saved topology is not a
+checkpoint of running applications. Save your work and upgrade from Foot or
+another terminal that is not owned by `splinterd`:
 
 ```bash
 systemctl --user stop splinterd.service
-# upgrade the splinterm package here
+# Upgrade the splinterm package here.
 systemctl --user daemon-reload
 systemctl --user start splinterd.service
 ```
 
-Then reopen Splinterm Windows. Package installation does not silently reload or
-restart the user service.
+Then reopen Splinterm Windows. Package installation does not silently restart
+the user service. See the [upgrade and rollback documentation](https://splinterm.com/docs/packaging/).
 
-## RC2 soak focus
+## Scope and limitations
 
-During the release-candidate soak, please pay particular attention to:
+Stable 0.1.0 does not add support for other distributions, compositors,
+architectures, or package formats, and does not promise live daemon replacement
+or a support lifetime. Splinterm is security-conscious, not absolutely secure;
+automation remains subject to explicit policy, consent, revocation, and resource
+bounds. Future 0.x releases may change interfaces with documented migration.
 
-- repeated valid, invalid, and rapidly superseded Omarchy font changes;
-- stable file-descriptor and memory use across repeated font and scale changes;
-- repeated Omarchy theme changes followed by newly created Splints;
-- existing PTYs retaining their original environment;
-- clean installation and Beta 3 upgrade/rollback;
-- saved-Lair restore and ordinary long-running terminal workloads;
-- trusted graphical-client identity and desktop launching; and
-- optional MCP package behavior when installed.
-
-RC2 remains a prerelease. If stabilization requires any code change, the next
-public build will be RC3 rather than the final `v0.1.0` release.
+[Documentation](https://splinterm.com/docs/) · [Source and issues](https://github.com/OldJobobo/splinterm)

--- a/docs/release-automation.md
+++ b/docs/release-automation.md
@@ -23,7 +23,7 @@ n8n is not trusted with release authority. Its unavailability may delay a notifi
 1. **Source** — an exact reviewed commit on `main` or `maint/0.1` contains a consistent workspace version, package recipes, documentation, and tests.
 2. **Candidate** — a manually dispatched, read-only workflow builds that commit once and emits a closed manifest, source archive, packages, checksums, release-notes draft, and AUR recipe drafts. Candidate artifacts are private GitHub workflow artifacts and are explicitly marked non-published.
 3. **Approved** — a maintainer starts `.github/workflows/promote-release.yml` with the exact candidate workflow run ID and manifest SHA-256, reviews the verified summary, and approves the protected GitHub `release` environment. Creating or selecting a candidate never implies approval.
-4. **Published** — the protected job creates the versioned tag and GitHub prerelease from the approved candidate artifacts without rebuilding them, downloads every published asset, verifies the tag target and exact asset set, and retains a publication receipt.
+4. **Published** — the protected job creates the versioned tag and GitHub release from the approved candidate artifacts without rebuilding them, downloads every published asset, verifies the tag target and exact asset set, and retains a publication receipt.
 5. **Distributed** — separately gated automation updates AUR recipes to the exact published assets and verifies their visible state.
 6. **Recorded** — release URLs, hashes, workflow run, AUR versions, and resulting status-document changes are retained as release evidence.
 
@@ -67,6 +67,12 @@ read/write permission. The read-only verifier cannot access it. The protected
 publisher needs Workflows permission because the versioned tag may point to a
 candidate that changes files under `.github/workflows/`; GitHub rejects that
 ref creation when only the job's ordinary `GITHUB_TOKEN` is used.
+
+The verified candidate version determines the GitHub prerelease flag: versions
+with a prerelease suffix remain prereleases, while a plain `X.Y.Z` version is a
+stable release. This flag is derived before approval, shown in the approval
+summary, reverified afterward, and checked against the public release before a
+receipt is retained. It is not a dispatch-time override.
 
 The publisher uploads only the source archive, main/MCP packages, candidate
 manifest, and checksums. AUR drafts remain private inputs for the separately

--- a/docs/status.md
+++ b/docs/status.md
@@ -50,6 +50,14 @@ not current compatibility promises. Headless `splinterd` does not require a
 graphical environment, but its packaged and remote workflows remain beta
 interfaces on the documented platform.
 
+## 0.1.0 stable preparation
+
+The maintenance branch prepares `0.1.0` with RC3's terminal and daemon source
+unchanged. Only release metadata, notes, and publication tooling change. The
+public release remains RC3 until the exact stable candidate passes validation,
+independent review, and protected publication. No wider platform support or live
+daemon-upgrade guarantee is introduced.
+
 ## 0.1.0 RC3 release
 
 RC3 is a maintenance stabilization candidate, not a new feature release. It

--- a/packaging/PKGBUILD
+++ b/packaging/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: OldJobobo
 pkgbase=splinterm
 pkgname=('splinterm' 'splinterm-mcp')
-pkgver=0.1.0rc.3
+pkgver=0.1.0
 pkgrel=1
 arch=('x86_64')
 url='https://github.com/oldjobobo/splinterm'

--- a/packaging/aur-bin/.SRCINFO
+++ b/packaging/aur-bin/.SRCINFO
@@ -1,17 +1,17 @@
 pkgbase = splinterm-bin
-	pkgver = 0.1.0rc.3
+	pkgver = 0.1.0
 	pkgrel = 1
 	url = https://github.com/oldjobobo/splinterm
 	arch = x86_64
 	license = MIT
-	noextract = splinterm-0.1.0rc.3-x86_64.pkg.tar.zst
-	noextract = splinterm-mcp-0.1.0rc.3-x86_64.pkg.tar.zst
+	noextract = splinterm-0.1.0-x86_64.pkg.tar.zst
+	noextract = splinterm-mcp-0.1.0-x86_64.pkg.tar.zst
 	options = !strip
 	options = !debug
-	source = splinterm-0.1.0rc.3-x86_64.pkg.tar.zst::https://github.com/OldJobobo/splinterm/releases/download/v0.1.0-rc.3/splinterm-2855721bf467f0d6fac0205d072d019012946158-x86_64.pkg.tar.zst
-	source = splinterm-mcp-0.1.0rc.3-x86_64.pkg.tar.zst::https://github.com/OldJobobo/splinterm/releases/download/v0.1.0-rc.3/splinterm-mcp-2855721bf467f0d6fac0205d072d019012946158-x86_64.pkg.tar.zst
-	sha256sums = 60b5cd2716d3277396d0f7e42a3edfc905206d4cf53c0e0af75702dc82e5f67f
-	sha256sums = 575ea09f20e4af3e9f6e24685b98c3e61ca8898746f45861e7122db0ca87473e
+	source = splinterm-0.1.0-x86_64.pkg.tar.zst::https://github.com/OldJobobo/splinterm/releases/download/v0.1.0/splinterm-0000000000000000000000000000000000000000-x86_64.pkg.tar.zst
+	source = splinterm-mcp-0.1.0-x86_64.pkg.tar.zst::https://github.com/OldJobobo/splinterm/releases/download/v0.1.0/splinterm-mcp-0000000000000000000000000000000000000000-x86_64.pkg.tar.zst
+	sha256sums = 0000000000000000000000000000000000000000000000000000000000000000
+	sha256sums = 0000000000000000000000000000000000000000000000000000000000000000
 
 pkgname = splinterm-bin
 	pkgdesc = Persistent Wayland terminal for humans and bounded automation (prebuilt binary)
@@ -31,13 +31,13 @@ pkgname = splinterm-bin
 	depends = xdg-terminal-exec
 	optdepends = fcitx5: Wayland text-input support
 	optdepends = splinterm-mcp-bin: explicitly configured MCP stdio adapter
-	provides = splinterm=0.1.0rc.3-1
+	provides = splinterm=0.1.0-1
 	conflicts = splinterm
 
 pkgname = splinterm-mcp-bin
 	pkgdesc = Policy-scoped MCP stdio adapter for Splinterm (prebuilt binary)
-	depends = splinterm=0.1.0rc.3-1
+	depends = splinterm=0.1.0-1
 	depends = gcc-libs
 	depends = glibc
-	provides = splinterm-mcp=0.1.0rc.3-1
+	provides = splinterm-mcp=0.1.0-1
 	conflicts = splinterm-mcp

--- a/packaging/aur-bin/PKGBUILD
+++ b/packaging/aur-bin/PKGBUILD
@@ -1,24 +1,24 @@
 # Maintainer: OldJobobo
 pkgbase=splinterm-bin
 pkgname=('splinterm-bin' 'splinterm-mcp-bin')
-pkgver=0.1.0rc.3
+pkgver=0.1.0
 pkgrel=1
-_commit=2855721bf467f0d6fac0205d072d019012946158
+_commit=0000000000000000000000000000000000000000
 arch=('x86_64')
 url='https://github.com/oldjobobo/splinterm'
 license=('MIT')
 options=('!strip' '!debug')
 source=(
-  "splinterm-$pkgver-$CARCH.pkg.tar.zst::https://github.com/OldJobobo/splinterm/releases/download/v0.1.0-rc.3/splinterm-$_commit-$CARCH.pkg.tar.zst"
-  "splinterm-mcp-$pkgver-$CARCH.pkg.tar.zst::https://github.com/OldJobobo/splinterm/releases/download/v0.1.0-rc.3/splinterm-mcp-$_commit-$CARCH.pkg.tar.zst"
+  "splinterm-$pkgver-$CARCH.pkg.tar.zst::https://github.com/OldJobobo/splinterm/releases/download/v0.1.0/splinterm-$_commit-$CARCH.pkg.tar.zst"
+  "splinterm-mcp-$pkgver-$CARCH.pkg.tar.zst::https://github.com/OldJobobo/splinterm/releases/download/v0.1.0/splinterm-mcp-$_commit-$CARCH.pkg.tar.zst"
 )
 noextract=(
   "splinterm-$pkgver-$CARCH.pkg.tar.zst"
   "splinterm-mcp-$pkgver-$CARCH.pkg.tar.zst"
 )
 sha256sums=(
-  '60b5cd2716d3277396d0f7e42a3edfc905206d4cf53c0e0af75702dc82e5f67f'
-  '575ea09f20e4af3e9f6e24685b98c3e61ca8898746f45861e7122db0ca87473e'
+  '0000000000000000000000000000000000000000000000000000000000000000'
+  '0000000000000000000000000000000000000000000000000000000000000000'
 )
 
 _extract_payload() {

--- a/packaging/aur/.SRCINFO
+++ b/packaging/aur/.SRCINFO
@@ -1,5 +1,5 @@
 pkgbase = splinterm
-	pkgver = 0.1.0rc.3
+	pkgver = 0.1.0
 	pkgrel = 1
 	url = https://github.com/oldjobobo/splinterm
 	arch = x86_64
@@ -19,8 +19,8 @@ pkgbase = splinterm
 	makedepends = ttf-jetbrains-mono-nerd
 	makedepends = wayland
 	makedepends = xdg-terminal-exec
-	source = https://github.com/OldJobobo/splinterm/releases/download/v0.1.0-rc.3/splinterm-0.1.0-rc.3.tar.gz
-	sha256sums = c0ccb3e29d4e47a2e905a03767b4b480e24a62ad67d1a74efa12cae4c1597767
+	source = https://github.com/OldJobobo/splinterm/releases/download/v0.1.0/splinterm-0.1.0.tar.gz
+	sha256sums = 0000000000000000000000000000000000000000000000000000000000000000
 
 pkgname = splinterm
 	pkgdesc = Persistent Wayland terminal for humans and bounded automation
@@ -43,6 +43,6 @@ pkgname = splinterm
 
 pkgname = splinterm-mcp
 	pkgdesc = Policy-scoped MCP stdio adapter for Splinterm
-	depends = splinterm=0.1.0rc.3-1
+	depends = splinterm=0.1.0-1
 	depends = gcc-libs
 	depends = glibc

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -1,8 +1,8 @@
 # Maintainer: OldJobobo
 pkgbase=splinterm
 pkgname=('splinterm' 'splinterm-mcp')
-pkgver=0.1.0rc.3
-_upstream_ver=0.1.0-rc.3
+pkgver=0.1.0
+_upstream_ver=0.1.0
 pkgrel=1
 arch=('x86_64')
 url='https://github.com/oldjobobo/splinterm'
@@ -28,7 +28,7 @@ source=(
   "https://github.com/OldJobobo/splinterm/releases/download/v$_upstream_ver/$pkgbase-$_upstream_ver.tar.gz"
 )
 sha256sums=(
-  'c0ccb3e29d4e47a2e905a03767b4b480e24a62ad67d1a74efa12cae4c1597767'
+  '0000000000000000000000000000000000000000000000000000000000000000'
 )
 
 prepare() {

--- a/tools/release/promote-release.py
+++ b/tools/release/promote-release.py
@@ -61,6 +61,12 @@ def current_public_release_tag() -> str:
     return tag
 
 
+def is_prerelease(version: str) -> bool:
+    if not isinstance(version, str) or SEMVER.fullmatch(version) is None:
+        raise ValueError("release version is malformed")
+    return "-" in version
+
+
 def safe_relative(value: Any) -> str:
     if not isinstance(value, str):
         raise ValueError("asset path must be a string")
@@ -245,6 +251,7 @@ def verify_candidate(
         "candidate_manifest_sha256": manifest_sha256,
         "commit": commit,
         "version": version,
+        "prerelease": is_prerelease(version),
         "tag": manifest["tag"],
         "release_notes": "RELEASE-NOTES.md",
         "public_assets": public_assets,
@@ -260,8 +267,11 @@ def create_receipt(
 ) -> dict[str, Any]:
     if release.get("tagName") != promotion["tag"] or release.get("isDraft") is not False:
         raise ValueError("published release identity or state does not match")
-    if release.get("isPrerelease") is not True:
-        raise ValueError("alpha release must remain marked prerelease")
+    expected_prerelease = is_prerelease(promotion["version"])
+    if promotion.get("prerelease") is not expected_prerelease:
+        raise ValueError("promotion prerelease state does not match its version")
+    if release.get("isPrerelease") is not expected_prerelease:
+        raise ValueError("published prerelease state does not match the approved version")
     ref_object = ref.get("object")
     if not isinstance(ref_object, dict) or ref_object.get("sha") != promotion["commit"]:
         raise ValueError("published tag does not resolve to the candidate commit")
@@ -300,6 +310,7 @@ def create_receipt(
         "candidate_manifest_sha256": promotion["candidate_manifest_sha256"],
         "commit": promotion["commit"],
         "version": promotion["version"],
+        "prerelease": expected_prerelease,
         "tag": promotion["tag"],
         "release_url": release.get("url"),
         "workflow_run": workflow_run,

--- a/tools/release/test_prepare_candidate.py
+++ b/tools/release/test_prepare_candidate.py
@@ -193,7 +193,7 @@ class PrepareCandidateTests(unittest.TestCase):
                 output.read_text(encoding="utf-8"),
                 MODULE.run(["git", "show", f"{commit}:RELEASE_NOTES.md"]) + "\n",
             )
-            self.assertIn("Font Reload Closure", output.read_text(encoding="utf-8"))
+            self.assertTrue(output.read_text(encoding="utf-8").startswith("# Splinterm "))
 
     def test_manifest_example_is_json_serializable(self) -> None:
         manifest = {

--- a/tools/release/test_promote_release.py
+++ b/tools/release/test_promote_release.py
@@ -22,10 +22,11 @@ RUN_ID = 12345
 
 class CandidateFixture:
     def __init__(
-        self, root: Path, previous_version_tag: str = "v0.1.0-rc.3"
+        self, root: Path, previous_version_tag: str = "v0.1.0-rc.3",
+        version: str = VERSION,
     ) -> None:
         self.root = root
-        self.assets = MODULE.expected_assets(COMMIT, VERSION)
+        self.assets = MODULE.expected_assets(COMMIT, version)
         records = []
         for relative, kind in self.assets.items():
             path = root / relative
@@ -41,9 +42,9 @@ class CandidateFixture:
             "publishable": False,
             "repository": REPOSITORY,
             "commit": COMMIT,
-            "version": VERSION,
-            "package_version": VERSION.replace("-", ""),
-            "tag": f"v{VERSION}",
+            "version": version,
+            "package_version": version.replace("-", ""),
+            "tag": f"v{version}",
             "architecture": "x86_64",
             "previous_version_tag": previous_version_tag,
             "workflow_run": f"https://github.com/{REPOSITORY}/actions/runs/{RUN_ID}",
@@ -124,6 +125,43 @@ class PromoteReleaseTests(unittest.TestCase):
             self.assertIn("candidate-manifest.json", promotion["public_assets"])
             self.assertIn("SHA256SUMS", promotion["public_assets"])
             self.assertNotIn("aur-source/PKGBUILD", promotion["public_assets"])
+
+    def test_release_classification_rejects_malformed_versions(self) -> None:
+        for version in (None, "", "v0.1.0", "0.1", "0.1.0\n"):
+            with self.subTest(version=version), self.assertRaisesRegex(ValueError, "malformed"):
+                MODULE.is_prerelease(version)
+
+    def test_stable_and_prerelease_candidates_bind_publication_state(self) -> None:
+        for version in ("0.1.0", "0.1.0-alpha1", "0.1.0-beta3", "0.1.0-rc.3"):
+            with self.subTest(version=version), tempfile.TemporaryDirectory() as value:
+                fixture = CandidateFixture(Path(value), version=version)
+                promotion = MODULE.verify_candidate(
+                    fixture.root, REPOSITORY, RUN_ID, COMMIT, fixture.manifest_sha256
+                )
+                expected = "-" in version
+                self.assertIs(promotion["prerelease"], expected)
+                release = {
+                    "tagName": f"v{version}", "isDraft": False,
+                    "isPrerelease": expected,
+                    "assets": [{"name": name} for name in promotion["public_assets"]],
+                }
+                ref = {"object": {"sha": COMMIT}}
+                receipt = MODULE.create_receipt(
+                    promotion, release, ref, fixture.root, "https://example.invalid/run/1"
+                )
+                self.assertIs(receipt["prerelease"], expected)
+                for wrong in (not expected, None, str(expected).lower(), int(expected)):
+                    release["isPrerelease"] = wrong
+                    with self.assertRaisesRegex(ValueError, "published prerelease state"):
+                        MODULE.create_receipt(
+                            promotion, release, ref, fixture.root, "https://example.invalid/run/1"
+                        )
+                release["isPrerelease"] = expected
+                promotion["prerelease"] = not expected
+                with self.assertRaisesRegex(ValueError, "promotion prerelease state"):
+                    MODULE.create_receipt(
+                        promotion, release, ref, fixture.root, "https://example.invalid/run/1"
+                    )
 
     def test_candidate_rejects_a_stale_predecessor_even_when_well_formed(self) -> None:
         with tempfile.TemporaryDirectory(prefix="splinterm-promotion-") as value:

--- a/tools/release/test_promote_release_workflow.py
+++ b/tools/release/test_promote_release_workflow.py
@@ -59,7 +59,7 @@ class PromoteReleaseWorkflowTests(unittest.TestCase):
         workflow = WORKFLOW.read_text(encoding="utf-8")
         environment = workflow.index("name: Require configured protected release environment")
         existing = workflow.index("name: Refuse existing tag or release and fail closed on API errors")
-        create = workflow.index("name: Create versioned tag and prerelease")
+        create = workflow.index("name: Create versioned tag and release")
         self.assertLess(environment, existing)
         self.assertLess(existing, create)
         self.assertIn('rule.get("type") == "required_reviewers"', workflow[environment:existing])
@@ -78,7 +78,7 @@ class PromoteReleaseWorkflowTests(unittest.TestCase):
 
     def test_published_assets_are_downloaded_and_receipted(self) -> None:
         workflow = WORKFLOW.read_text(encoding="utf-8")
-        create = workflow.index("name: Create versioned tag and prerelease")
+        create = workflow.index("name: Create versioned tag and release")
         upload = workflow.index("name: Upload exact approved assets without replacement")
         verify = workflow.index("name: Download and verify published release")
         receipt = workflow.index("name: Retain durable publication receipt")
@@ -88,6 +88,17 @@ class PromoteReleaseWorkflowTests(unittest.TestCase):
         self.assertIn("gh release download", workflow[verify:receipt])
         self.assertIn("promote-release.py receipt", workflow[verify:receipt])
         self.assertIn("retention-days: 90", workflow[receipt:])
+
+    def test_release_state_comes_from_verified_candidate_not_dispatch_input(self) -> None:
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+        self.assertIn("prerelease: ${{ steps.candidate.outputs.prerelease }}", workflow)
+        self.assertIn("str(promotion['prerelease']).lower()", workflow)
+        self.assertIn("RELEASE_PRERELEASE: ${{ needs.verify.outputs.prerelease }}", workflow)
+        self.assertIn('case "$RELEASE_PRERELEASE" in', workflow)
+        self.assertIn("true|false)", workflow)
+        self.assertIn('--prerelease="$RELEASE_PRERELEASE"', workflow)
+        self.assertNotIn("inputs.prerelease", workflow)
+        self.assertNotIn("--prerelease \\", workflow)
 
     def test_promotion_tests_are_part_of_ci(self) -> None:
         ci = (ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

Prepare Splinterm's first stable `0.1.0` release from `maint/0.1`, retaining RC3's product implementation unchanged.

- Bump workspace and Arch recipe versions to `0.1.0`; no third-party dependency changes.
- Replace accumulated prerelease notes with final feature, stabilization, installation, scope, and upgrade notes.
- Derive GitHub's prerelease flag from the verified candidate version, expose it in the approval summary, reverify it after approval, and reject a public-state mismatch in the receipt. No dispatch override, build, credential, or approval-boundary relaxation.
- Keep public-release state at RC3 until publication succeeds. AUR checksum/commit placeholders are resolved by candidate assembly; only exact generated drafts may be distributed.

## Validation

- `cargo fmt --all --check` — passed.
- ShellCheck on the installer/package helpers and `bash -n` on all three PKGBUILDs — passed.
- Eight CI Python unittest suites — 60 tests, one existing skip for an unavailable historical tag.
- Semantic vectors, semantic fixtures, automation/MCP contract fixtures — passed.
- Benchmark and final-buffer-comparison pytest suites — 73 passed.
- `cargo clippy --frozen --workspace --all-targets -- -D warnings` — passed.
- `cargo test --frozen --workspace -- --test-threads=1` — 1,191 passed, zero failures, nine existing ignored tests (excluding a nested filtered subprocess result from the total).
- Generated AUR `.SRCINFO` files exactly match `makepkg --printsrcinfo`; `vercmp 0.1.0 0.1.0rc.3` returns 1.
- `prepare-candidate.py check --version 0.1.0 --previous-version-tag v0.1.0-rc.3` — passed on the clean commit.
- `git diff --check` — passed. `git diff v0.1.0-rc.3 -- crates config dist fixtures` is empty.
- actionlint 1.7.7 — passed with one narrowly excluded pre-existing stale action-input diagnostic: upstream `actions/download-artifact@v4/action.yml` confirms `artifact-ids` is supported.

## Environment and residual risks

Initial local tests exposed setup constraints, not source changes: a repository-local TMPDIR exceeded Linux Unix-socket pathname limits; the workstation font configuration resolves the test's explicit JetBrains family to Maple Mono. The passing full run used `/tmp` and isolated Fontconfig with checksum-verified CI-pinned fonts; no desktop configuration or installed package was changed.

No new graphical sequence was run. RC3's documented guarded package acceptance is inherited only for unchanged product source. Platform scope remains x86_64 Omarchy/Arch on native Wayland/Hyprland. There is no live daemon upgrade handoff; upgrades must be performed from an external terminal after saving work.

Independent read-only release review is in progress and will be recorded before merge. Candidate construction and exact-candidate protected promotion remain separate steps.
