### PR TITLE
feat: add vim copy mode word motions

### DIFF
--- a/crates/splinterm/src/frontend/binding_help.rs
+++ b/crates/splinterm/src/frontend/binding_help.rs
@@ -91,9 +91,9 @@ impl BindingHelpUi {
                 });
             };
         push_copy_row(
-            "copy: h/j/k/l · arrows · Home/End · PgUp/PgDn",
+            "copy: h/j/k/l · arrows · w/b/e · 0/$ · Home/End · PgUp/PgDn",
             "move copy cursor",
-            "copy: h/j/k/l · arrows · Home/End · PgUp/PgDn — move",
+            "copy: h/j/k/l · arrows · w/b/e · 0/$ · Home/End · PgUp/PgDn — move",
             &["copy", "cursor", "move", "navigate", "history"],
         );
         push_copy_row(
@@ -440,6 +440,15 @@ mod tests {
             row.action == ActionId::CopyModeEnter.config_name() && row.shortcut == "Prefix ["
         }));
         assert!(help.rows().iter().any(|row| row.shortcut == "copy: v"));
+        let movement = help
+            .rows()
+            .iter()
+            .find(|row| row.action == "move copy cursor")
+            .unwrap();
+        for alias in ["w/b/e", "0/$"] {
+            assert!(movement.shortcut.contains(alias));
+            assert!(movement.compact.contains(alias));
+        }
     }
 
     #[test]

