### PR TITLE
Bootstrap frozen daemon and MCP stress tests

### DIFF
--- a/.github/workflows/flake-stress.yml
+++ b/.github/workflows/flake-stress.yml
@@ -25,6 +25,10 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Install native dependencies
         run: sudo apt-get update && sudo apt-get install -y libfontconfig1-dev libfreetype6-dev libpixman-1-dev libxkbcommon-dev pkg-config
+      - name: Fetch the locked dependency graph
+        run: cargo fetch --locked
+      - name: Build the PTY child helper required by daemon integration tests
+        run: cargo build --frozen -p splinterm-pty --bin splinterm-pty-child
       - name: Run bounded repetitions and stop on first failure
         env:
           REQUESTED_ITERATIONS: ${{ inputs.iterations || '10' }}

--- a/tools/release/test_ci_workflow.py
+++ b/tools/release/test_ci_workflow.py
@@ -148,6 +148,24 @@ class CiWorkflowTests(unittest.TestCase):
         self.assertNotIn("\n  push:", standalone)
         self.assertNotIn("\n  pull_request:", standalone)
 
+    def test_flake_stress_bootstraps_before_frozen_repetitions(self) -> None:
+        workflow = (ROOT / ".github/workflows/flake-stress.yml").read_text(
+            encoding="utf-8"
+        )
+        fetch = "run: cargo fetch --locked"
+        helper = "run: cargo build --frozen -p splinterm-pty --bin splinterm-pty-child"
+        self.assertEqual(workflow.count(fetch), 1)
+        self.assertEqual(workflow.count(helper), 1)
+        self.assertLess(workflow.index(fetch), workflow.index("--frozen"))
+        loop = workflow.index("for ((iteration = 1;")
+        self.assertLess(workflow.index(helper), loop)
+        for target in (
+            "cargo test --frozen -p splinterd --test end_to_end -- --test-threads=1",
+            "cargo test --frozen -p splinterm-mcp --test stdio_protocol -- --test-threads=1",
+        ):
+            self.assertEqual(workflow.count(target), 1)
+            self.assertGreater(workflow.index(target), loop)
+
     def test_flake_stress_is_manual_scheduled_bounded_and_stops_on_failure(self) -> None:
         workflow = (ROOT / ".github/workflows/flake-stress.yml").read_text(
             encoding="utf-8"


### PR DESCRIPTION
## Summary

- Fetch the locked Cargo dependency graph before frozen commands so cold-cache scheduled runs do not fail before testing.
- Build the required PTY child helper before the serialized daemon/MCP repetition loop.
- Add a workflow-contract regression for bootstrap ordering and both frozen serialized targets; retain stop-on-first-failure behavior.

## Validation

- `python -m unittest discover -s tools/release -p 'test_*.py'`: 72 passed.
- Rust 1.88.0 `cargo fetch --locked` and `cargo build --frozen -p splinterm-pty --bin splinterm-pty-child`: passed.
- `cargo test --frozen -p splinterd --test end_to_end -- --test-threads=1`: 21 passed.
- `cargo test --frozen -p splinterm-mcp --test stdio_protocol -- --test-threads=1`: 30 passed.
- Actual diff inspected; `git diff --check` passed.
- Fresh independent read-only review: approved, no findings.

## Residual risks

Local integration tests used private short temporary paths because repository-local Unix socket paths exceeded Linux's length limit. No production source changed. Local validation ran one full serialized pass, not the ten-pass scheduled stress sequence. Hosted CI must pass before merge; standalone actionlint was not run locally.