--- a/crates/splinterm/src/wayland.rs
+++ b/crates/splinterm/src/wayland.rs
@@ -4092,10 +4092,13 @@ impl App {
             Keysym::l | Keysym::L | Keysym::Right if plain => Some(CopyMotion::Right),
             Keysym::k | Keysym::K | Keysym::Up if plain => Some(CopyMotion::Up(1)),
             Keysym::j | Keysym::J | Keysym::Down if plain => Some(CopyMotion::Down(1)),
+            Keysym::w | Keysym::W if plain => Some(CopyMotion::WordForward),
+            Keysym::b | Keysym::B if plain => Some(CopyMotion::WordBackward),
+            Keysym::e | Keysym::E if plain => Some(CopyMotion::WordEnd),
             Keysym::Page_Up => Some(CopyMotion::Up(page)),
             Keysym::Page_Down => Some(CopyMotion::Down(page)),
-            Keysym::Home => Some(CopyMotion::LineStart),
-            Keysym::End => Some(CopyMotion::LineEnd),
+            Keysym::_0 | Keysym::Home if plain => Some(CopyMotion::LineStart),
+            Keysym::dollar | Keysym::End if plain => Some(CopyMotion::LineEnd),
             _ => None,
         };
         let Some(motion) = motion else {
@@ -10603,6 +10606,33 @@ mod tests {
         assert_eq!(state.overlay_selection().anchor.row_id, 4);
         snapshot.history_generation += 1;
         assert!(!copy_mode_is_valid(&snapshot, state));
+    }
+
+    #[test]
+    fn copy_mode_vim_word_motions_cross_whitespace_and_punctuation() {
+        let mut snapshot = snapshot(SplintId::new(), 1, 1);
+        snapshot.columns = 17;
+        snapshot.rows = 1;
+        let mut row = blank_row(snapshot.columns);
+        row.row_id = Some(1);
+        for (column, content) in "alpha beta, gamma".chars().enumerate() {
+            row.cells[column].content = content.to_string();
+        }
+        snapshot.visible_rows = vec![row];
+
+        let mut state = copy_mode_enter(&snapshot, &snapshot).unwrap();
+        assert!(move_copy_cursor(&snapshot, &mut state, CopyMotion::WordEnd).moved);
+        assert_eq!(state.cursor.column, 4);
+
+        state.cursor.column = 0;
+        assert!(move_copy_cursor(&snapshot, &mut state, CopyMotion::WordForward).moved);
+        assert_eq!(state.cursor.column, 6);
+        assert!(move_copy_cursor(&snapshot, &mut state, CopyMotion::WordBackward).moved);
+        assert_eq!(state.cursor.column, 0);
+
+        state.cursor.column = 10;
+        assert!(move_copy_cursor(&snapshot, &mut state, CopyMotion::WordEnd).moved);
+        assert_eq!(state.cursor.column, 16);
     }
 
     fn pane_options(splint_id: SplintId) -> WindowPaneOptions {

--- a/crates/splinterm/src/wayland.rs
+++ b/crates/splinterm/src/wayland.rs
@@ -10635,6 +10635,75 @@ mod tests {
         assert_eq!(state.cursor.column, 16);
     }
 
+    #[test]
+    fn copy_mode_words_respect_row_boundaries_and_loaded_history() {
+        let mut snapshot = snapshot(SplintId::new(), 1, 1);
+        snapshot.columns = 3;
+        snapshot.rows = 1;
+        let mut rows = Vec::new();
+        for (index, text) in ["foo", "bar", "   ", "baz"].into_iter().enumerate() {
+            let mut row = blank_row(3);
+            row.row_id = Some(index as u64 + 1);
+            for (column, character) in text.chars().enumerate() {
+                row.cells[column].content = character.to_string();
+            }
+            rows.push(row);
+        }
+        snapshot.visible_rows = rows.split_off(3);
+        snapshot.scrollback_rows = rows;
+        let mut state = copy_mode_enter(&snapshot, &snapshot).unwrap();
+        for (motion, start, expected) in [
+            (CopyMotion::WordEnd, (1, 0), (1, 2)),
+            (CopyMotion::WordForward, (1, 0), (2, 0)),
+            (CopyMotion::WordBackward, (2, 2), (2, 0)),
+            (CopyMotion::WordBackward, (2, 0), (1, 0)),
+            (CopyMotion::WordEnd, (1, 2), (2, 2)),
+            (CopyMotion::WordForward, (2, 0), (4, 0)),
+            (CopyMotion::WordBackward, (4, 0), (2, 0)),
+            (CopyMotion::WordEnd, (2, 2), (4, 2)),
+            (CopyMotion::WordEnd, (4, 2), (4, 2)),
+            (CopyMotion::WordBackward, (1, 0), (1, 0)),
+        ] {
+            state.cursor.row_id = start.0;
+            state.cursor.column = start.1;
+            move_copy_cursor(&snapshot, &mut state, motion);
+            assert_eq!(
+                (state.cursor.row_id, state.cursor.column),
+                expected,
+                "{motion:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn copy_mode_word_motions_skip_wide_character_spacers() {
+        let mut snapshot = snapshot(SplintId::new(), 1, 1);
+        snapshot.columns = 8;
+        snapshot.rows = 1;
+        let mut row = blank_row(8);
+        row.row_id = Some(1);
+        for (column, content) in [(0, "中"), (2, "文"), (4, " "), (5, "f"), (6, "o"), (7, "o")] {
+            row.cells[column].content = content.into();
+        }
+        for column in [1, 3] {
+            row.cells[column].content.clear();
+            row.cells[column].spacer_remaining = Some(1);
+        }
+        snapshot.visible_rows = vec![row];
+        let mut state = copy_mode_enter(&snapshot, &snapshot).unwrap();
+        for (motion, start, expected) in [
+            (CopyMotion::WordEnd, 0, 2),
+            (CopyMotion::WordEnd, 2, 7),
+            (CopyMotion::WordForward, 0, 5),
+            (CopyMotion::WordBackward, 5, 0),
+            (CopyMotion::WordBackward, 2, 0),
+        ] {
+            state.cursor.column = start;
+            move_copy_cursor(&snapshot, &mut state, motion);
+            assert_eq!(state.cursor.column, expected, "{motion:?}");
+        }
+    }
+
     fn pane_options(splint_id: SplintId) -> WindowPaneOptions {
         let (_updates, update_receiver) = tokio::sync::mpsc::channel(1);
         let (commands, _command_receiver) = tokio::sync::mpsc::channel(1);

--- a/crates/splinterm/src/wayland/selection.rs
+++ b/crates/splinterm/src/wayland/selection.rs
@@ -39,6 +39,9 @@ pub(super) enum CopyMotion {
     Down(usize),
     LineStart,
     LineEnd,
+    WordForward,
+    WordBackward,
+    WordEnd,
 }
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -133,6 +136,18 @@ pub(super) fn move_copy_cursor(
         ),
         CopyMotion::LineStart => (row, 0, false),
         CopyMotion::LineEnd => (row, snapshot.columns - 1, false),
+        CopyMotion::WordForward => {
+            let (row, column) = word_forward(snapshot, (row, state.cursor.column));
+            (row, column, false)
+        }
+        CopyMotion::WordBackward => {
+            let (row, column) = word_backward(snapshot, (row, state.cursor.column));
+            (row, column, false)
+        }
+        CopyMotion::WordEnd => {
+            let (row, column) = word_end(snapshot, (row, state.cursor.column));
+            (row, column, false)
+        }
     };
     let row_id = snapshot
         .scrollback_rows
@@ -157,6 +172,141 @@ pub(super) fn move_copy_cursor(
         moved,
         request_older,
     }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum WordClass {
+    Whitespace,
+    Keyword,
+    Punctuation,
+}
+
+fn word_class(snapshot: &TerminalSnapshot, (row, column): (usize, usize)) -> WordClass {
+    let cell = snapshot
+        .scrollback_rows
+        .iter()
+        .chain(&snapshot.visible_rows)
+        .nth(row)
+        .and_then(|row| row.cells.get(column));
+    let Some(cell) = cell else {
+        return WordClass::Whitespace;
+    };
+    if cell.spacer_remaining.is_some()
+        || cell.content.is_empty()
+        || cell.content.chars().all(char::is_whitespace)
+    {
+        return WordClass::Whitespace;
+    }
+    if cell
+        .content
+        .chars()
+        .all(|character| character.is_alphanumeric() || character == '_')
+    {
+        WordClass::Keyword
+    } else {
+        WordClass::Punctuation
+    }
+}
+
+fn next_cell(
+    row_count: usize,
+    columns: usize,
+    (row, column): (usize, usize),
+) -> Option<(usize, usize)> {
+    (column + 1 < columns)
+        .then_some((row, column + 1))
+        .or_else(|| (row + 1 < row_count).then_some((row + 1, 0)))
+}
+
+fn previous_cell(columns: usize, (row, column): (usize, usize)) -> Option<(usize, usize)> {
+    column
+        .checked_sub(1)
+        .map(|column| (row, column))
+        .or_else(|| row.checked_sub(1).map(|row| (row, columns - 1)))
+}
+
+fn word_forward(snapshot: &TerminalSnapshot, position: (usize, usize)) -> (usize, usize) {
+    let row_count = snapshot
+        .scrollback_rows
+        .len()
+        .saturating_add(snapshot.visible_rows.len());
+    let mut cursor = position;
+    let class = word_class(snapshot, cursor);
+    while class != WordClass::Whitespace {
+        let Some(next) = next_cell(row_count, snapshot.columns, cursor) else {
+            return cursor;
+        };
+        if word_class(snapshot, next) != class {
+            cursor = next;
+            break;
+        }
+        cursor = next;
+    }
+    while word_class(snapshot, cursor) == WordClass::Whitespace {
+        let Some(next) = next_cell(row_count, snapshot.columns, cursor) else {
+            return cursor;
+        };
+        cursor = next;
+    }
+    cursor
+}
+
+fn word_backward(snapshot: &TerminalSnapshot, position: (usize, usize)) -> (usize, usize) {
+    let mut cursor = position;
+    loop {
+        let Some(previous) = previous_cell(snapshot.columns, cursor) else {
+            return cursor;
+        };
+        cursor = previous;
+        if word_class(snapshot, cursor) != WordClass::Whitespace {
+            break;
+        }
+    }
+    let class = word_class(snapshot, cursor);
+    while let Some(previous) = previous_cell(snapshot.columns, cursor) {
+        if word_class(snapshot, previous) != class {
+            break;
+        }
+        cursor = previous;
+    }
+    cursor
+}
+
+fn word_end(snapshot: &TerminalSnapshot, position: (usize, usize)) -> (usize, usize) {
+    let row_count = snapshot
+        .scrollback_rows
+        .len()
+        .saturating_add(snapshot.visible_rows.len());
+    let mut cursor = position;
+    let class = word_class(snapshot, cursor);
+    if class != WordClass::Whitespace {
+        while let Some(next) = next_cell(row_count, snapshot.columns, cursor) {
+            if word_class(snapshot, next) != class {
+                break;
+            }
+            cursor = next;
+        }
+        if cursor != position {
+            return cursor;
+        }
+    }
+    loop {
+        let Some(next) = next_cell(row_count, snapshot.columns, cursor) else {
+            return cursor;
+        };
+        cursor = next;
+        if word_class(snapshot, cursor) != WordClass::Whitespace {
+            break;
+        }
+    }
+    let class = word_class(snapshot, cursor);
+    while let Some(next) = next_cell(row_count, snapshot.columns, cursor) {
+        if word_class(snapshot, next) != class {
+            break;
+        }
+        cursor = next;
+    }
+    cursor
 }
 
 pub(super) fn selection_endpoint(

--- a/crates/splinterm/src/wayland/selection.rs
+++ b/crates/splinterm/src/wayland/selection.rs
@@ -208,42 +208,67 @@ fn word_class(snapshot: &TerminalSnapshot, (row, column): (usize, usize)) -> Wor
     }
 }
 
-fn next_cell(
-    row_count: usize,
-    columns: usize,
-    (row, column): (usize, usize),
-) -> Option<(usize, usize)> {
-    (column + 1 < columns)
-        .then_some((row, column + 1))
-        .or_else(|| (row + 1 < row_count).then_some((row + 1, 0)))
+fn is_spacer(snapshot: &TerminalSnapshot, (row, column): (usize, usize)) -> bool {
+    snapshot
+        .scrollback_rows
+        .iter()
+        .chain(&snapshot.visible_rows)
+        .nth(row)
+        .and_then(|row| row.cells.get(column))
+        .is_some_and(|cell| cell.spacer_remaining.is_some())
 }
 
-fn previous_cell(columns: usize, (row, column): (usize, usize)) -> Option<(usize, usize)> {
-    column
-        .checked_sub(1)
-        .map(|column| (row, column))
-        .or_else(|| row.checked_sub(1).map(|row| (row, columns - 1)))
+fn next_cell(snapshot: &TerminalSnapshot, mut position: (usize, usize)) -> Option<(usize, usize)> {
+    let row_count = snapshot.scrollback_rows.len() + snapshot.visible_rows.len();
+    loop {
+        let (row, column) = position;
+        position = if column + 1 < snapshot.columns {
+            (row, column + 1)
+        } else if row + 1 < row_count {
+            (row + 1, 0)
+        } else {
+            return None;
+        };
+        if !is_spacer(snapshot, position) {
+            return Some(position);
+        }
+    }
+}
+
+fn previous_cell(
+    snapshot: &TerminalSnapshot,
+    mut position: (usize, usize),
+) -> Option<(usize, usize)> {
+    loop {
+        let (row, column) = position;
+        position = if let Some(column) = column.checked_sub(1) {
+            (row, column)
+        } else {
+            (row.checked_sub(1)?, snapshot.columns - 1)
+        };
+        if !is_spacer(snapshot, position) {
+            return Some(position);
+        }
+    }
 }
 
 fn word_forward(snapshot: &TerminalSnapshot, position: (usize, usize)) -> (usize, usize) {
-    let row_count = snapshot
-        .scrollback_rows
-        .len()
-        .saturating_add(snapshot.visible_rows.len());
     let mut cursor = position;
     let class = word_class(snapshot, cursor);
-    while class != WordClass::Whitespace {
-        let Some(next) = next_cell(row_count, snapshot.columns, cursor) else {
-            return cursor;
-        };
-        if word_class(snapshot, next) != class {
+    if class != WordClass::Whitespace {
+        loop {
+            let Some(next) = next_cell(snapshot, cursor) else {
+                return cursor;
+            };
+            if next.0 != cursor.0 || word_class(snapshot, next) != class {
+                cursor = next;
+                break;
+            }
             cursor = next;
-            break;
         }
-        cursor = next;
     }
     while word_class(snapshot, cursor) == WordClass::Whitespace {
-        let Some(next) = next_cell(row_count, snapshot.columns, cursor) else {
+        let Some(next) = next_cell(snapshot, cursor) else {
             return cursor;
         };
         cursor = next;
@@ -254,7 +279,7 @@ fn word_forward(snapshot: &TerminalSnapshot, position: (usize, usize)) -> (usize
 fn word_backward(snapshot: &TerminalSnapshot, position: (usize, usize)) -> (usize, usize) {
     let mut cursor = position;
     loop {
-        let Some(previous) = previous_cell(snapshot.columns, cursor) else {
+        let Some(previous) = previous_cell(snapshot, cursor) else {
             return cursor;
         };
         cursor = previous;
@@ -263,8 +288,8 @@ fn word_backward(snapshot: &TerminalSnapshot, position: (usize, usize)) -> (usiz
         }
     }
     let class = word_class(snapshot, cursor);
-    while let Some(previous) = previous_cell(snapshot.columns, cursor) {
-        if word_class(snapshot, previous) != class {
+    while let Some(previous) = previous_cell(snapshot, cursor) {
+        if previous.0 != cursor.0 || word_class(snapshot, previous) != class {
             break;
         }
         cursor = previous;
@@ -273,15 +298,11 @@ fn word_backward(snapshot: &TerminalSnapshot, position: (usize, usize)) -> (usiz
 }
 
 fn word_end(snapshot: &TerminalSnapshot, position: (usize, usize)) -> (usize, usize) {
-    let row_count = snapshot
-        .scrollback_rows
-        .len()
-        .saturating_add(snapshot.visible_rows.len());
     let mut cursor = position;
     let class = word_class(snapshot, cursor);
     if class != WordClass::Whitespace {
-        while let Some(next) = next_cell(row_count, snapshot.columns, cursor) {
-            if word_class(snapshot, next) != class {
+        while let Some(next) = next_cell(snapshot, cursor) {
+            if next.0 != cursor.0 || word_class(snapshot, next) != class {
                 break;
             }
             cursor = next;
@@ -291,7 +312,7 @@ fn word_end(snapshot: &TerminalSnapshot, position: (usize, usize)) -> (usize, us
         }
     }
     loop {
-        let Some(next) = next_cell(row_count, snapshot.columns, cursor) else {
+        let Some(next) = next_cell(snapshot, cursor) else {
             return cursor;
         };
         cursor = next;
@@ -300,8 +321,8 @@ fn word_end(snapshot: &TerminalSnapshot, position: (usize, usize)) -> (usize, us
         }
     }
     let class = word_class(snapshot, cursor);
-    while let Some(next) = next_cell(row_count, snapshot.columns, cursor) {
-        if word_class(snapshot, next) != class {
+    while let Some(next) = next_cell(snapshot, cursor) {
+        if next.0 != cursor.0 || word_class(snapshot, next) != class {
             break;
         }
         cursor = next;

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -145,8 +145,9 @@ profile defines no actions on those four shifted prefix keys. New Dojos and
 Lairs inherit the focused Splint cwd.
 
 `Prefix+[` enters copy mode at the live cursor or current history viewport.
-`h/j/k/l` and arrows move over visible and loaded historical rows; Home/End move
-to line edges and PageUp/PageDown page within bounded loaded history while
+`h/j/k/l` and arrows move over visible and loaded historical rows; `w`, `b`, and
+`e` move by Vim-style words; `0`/`$` (or Home/End) move to line edges; and
+PageUp/PageDown page within bounded loaded history while
 requesting older bounded pages when needed. `v` anchors a selection, `y` copies
 it to the Wayland clipboard with the triggering keyboard serial and exits, and
 Escape cancels. Copy mode isolates terminal input, paste, pointer actions, IME,

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -139,8 +139,9 @@ With the `omarchy-tmux` profile, `Prefix+B` toggles the Dojo tab strip,
 labels, configuration names, shortcuts, sources, and closed keywords; use
 Up/Down or PageUp/PageDown to navigate, `Ctrl+U` to clear, and Escape once to
 clear a query or again to close.
-Move with `h/j/k/l`, arrows, Home/End, or PageUp/PageDown; press `v` to begin a
-selection, `y` or `Super+C` to publish it to the Wayland clipboard and exit, or
+Move with `h/j/k/l`, arrows, `w`/`b`/`e` word motions, `0`/`$` (or Home/End),
+or PageUp/PageDown; press `v` to begin a selection, `y` or `Super+C` to publish
+it to the Wayland clipboard and exit, or
 Escape to cancel. Copy-mode `Super+V/X/Z` are consumed locally; copy mode never
 forwards these keys, pointer input, paste, or IME text to the terminal
 application. Outside copy mode, both built-in profiles provide terminal


### PR DESCRIPTION
## Summary
- add Vim-style w, b, and e word motions to copy mode
- add 0 and dollar-sign line-boundary motions
- document the new copy-mode controls

## Validation
- cargo fmt --check
- focused word-motion test
- copy-mode test set
- cargo build -p splinterm
- git diff --check