### PR TITLE
Add NixOS packaging and validation to 0.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,26 @@ permissions:
   contents: read
 
 jobs:
+  nix:
+    name: NixOS packages and headless lifecycle
+    runs-on: ubuntu-24.04
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: cachix/install-nix-action@1ca7d21a94afc7c957383a2d217460d980de4934 # v31.10.1
+        with:
+          enable_kvm: true
+          extra_nix_config: |
+            system-features = nixos-test benchmark big-parallel kvm
+      - name: Require hardware virtualization for headless VM tests
+        run: test -r /dev/kvm && test -w /dev/kvm
+      - name: Check packages, module, and headless VMs
+        run: nix flake check --print-build-logs --max-jobs 2 --cores 4
+
   check:
+    needs: nix
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -51,6 +70,7 @@ jobs:
             tools/package/test_installer_safety.py \
             tools/package/test_validate_mcp_package.py \
             tools/release/test_prepare_candidate.py \
+            tools/release/test_nix_ci_workflow.py \
             tools/release/test_promote_release.py \
             tools/release/test_release_candidate_workflow.py \
             tools/release/test_promote_release_workflow.py

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,8 @@
 target/
+/result
+/result-*
+/.nix-store/
+/.validation/
 /.idea/
 /.vscode/
 *.swp

--- a/README.md
+++ b/README.md
@@ -55,11 +55,16 @@ Foot is Splinterm's behavioral foundation, not just visual inspiration. The term
 | Public source and versioned builds | Available |
 | AUR packages | Prebuilt `splinterm-bin` and source-built `splinterm`; see [current release status](docs/status.md) |
 | Support lifetime and broader compatibility | No additional guarantee |
-| Nix and broader distributions | Planned |
+| NixOS | Source flake and desktop/headless module; deployment acceptance remains separate |
 
 For limitations and release gates, read [Current status](docs/status.md). Exact image support is documented in [`docs/images.md`](docs/images.md).
 
 ## Install
+
+**NixOS:** the repository includes a source-built flake with the full Wayland GUI,
+desktop launcher, headless daemon, and optional MCP variant. See
+[the NixOS installation guide](docs/nixos.md) for declarative desktop and server
+setup. This does not extend the Arch graphical validation claim to NixOS.
 
 The validated installation target is **x86_64 Omarchy/Arch Linux with native Wayland**. The recommended AUR packages download verified prebuilt binaries and do not compile locally:
 

--- a/crates/splinterm/src/remote.rs
+++ b/crates/splinterm/src/remote.rs
@@ -26,7 +26,11 @@ const MAX_IDENTITY_FILES: usize = 8;
 const MIN_CONNECT_TIMEOUT_SECONDS: u16 = 1;
 const MAX_CONNECT_TIMEOUT_SECONDS: u16 = 300;
 const DEFAULT_CONNECT_TIMEOUT_SECONDS: u16 = 15;
-const GRAPHICAL_REMOTE_COMMAND: &str = "/usr/bin/splinterm relay --graphical-stdio";
+const DEFAULT_REMOTE_EXECUTABLE: &str = "/usr/bin/splinterm";
+
+fn default_remote_executable() -> String {
+    DEFAULT_REMOTE_EXECUTABLE.to_owned()
+}
 
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -42,6 +46,8 @@ struct RawRemoteProfile {
     host: String,
     user: Option<String>,
     port: Option<u16>,
+    #[serde(default = "default_remote_executable")]
+    executable: String,
     #[serde(default)]
     identity_files: Vec<String>,
     known_hosts_file: Option<String>,
@@ -61,6 +67,7 @@ pub struct RemoteProfile {
     user: Option<String>,
     port: Option<u16>,
     identity_files: Vec<PathBuf>,
+    executable: String,
     known_hosts_file: Option<PathBuf>,
     connect_timeout_seconds: u16,
 }
@@ -152,7 +159,12 @@ impl RemoteProfile {
             )));
         }
         arguments.push(OsString::from(&self.host));
-        arguments.push(OsString::from(GRAPHICAL_REMOTE_COMMAND));
+        // OpenSSH sends this string to the remote login shell. The executable
+        // is a strictly validated absolute path, never a command or shell text.
+        arguments.push(OsString::from(format!(
+            "{} relay --graphical-stdio",
+            self.executable
+        )));
         SshLaunchPlan {
             program: OsString::from("ssh"),
             arguments,
@@ -263,6 +275,8 @@ impl RemoteCatalog {
         for (name, raw) in document.remotes {
             validate_profile_name(&name)?;
             validate_host(&raw.host).with_context(|| format!("remote profile {name}"))?;
+            validate_remote_executable(&raw.executable)
+                .with_context(|| format!("remote profile {name}"))?;
             if let Some(user) = &raw.user {
                 validate_user(user).with_context(|| format!("remote profile {name}"))?;
             }
@@ -300,6 +314,7 @@ impl RemoteCatalog {
                 RemoteProfile {
                     name,
                     host: raw.host,
+                    executable: raw.executable,
                     user: raw.user,
                     port: raw.port,
                     identity_files,
@@ -391,6 +406,26 @@ fn validate_user(user: &str) -> Result<()> {
     Ok(())
 }
 
+fn validate_remote_executable(value: &str) -> Result<()> {
+    // This is a remote path: do not resolve it on the client or expand HOME.
+    // A conservative ASCII allowlist makes it one literal POSIX-shell word.
+    if !value.starts_with('/')
+        || value.len() > MAX_PATH_BYTES
+        || value
+            .split('/')
+            .skip(1)
+            .any(|part| part.is_empty() || part == "." || part == "..")
+        || !value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'/' | b'.' | b'_' | b'-'))
+    {
+        bail!(
+            "remote executable must be an absolute path with only ASCII letters, digits, /, ., _, or - and no empty or dot components"
+        );
+    }
+    Ok(())
+}
+
 fn resolve_readable_file(value: &str, home: Option<&Path>) -> Result<PathBuf> {
     if value.is_empty()
         || value.len() > MAX_PATH_BYTES
@@ -473,7 +508,10 @@ connect_timeout_seconds = 23
             .iter()
             .map(|argument| argument.to_string_lossy().into_owned())
             .collect::<Vec<_>>();
-        assert_eq!(args.last().unwrap(), GRAPHICAL_REMOTE_COMMAND);
+        assert_eq!(
+            args.last().unwrap(),
+            "/usr/bin/splinterm relay --graphical-stdio"
+        );
         assert_eq!(args[args.len() - 2], "wintermute");
         assert!(args.windows(2).any(|pair| pair == ["-l", "operator"]));
         assert!(args.windows(2).any(|pair| pair == ["-p", "2222"]));
@@ -492,6 +530,66 @@ connect_timeout_seconds = 23
         assert!(args.iter().any(|argument| argument == "RemoteCommand=none"));
         assert!(!args.iter().any(|argument| argument.contains("fixture key")));
         fs::remove_dir_all(home).unwrap();
+    }
+
+    #[test]
+    fn nixos_remote_executable_is_literal_and_need_not_exist_locally() {
+        for executable in [
+            "/run/current-system/sw/bin/splinterm",
+            "/nix/store/0123456789abcdef-splinterm/bin/splinterm",
+            "/home/operator/.nix-profile/bin/splinterm",
+        ] {
+            let catalog = RemoteCatalog::parse(
+                &format!(
+                    "version = 1\n[remotes.nixos]\nhost = \"nixos\"\nexecutable = {executable:?}\n"
+                ),
+                None,
+            )
+            .unwrap();
+            let plan = catalog.get("nixos").unwrap().ssh_plan();
+            assert_eq!(
+                plan.arguments().last().unwrap(),
+                &OsString::from(format!("{executable} relay --graphical-stdio"))
+            );
+        }
+    }
+
+    #[test]
+    fn remote_executable_rejects_shell_syntax_and_ambiguous_paths() {
+        for executable in [
+            "",
+            "splinterm",
+            "~/bin/splinterm",
+            "/",
+            "/bin/",
+            "//bin/splinterm",
+            "/bin/../splinterm",
+            "/bin/./splinterm",
+            "/bin/splinterm --flag",
+            "/bin/splinterm;id",
+            "/bin/$(id)",
+            "/bin/`id`",
+            "/bin/$HOME",
+            "/bin/'splinterm'",
+            "/bin/\"splinterm\"",
+            "/bin/splinterm\n",
+            "/bin/*",
+            "/bin/splinterm\\x",
+            "/bin/splinterm\u{202e}",
+        ] {
+            assert!(
+                validate_remote_executable(executable).is_err(),
+                "{executable:?}"
+            );
+        }
+        assert!(validate_remote_executable(&format!("/{}", "a".repeat(MAX_PATH_BYTES))).is_err());
+        assert!(
+            RemoteCatalog::parse(
+                "version = 1\n[remotes.bad]\nhost = \"safe\"\nexecutable = \"/bin/splinterm;id\"\n",
+                None,
+            )
+            .is_err()
+        );
     }
 
     #[test]

--- a/crates/splinterm/src/wayland.rs
+++ b/crates/splinterm/src/wayland.rs
@@ -2487,10 +2487,10 @@ fn window_title(
     control_transfer_pending: bool,
     search: Option<&SearchUiState>,
 ) -> String {
-    let base = snapshot_title
-        .map(str::trim)
-        .filter(|title| !title.is_empty())
-        .unwrap_or("Splinterm");
+    let base = match snapshot_title.map(str::trim) {
+        None | Some("" | "Splinterm") => "Splinterm".to_owned(),
+        Some(title) => format!("Splinterm — {title}"),
+    };
     let controller = controller_active.then_some("local controller");
     let authority_label = if authority.development_bypass {
         Some("DEVELOPMENT BYPASS")
@@ -2503,7 +2503,7 @@ fn window_title(
         (Some(controller), Some(authority)) => format!("{base} — {controller} — {authority}"),
         (Some(controller), None) => format!("{base} — {controller}"),
         (None, Some(authority)) => format!("{base} — {authority}"),
-        (None, None) => base.to_owned(),
+        (None, None) => base,
     };
     let title = if control_transfer_pending {
         format!("{title} — CONTROL REQUEST: Ctrl+Shift+Y accept / Ctrl+Shift+N deny")
@@ -12451,6 +12451,69 @@ mod tests {
     }
 
     #[test]
+    fn window_title_preserves_app_identity_and_shell_title() {
+        let authority = AuthorityStatus::default();
+        for title in [
+            None,
+            Some(""),
+            Some(" \t\n"),
+            Some("Splinterm"),
+            Some(" Splinterm "),
+        ] {
+            assert_eq!(
+                window_title(title, false, &authority, false, None),
+                "Splinterm"
+            );
+        }
+        for (title, expected) in [
+            (
+                "tester@nixos-plasma: ~",
+                "Splinterm — tester@nixos-plasma: ~",
+            ),
+            ("  project — editor  ", "Splinterm — project — editor"),
+            ("作業", "Splinterm — 作業"),
+        ] {
+            assert_eq!(
+                window_title(Some(title), false, &authority, false, None),
+                expected
+            );
+        }
+    }
+
+    #[test]
+    fn window_title_preserves_app_identity_with_authority_status() {
+        for (authority, label) in [
+            (AuthorityStatus::default(), ""),
+            (
+                AuthorityStatus {
+                    grants: vec![(1, "agent".into())],
+                    development_bypass: false,
+                },
+                " — EXTERNAL ACCESS ACTIVE",
+            ),
+            (
+                AuthorityStatus {
+                    grants: vec![(1, "agent".into())],
+                    development_bypass: true,
+                },
+                " — DEVELOPMENT BYPASS",
+            ),
+        ] {
+            for controller_active in [false, true] {
+                let controller = if controller_active {
+                    " — local controller"
+                } else {
+                    ""
+                };
+                assert_eq!(
+                    window_title(Some("shell"), controller_active, &authority, false, None),
+                    format!("Splinterm — shell{controller}{label}")
+                );
+            }
+        }
+    }
+
+    #[test]
     fn trusted_title_surfaces_control_decision_and_bounded_search_state() {
         let authority = AuthorityStatus::default();
         let mut search = SearchUiState {
@@ -12469,7 +12532,7 @@ mod tests {
             preview: "needle".into(),
         });
         let title = window_title(Some("shell"), true, &authority, true, Some(&search));
-        assert!(title.contains("local controller"));
+        assert!(title.starts_with("Splinterm — shell — local controller"));
         assert!(title.contains("CONTROL REQUEST"));
         assert!(title.contains("SEARCH: needlespoof [1 match(es)"));
         assert!(!title.contains('\n'));

--- a/crates/splinterm/tests/remote_cli.rs
+++ b/crates/splinterm/tests/remote_cli.rs
@@ -83,12 +83,12 @@ known_hosts_file = "~/.ssh/known_hosts"
 }
 
 #[test]
-fn remote_check_uses_one_fixed_fake_ssh_and_only_read_only_probes() {
+fn remote_check_uses_configured_nixos_executable_and_only_read_only_probes() {
     let home = test_directory("check");
     let profiles = home.join("remotes.toml");
     fs::write(
         &profiles,
-        "version = 1\n[remotes.test]\nhost = \"example.invalid\"\n",
+        "version = 1\n[remotes.test]\nhost = \"example.invalid\"\nexecutable = \"/run/current-system/sw/bin/splinterm\"\n",
     )
     .unwrap();
     install_fake_ssh(&home);
@@ -110,7 +110,7 @@ fn remote_check_uses_one_fixed_fake_ssh_and_only_read_only_probes() {
         serde_json::from_slice(&fs::read(home.join("argv.json")).unwrap()).unwrap();
     assert_eq!(
         arguments.last().unwrap(),
-        "/usr/bin/splinterm relay --graphical-stdio"
+        "/run/current-system/sw/bin/splinterm relay --graphical-stdio"
     );
     fs::remove_dir_all(home).unwrap();
 }

--- a/docs/nixos.md
+++ b/docs/nixos.md
@@ -20,8 +20,9 @@ Add Splinterm to your configuration flake and commit the resulting `flake.lock`:
 inputs.splinterm.url = "github:OldJobobo/splinterm/<reviewed-revision>";
 ```
 
-Replace `<reviewed-revision>` with the commit containing Nix support. Until that
-branch is merged/published, use a local checkout containing the implementation.
+Replace `<reviewed-revision>` with a reviewed 0.1 maintenance commit containing
+Nix support. The original `v0.1.0` tag predates this integration. Until the
+packaging branch is merged/published, use a local checkout containing it.
 The public release installer and Arch packages are **not** NixOS installers.
 The package's own pinned nixpkgs supplies its Rust/native toolchain; following a
 host's older nixpkgs input may not provide a sufficiently recent Rust compiler.
@@ -182,7 +183,12 @@ not implied by a successful build.
 nix build .#checks.x86_64-linux.headless --print-build-logs
 ```
 
-This check is also included in `nix flake check`. It boots two disposable,
+This check is also included in `nix flake check`. CI runs it together with the
+package and module checks; the required `check` job depends on the Nix job, so a
+Nix failure cannot produce a successful release-authority CI result. Graphical
+tests remain opt-in and are not launched by CI.
+
+It boots two disposable,
 non-graphical NixOS VMs (1.5 GiB RAM and two vCPUs each) on an isolated test
 network. The Nix builder needs working KVM access and the `kvm`/`nixos-test`
 system features. First use downloads the pinned NixOS VM/test-driver closure.
@@ -194,7 +200,7 @@ The check covers:
 - automatic startup under an explicitly lingering test account, without display
   variables or a desktop session;
 - owner environment-file loading, configured shell, UID, home, CWD, and PTY;
-- strict workload cgroup placement, per-Splint/Dojo/aggregate task and memory
+- strict workload cgroup placement, inherited aggregate task and nested memory
   boundaries, and scope/slice cleanup after exit or daemon shutdown;
 - denied machine-mode access without policy, removal of the development bypass,
   and rejected local clients from a different package derivation;

--- a/docs/nixos.md
+++ b/docs/nixos.md
@@ -170,7 +170,42 @@ Checks cover remote-profile validation, installed desktop-file validity,
 unwrapped sibling layout, a private non-graphical daemon with trusted human CLI
 access, PTY helper execution and clean shutdown, and desktop/headless/disabled
 NixOS module evaluation.
-The private daemon test does not require a live user manager and does not test
-workload cgroups. The broader upstream Rust suite remains a separate boundary.
-Live NixOS user-service/cgroup/SSH testing and approved Wayland graphical
-acceptance are additional deployment checks, not implied by a successful build.
+The package's private-daemon smoke does not require a live user manager. The
+separate headless VM check below tests the actual module/service integration.
+The broader upstream Rust suite remains a separate boundary. Acceptance on real
+hosts and approved Wayland graphical testing are additional deployment checks,
+not implied by a successful build.
+
+### Headless NixOS integration test
+
+```sh
+nix build .#checks.x86_64-linux.headless --print-build-logs
+```
+
+This check is also included in `nix flake check`. It boots two disposable,
+non-graphical NixOS VMs (1.5 GiB RAM and two vCPUs each) on an isolated test
+network. The Nix builder needs working KVM access and the `kvm`/`nixos-test`
+system features. First use downloads the pinned NixOS VM/test-driver closure.
+It does not activate a workstation service or contact production hosts.
+
+The check covers:
+
+- disabled-by-default service and lingering, and explicit manual startup;
+- automatic startup under an explicitly lingering test account, without display
+  variables or a desktop session;
+- owner environment-file loading, configured shell, UID, home, CWD, and PTY;
+- strict workload cgroup placement, per-Splint/Dojo/aggregate task and memory
+  boundaries, and scope/slice cleanup after exit or daemon shutdown;
+- denied machine-mode access without policy, removal of the development bypass,
+  and rejected local clients from a different package derivation;
+- real SSH login/logout, native remote checks and reconnection, with strict host
+  keys, disposable test credentials and the NixOS remote executable path;
+- controlled switching between the standard and MCP-enabled package generations
+  and back, retaining matching executable/service identities; and
+- reboot startup with persisted topology but no automatic workload execution.
+
+Generation switching uses two variants of the same source revision. It tests
+store-path/inode and NixOS activation behavior, **not** cross-version protocol
+migration or live process preservation. The test driver bounds execution to
+15 minutes and tears down its private VMs. A failing build retains its Nix log;
+use `nix log` on the failed derivation to inspect the exact failing subtest.

--- a/docs/nixos.md
+++ b/docs/nixos.md
@@ -1,0 +1,176 @@
+# NixOS installation
+
+The repository flake builds the **complete Wayland desktop terminal**, not a
+headless-only edition. The default package includes `splinterm`, `splinterd`,
+`splinterm-relay`, `splinterm-pty-child`, the desktop entry/icon, and the Dojo
+launcher aliases. The same package works as a headless SSH session host without
+a compositor. Omarchy is not required; its optional integration commands are
+not part of NixOS setup.
+
+Initial packaging targets `x86_64-linux`. Other architectures are not advertised
+until built and tested. A native Wayland desktop is required for GUI windows;
+headless operation requires no graphical session. This packaging work does not
+establish graphical acceptance on every NixOS compositor.
+
+## Recommended: NixOS module
+
+Add Splinterm to your configuration flake and commit the resulting `flake.lock`:
+
+```nix
+inputs.splinterm.url = "github:OldJobobo/splinterm/<reviewed-revision>";
+```
+
+Replace `<reviewed-revision>` with the commit containing Nix support. Until that
+branch is merged/published, use a local checkout containing the implementation.
+The public release installer and Arch packages are **not** NixOS installers.
+The package's own pinned nixpkgs supplies its Rust/native toolchain; following a
+host's older nixpkgs input may not provide a sufficiently recent Rust compiler.
+
+Import the module into each desired `nixosConfigurations.<host>.modules` list:
+
+```nix
+inputs.splinterm.nixosModules.default
+```
+
+Then enable it in a host module:
+
+```nix
+{
+  programs.splinterm.enable = true;
+}
+```
+
+Rebuild NixOS normally from an external terminal or SSH connection, **not a shell
+owned by the daemon being replaced**. The module installs the full package and
+user service, enables Fontconfig, and adds JetBrains Mono Nerd Font plus CJK and
+emoji fonts. It does not select a compositor, change your default terminal,
+configure SSH authorization, enable lingering, or modify home-directory files.
+
+Launch **Splinterm** from the application menu. Its launcher starts the user
+daemon on demand; Recent Dojos and Reopen Last Dojo use the same package. To
+start it from an existing shell:
+
+```sh
+splinterm-xdg-terminal-exec
+```
+
+`nix run .# -- --help` runs the raw CLI, not the daemon-starting desktop wrapper.
+Installing only the package with `nix profile install` does not register its
+systemd user unit with NixOS. Use the module for the supported desktop setup.
+
+## Headless hosts
+
+Use the same module and package, but omit the desktop font integration and start
+the daemon automatically:
+
+```nix
+{
+  programs.splinterm = {
+    enable = true;
+    desktopIntegration = false;
+    startAtLogin = true;
+  };
+
+  # Optional: start this user's manager at boot and keep it after logout.
+  users.users.operator.linger = true;
+}
+```
+
+Replace `operator` with an existing account. `startAtLogin` enables the service
+for all user managers; lingering is explicitly per user. The GUI remains in the
+package, so a desktop profile can simply restore `desktopIntegration = true`.
+No local daemon TCP listener or firewall opening is needed; remote access uses
+OpenSSH. Configure the policy separately using `docs/remote.md`.
+
+The unit retains the upstream `--require-workload-cgroups` requirement,
+`app-splinterm.slice`, resource limits, SIGHUP reload and SIGINT cleanup. It
+reads the optional owner-controlled `~/.config/splinterm/daemon.env`, matching
+the Arch unit. Do not blindly add service sandboxing that blocks user PTYs,
+Unix sockets, user-manager D-Bus, or workload scope creation.
+
+## Remote profiles targeting NixOS
+
+On each connecting client, set the remote executable explicitly:
+
+```toml
+version = 1
+
+[remotes.server]
+host = "server"
+executable = "/run/current-system/sw/bin/splinterm"
+```
+
+`executable` defaults to `/usr/bin/splinterm` for existing Arch profiles. It is
+an absolute path on the **remote** host, not a local file or arbitrary command.
+Only ASCII letters, digits, `/`, `.`, `_`, and `-` are accepted; empty, `.` and
+`..` components are rejected. No whitespace, tilde expansion, shell operators,
+or user-supplied arguments are accepted. The relay arguments remain fixed.
+Both ends must run protocol-compatible versions. The connecting client also
+needs a version supporting the new profile field.
+
+Use the resolved store executable and its SHA-256 digest when authorizing the
+relay or MCP adapter in policy, not an assumed `/usr/bin` identity:
+
+```sh
+readlink -f /run/current-system/sw/bin/splinterm-relay
+sha256sum /run/current-system/sw/bin/splinterm-relay
+```
+
+Review/update policy after package changes. A NixOS activation does not silently
+grant a new executable automation authority.
+
+## Optional MCP adapter
+
+The default package does not include MCP. Select the complete matching variant
+rather than mixing binaries from different derivations:
+
+```nix
+{ pkgs, ... }: {
+  programs.splinterm.package =
+    inputs.splinterm.packages.${pkgs.stdenv.hostPlatform.system}.splinterm-with-mcp;
+}
+```
+
+Here `inputs` must be in your module's lexical scope or passed through your
+configuration's `specialArgs`. This variant includes the main package and the
+adapter; it does not configure an MCP host or grant policy permissions. See
+`docs/mcp.md` for explicit setup.
+
+## Executable identity and upgrades
+
+The client, daemon, relay and PTY helper are unwrapped sibling ELF binaries in
+one immutable store output. NixOS profile symlinks lead to those binaries; the
+package does not rename them to `.wrapped` files. Desktop scripts and service
+units use matching store paths, and native helpers such as `fc-match` are bound
+to their Nix dependencies without an `LD_LIBRARY_PATH` wrapper.
+
+A store generation change does not migrate a running daemon's processes.
+Schedule upgrades, stop the old user daemon, switch configuration, and restart
+it; close and reopen old GUI windows. Otherwise old daemon/new client identity
+checks may reject connections even when the protocol version is unchanged.
+A rollback must restore both the package/service generation and any associated
+policy identities. Persistent shell processes are not restored by rollback.
+
+## Build and non-graphical checks
+
+From a Git checkout containing the flake:
+
+```sh
+nix build .#splinterm
+nix flake check
+nix build .#splinterm-with-mcp
+```
+
+Commit provenance comes from the Git flake revision; a dirty checkout is for
+development only and is not a release artifact. `nix/package.nix` also accepts
+an explicit 40-character `sourceRevision` for non-flake source packaging; do not
+invent a revision for a source snapshot.
+
+Checks cover remote-profile validation, installed desktop-file validity,
+unwrapped sibling layout, a private non-graphical daemon with trusted human CLI
+access, PTY helper execution and clean shutdown, and desktop/headless/disabled
+NixOS module evaluation.
+The private daemon test does not require a live user manager and does not test
+workload cgroups. The broader upstream Rust suite remains a separate boundary.
+Live NixOS user-service/cgroup/SSH testing and approved Wayland graphical
+acceptance are additional deployment checks, not implied by a successful build.

--- a/docs/nixos.md
+++ b/docs/nixos.md
@@ -209,3 +209,49 @@ store-path/inode and NixOS activation behavior, **not** cross-version protocol
 migration or live process preservation. The test driver bounds execution to
 15 minutes and tears down its private VMs. A failing build retains its Nix log;
 use `nix log` on the failed derivation to inspect the exact failing subtest.
+
+### Opt-in disposable Wayland desktop acceptance
+
+Graphical acceptance requires approval for the complete bounded guest sequence.
+These test packages are deliberately **not** part of ordinary `nix flake check`:
+
+```sh
+nix build .#desktop-smoke --no-link --print-build-logs
+nix build .#desktop-test --no-link --print-build-logs --json
+```
+
+Run the smoke first. The full test also repeats that smoke before continuing.
+Both use one disposable NixOS VM with Sway, a guest-only virtual GPU, software
+rendering, 2 GiB RAM, two vCPUs, and a 15-minute execution limit. There is no host
+viewer, workstation input, SSH connection to a real host, or host installation.
+
+The smoke launches the installed desktop entry through GIO with `splinterd`
+stopped, verifies matching client/daemon executable paths, enters a shell marker
+through the guest virtual keyboard, and verifies visible text with OCR.
+The full matrix additionally checks:
+
+- installed New, Dojos, and Reopen desktop actions;
+- tab creation/cycling and a split, with shell PID/count assertions;
+- resizing with changed PTY geometry and rendering at 1× and 1.5× scale;
+- ASCII, Chinese, Japanese, Korean, and color emoji specimens;
+- clipboard paste into a shell and copying a pointer-selected text fixture; and
+- Ctrl-click URL dispatch to a guest-local recording handler, with no browser
+  or external network request.
+
+Reopen must return to the same live shell after the disposable window is closed.
+Each case records window ID/PID, focus, workspace, geometry, output scale and
+transform, seat state, and test-controlled cursor position. Every input batch
+checks the sole owned guest window; unexpected windows or focus/workspace drift
+abort the test. Pointer fixtures use OCR bounds from unmodified guest captures.
+Cases close only their test windows, stop the private user daemon, check socket
+and helper cleanup, and restore an empty workspace 8, scale 1, and cursor origin.
+The NixOS driver tears down its private VM on success or failure.
+
+A successful test output contains `acceptance/` with PNG captures, state records,
+shell markers, and launcher logs. Inspect the captures as well as the assertions:
+OCR proves selected ASCII fixtures are visible, not comprehensive glyph quality.
+Font specimens are reprinted after scale changes; this is not a test of a fixed
+viewport across terminal reflow. This software-rendered Sway fixture does not
+replace acceptance on another compositor, physical GPU, browser, or real host.
+Desktop actions exercise their installed `Exec` entries, not a desktop-menu
+widget's navigation.

--- a/docs/remote.md
+++ b/docs/remote.md
@@ -202,15 +202,20 @@ port = 22                            # optional
 identity_files = ["~/.ssh/id_ed25519"]
 known_hosts_file = "~/.ssh/known_hosts"
 connect_timeout_seconds = 15
+executable = "/usr/bin/splinterm"      # optional remote path; this is the default
 ```
 
 Unknown fields, unsupported versions, more than 64 profiles, unsafe names,
 ambiguous host/user tokens, zero ports, timeouts outside 1–300 seconds, more
 than eight identity files, documents above 64 KiB, and path values above 4 KiB
-fail closed. Explicit paths must be absolute or begin with `~/`, name readable
-regular files, and contain no whitespace or control characters. Profiles cannot
-supply arbitrary SSH options, commands, forwarding, environment, or shell
-fragments.
+fail closed. Identity and known-hosts paths must be absolute or begin with `~/`,
+name readable local regular files, and contain no whitespace or control characters.
+The optional `executable` is instead an absolute path on the remote host; it is
+not checked locally. For a system-installed NixOS package, use
+`/run/current-system/sw/bin/splinterm`. It accepts only ASCII letters, digits,
+`/`, `.`, `_`, and `-`, with no empty, `.` or `..` components. Relay arguments
+remain fixed. Profiles cannot supply arbitrary SSH options, commands, forwarding,
+environment, or shell fragments. See `docs/nixos.md` for NixOS installation.
 
 `~/.ssh/config` may still select ordinary aliases, identities, certificates, and
 proxy routing. Splinterm's command-line safety options override conflicting

--- a/docs/status.md
+++ b/docs/status.md
@@ -379,7 +379,7 @@ post-alpha3, pre-1.0 roadmap milestone.
 | AUR packages | Available | Recommended prebuilt [`splinterm-bin` `0.1.0-1`](https://aur.archlinux.org/packages/splinterm-bin) publishes `splinterm-bin` and optional `splinterm-mcp-bin` from checksummed immutable versioned-release assets without local compilation. Source-built [`splinterm` `0.1.0-1`](https://aur.archlinux.org/packages/splinterm) and `splinterm-mcp` remain available. |
 | Public source and versioned releases | Available | The repository, documentation, protected GitHub releases, and AUR packages are public. The retired rolling edge channel is no longer produced or consumed. |
 | Long-term or broader support | Not promised | No compatibility window, support duration, or formal support/security-reporting process is promised yet. |
-| Nix and broader distribution | Planned | Not current product behavior or support. |
+| NixOS packaging | Source flake and module | Full Wayland GUI and headless service packaging; live NixOS/graphical acceptance remains separate. See `docs/nixos.md`. |
 
 **Classification meanings:** implemented means present in current code; validated
 means required recorded evidence exists for the named scope; supported means a

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1782847189,
+        "narHash": "sha256-twXPFqFsrrY5r28Zh7Homgcp2gUMBgQ6WDS98Q/3xFI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b6018f87da91d19d0ab4cf979885689b469cdd41",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-25.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -24,6 +24,12 @@
           default = package;
           splinterm = package;
           splinterm-with-mcp = package.override { withMcp = true; };
+          # Graphical acceptance is opt-in, never part of ordinary flake check.
+          desktop-test = import ./nix/desktop-test.nix { inherit self pkgs; };
+          desktop-smoke = import ./nix/desktop-test.nix {
+            inherit self pkgs;
+            smokeOnly = true;
+          };
         }
       );
 

--- a/flake.nix
+++ b/flake.nix
@@ -37,6 +37,7 @@
         in
         {
           package = self.packages.${system}.default;
+          headless = import ./nix/headless-test.nix { inherit self pkgs; };
           module = import ./nix/module-check.nix {
             inherit
               self

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,51 @@
+{
+  description = "Splinterm — persistent Wayland terminal and headless session daemon";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+
+  outputs =
+    { self, nixpkgs }:
+    let
+      systems = [ "x86_64-linux" ];
+      forAllSystems = nixpkgs.lib.genAttrs systems;
+    in
+    {
+      packages = forAllSystems (
+        system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+          package = pkgs.callPackage ./nix/package.nix {
+            src = ./.;
+            sourceRevision =
+              self.rev or (if self ? dirtyRev then nixpkgs.lib.removeSuffix "-dirty" self.dirtyRev else null);
+          };
+        in
+        {
+          default = package;
+          splinterm = package;
+          splinterm-with-mcp = package.override { withMcp = true; };
+        }
+      );
+
+      nixosModules.default = import ./nix/module.nix { inherit self; };
+      nixosModules.splinterm = self.nixosModules.default;
+
+      checks = forAllSystems (
+        system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+        in
+        {
+          package = self.packages.${system}.default;
+          module = import ./nix/module-check.nix {
+            inherit
+              self
+              nixpkgs
+              pkgs
+              system
+              ;
+          };
+        }
+      );
+    };
+}

--- a/nix/desktop-test.nix
+++ b/nix/desktop-test.nix
@@ -1,0 +1,90 @@
+{
+  self,
+  pkgs,
+  smokeOnly ? false,
+}:
+let
+  package = self.packages.${pkgs.stdenv.hostPlatform.system}.splinterm;
+  urlSink = pkgs.writeShellScript "splinterm-vm-url" ''
+    printf '%s\n' "$1" >> /home/operator/acceptance/url-opened
+  '';
+  swayConfig = pkgs.writeText "splinterm-vm-sway.conf" ''
+    output * bg #20242c solid_color
+    output * mode 1280x960
+    seat seat0 fallback true
+    seat seat0 hide_cursor 0
+    focus_follows_mouse no
+    default_border none
+    default_floating_border none
+    workspace 8
+    seat seat0 cursor set 0 0
+    exec touch /home/operator/acceptance/compositor-ready
+  '';
+in
+pkgs.testers.runNixOSTest {
+  name = "splinterm-desktop";
+  globalTimeout = 900;
+  enableOCR = true;
+  nodes.desktop = {
+    imports = [ self.nixosModules.default ];
+    programs.splinterm.enable = true;
+    programs.sway.enable = true;
+    users.groups.operator.gid = 1000;
+    users.users.operator = {
+      isNormalUser = true;
+      uid = 1000;
+      group = "operator";
+      shell = pkgs.bashInteractive;
+    };
+    services.getty.autologinUser = "operator";
+    programs.bash.loginShellInit = ''
+      if [ "$(tty)" = /dev/tty1 ]; then
+        export SWAYSOCK=/run/user/1000/sway-test.sock
+        export WLR_RENDERER=pixman
+        exec sway --config ${swayConfig} > /home/operator/acceptance/sway.log 2>&1
+      fi
+    '';
+    environment.systemPackages = with pkgs; [
+      glib
+      grim
+      wtype
+      wlrctl
+      wl-clipboard
+      procps
+      util-linux
+      xdg-utils
+    ];
+    system.activationScripts.splinterm-desktop-fixtures = {
+      deps = [ "users" ];
+      text = ''
+        install -d -m700 -o operator -g operator /home/operator/acceptance
+        install -d -m700 -o operator -g operator /home/operator/.config/splinterm
+        install -d -m700 -o operator -g operator /home/operator/.local/share/applications
+        printf '%s\n' 'SHELL=${pkgs.bashInteractive}/bin/bash' > /home/operator/.config/splinterm/daemon.env
+        printf '%s\n' 'PS1="VM> "' > /home/operator/.bashrc
+        printf '%s\n' '[main]' 'font-pixelsize=18' > /home/operator/.config/splinterm/config.ini
+        cat > /home/operator/.local/share/applications/splinterm-vm-url.desktop <<'EOF'
+        [Desktop Entry]
+        Type=Application
+        Name=Guest-only URL recorder
+        Exec=${urlSink} %u
+        MimeType=x-scheme-handler/http;x-scheme-handler/https;
+        NoDisplay=true
+        EOF
+        chown -R operator:operator /home/operator/.config /home/operator/.local /home/operator/.bashrc
+      '';
+    };
+    virtualisation = {
+      memorySize = 2048;
+      cores = 2;
+      # A guest-only virtual GPU. The NixOS driver owns QEMU; no host viewer.
+      qemu.options = [ "-vga none -device virtio-gpu-pci" ];
+    };
+  };
+  testScript = ''
+    SMOKE_ONLY = ${if smokeOnly then "True" else "False"}
+    PACKAGE = "${package}"
+    SHELL = "${pkgs.bashInteractive}/bin/bash"
+  ''
+  + builtins.readFile ./desktop-test.py;
+}

--- a/nix/desktop-test.py
+++ b/nix/desktop-test.py
@@ -1,0 +1,353 @@
+# NixOS test driver globals and constants are supplied by desktop-test.nix.
+import csv
+import io
+import json
+import shlex
+import subprocess
+from typing import Any, Iterator
+
+APP_ID = "com.oldjobobo.splinterm"
+ARTIFACTS = "/home/operator/acceptance"
+WAYLAND = "wayland-1"
+owned: tuple[int, int] | None = None
+cursor = {"x": 0, "y": 0, "source": "guest compositor initialization"}
+
+
+def as_user(command: str) -> str:
+    return (
+        "setpriv --reuid=1000 --regid=1000 --init-groups env -i "
+        "HOME=/home/operator USER=operator LOGNAME=operator "
+        "PATH=/run/current-system/sw/bin XDG_RUNTIME_DIR=/run/user/1000 "
+        "DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/1000/bus "
+        "XDG_CURRENT_DESKTOP=sway SWAYSOCK=/run/user/1000/sway-test.sock "
+        f"WAYLAND_DISPLAY={WAYLAND} SHELL={SHELL} "
+        f"{SHELL} -c {shlex.quote(command)}"
+    )
+
+
+def user(command: str) -> str:
+    return desktop.succeed(as_user(command), timeout=30).strip()
+
+
+def sway(command: str, kind: str = "command") -> Any:
+    result = json.loads(user(f"swaymsg -r -t {kind} -- {shlex.quote(command)}"))
+    if kind == "command":
+        assert all(item["success"] for item in result), result
+    return result
+
+
+def walk(node: dict[str, Any]) -> Iterator[dict[str, Any]]:
+    yield node
+    for key in ("nodes", "floating_nodes"):
+        for child in node.get(key, []):
+            yield from walk(child)
+
+
+def windows() -> list[dict[str, Any]]:
+    return [node for node in walk(sway("", "get_tree")) if node.get("pid")]
+
+
+def target(require_focus: bool = True) -> dict[str, Any]:
+    current = windows()
+    assert len(current) == 1, ("unexpected guest window; abort input", current)
+    node = current[0]
+    assert owned == (node["id"], node["pid"]), (owned, node)
+    assert node["app_id"] == APP_ID, node
+    if require_focus:
+        assert node["focused"], ("target lost focus; abort input", node)
+    workspace = next(w for w in sway("", "get_workspaces") if w["focused"])
+    assert workspace["name"] == "8", workspace
+    return node
+
+
+def record(label: str) -> None:
+    data = {
+        "windows": windows(),
+        "outputs": sway("", "get_outputs"),
+        "workspaces": sway("", "get_workspaces"),
+        "seats": sway("", "get_seats"),
+        "cursor": cursor,
+    }
+    user(
+        f"printf %s {shlex.quote(json.dumps(data, indent=2))} > {ARTIFACTS}/{label}.json"
+    )
+
+
+def capture(label: str) -> None:
+    target()
+    record(label)
+    user(f"grim {ARTIFACTS}/{label}.png")
+
+
+def keys(arguments: str) -> None:
+    target()
+    user(f"wtype {arguments}")
+    target()
+
+
+def shell(command: str, marker: str) -> None:
+    target()
+    user(f"wtype -- {shlex.quote(command + '; touch ' + ARTIFACTS + '/' + marker)}")
+    keys("-k Return")
+    desktop.wait_for_file(f"{ARTIFACTS}/{marker}", timeout=30)
+
+
+def pointer(x: int, y: int, operation: str | None = None) -> None:
+    node = target()
+    rect = node["rect"]
+    assert rect["x"] <= x < rect["x"] + rect["width"]
+    assert rect["y"] <= y < rect["y"] + rect["height"]
+    sway(f"seat seat0 cursor set {x} {y}")
+    cursor.update(x=x, y=y, source="exact-target guest pointer command")
+    if operation:
+        sway(f"seat seat0 cursor {operation} button1")
+    target()
+
+
+def text_bounds(text: str, label: str) -> tuple[int, int, int, int]:
+    # Locate literal fixture text on the unmodified guest framebuffer. No guessed
+    # font metrics, translated captures, or workstation pointer coordinates.
+    target()
+    assert all(o["scale"] == 1 for o in sway("", "get_outputs") if o["active"])
+    desktop.screenshot(label)
+    tsv = subprocess.check_output(
+        [
+            "tesseract",
+            str(desktop.out_dir / f"{label}.png"),
+            "stdout",
+            "--psm",
+            "6",
+            "tsv",
+        ],
+        text=True,
+        timeout=30,
+    )
+    matches = [
+        row
+        for row in csv.DictReader(io.StringIO(tsv), delimiter="\t")
+        if text in row["text"]
+    ]
+    assert len(matches) == 1, (text, matches, tsv)
+    row = matches[0]
+    return int(row["left"]), int(row["top"]), int(row["width"]), int(row["height"])
+
+
+def daemon_pid() -> str:
+    return user("systemctl --user show splinterd.service -p MainPID --value")
+
+
+def wait_for_shells(count: int) -> None:
+    desktop.wait_until_succeeds(
+        f'test "$(pgrep -P {daemon_pid()} | wc -l)" -eq {count}', timeout=30
+    )
+
+
+def launch(action: str | None = None) -> None:
+    global owned
+    assert not windows(), "test workspace must be empty before launch"
+    record("before-launch" + (action or "default"))
+    if action is None:
+        command = f"gio launch {PACKAGE}/share/applications/{APP_ID}.desktop"
+    else:
+        # Read the installed desktop action, rather than testing an invented command.
+        import configparser
+
+        entry = configparser.ConfigParser(interpolation=None)
+        entry.read_string(
+            desktop.succeed(f"cat {PACKAGE}/share/applications/{APP_ID}.desktop")
+        )
+        command = shlex.join(shlex.split(entry[f"Desktop Action {action}"]["Exec"]))
+    user(f"{command} > {ARTIFACTS}/launcher-{action or 'default'}.log 2>&1 &")
+    desktop.wait_until_succeeds(
+        as_user("swaymsg -t get_tree | grep -F 'com.oldjobobo.splinterm'"), timeout=60
+    )
+    current = windows()
+    assert len(current) == 1 and current[0]["app_id"] == APP_ID, current
+    owned = (current[0]["id"], current[0]["pid"])
+    record("identified-" + (action or "default"))
+    target(require_focus=False)
+    sway(f"[con_id={owned[0]}] focus")
+    target()
+    assert (
+        desktop.succeed(f"readlink /proc/{owned[1]}/exe").strip()
+        == f"{PACKAGE}/bin/splinterm"
+    )
+
+
+def detach() -> None:
+    global owned
+    node = target()
+    sway(f"[con_id={node['id']}] kill")
+    desktop.wait_until_fails(f"test -e /proc/{node['pid']}", timeout=30)
+    assert not windows()
+    owned = None
+
+
+def cleanup(label: str) -> None:
+    if owned is not None:
+        detach()
+    assert not windows(), "refuse to clean up an unidentified guest window"
+    user("systemctl --user stop splinterd.service")
+    desktop.wait_until_fails(
+        "test -S /run/user/1000/splinterm/splinterd.sock", timeout=30
+    )
+    desktop.wait_until_fails("pgrep -u operator -x splinterm-pty-c", timeout=30)
+    sway("output * scale 1")
+    sway("workspace 8")
+    sway("seat seat0 cursor set 0 0")
+    cursor.update(x=0, y=0, source="guest-only cleanup")
+    record("clean-" + label)
+
+
+desktop.start()
+desktop.wait_for_unit("multi-user.target", timeout=60)
+desktop.wait_for_file(f"{ARTIFACTS}/compositor-ready", timeout=60)
+desktop.wait_for_file("/run/user/1000/sway-test.sock", timeout=30)
+WAYLAND = desktop.succeed(
+    "find /run/user/1000 -maxdepth 1 -type s -name 'wayland-*' -printf '%f'"
+).strip()
+assert WAYLAND and "/" not in WAYLAND
+assert not windows()
+record("initial")
+desktop.fail(as_user("systemctl --user is-active splinterd.service"))
+
+with subtest("guarded installed desktop-entry smoke starts daemon and renders shell"):
+    launch()
+    shell("printf '\\nSMOKE-PASS\\n'", "smoke-input")
+    desktop.wait_for_text("SMOKE-PASS", timeout=3)
+    capture("smoke")
+    pid = user("systemctl --user show splinterd.service -p MainPID --value")
+    assert (
+        desktop.succeed(f"readlink /proc/{pid}/exe").strip()
+        == f"{PACKAGE}/bin/splinterd"
+    )
+    cleanup("smoke")
+
+# The full matrix is deliberately gated on the successful smoke above.
+if not SMOKE_ONLY:
+    with subtest("installed New action renders a fresh terminal"):
+        launch("New")
+        shell("printf '\\nDESKTOP-MATRIX\\n'", "new-input")
+        desktop.wait_for_text("DESKTOP-MATRIX", timeout=3)
+        capture("new-action")
+        shell("echo $$ > /home/operator/acceptance/first-shell", "first-shell-ready")
+        wait_for_shells(1)
+        keys("-M ctrl -M shift -k d -m shift -m ctrl")
+        wait_for_shells(2)
+        shell("echo $$ > /home/operator/acceptance/second-shell", "second-shell-ready")
+        assert user(f"cat {ARTIFACTS}/first-shell") != user(
+            f"cat {ARTIFACTS}/second-shell"
+        )
+        keys("-M ctrl -k Tab -m ctrl")
+        shell("echo $$ > /home/operator/acceptance/cycled-shell", "cycle-ready")
+        assert user(f"cat {ARTIFACTS}/first-shell") == user(
+            f"cat {ARTIFACTS}/cycled-shell"
+        )
+        keys("-M ctrl -M shift -k Return -m shift -m ctrl")
+        wait_for_shells(3)
+        shell("printf '\\nSPLIT-PASS\\n'", "split-ready")
+        desktop.wait_for_text("SPLIT-PASS", timeout=3)
+        capture("tabs-and-split")
+        cleanup("tabs-and-split")
+
+    with subtest(
+        "resize, multilingual fonts, scaling, clipboard, and local URL handler"
+    ):
+        launch("New")
+        shell("stty size > /home/operator/acceptance/original-grid", "grid-before")
+        node = target()
+        sway(f"[con_id={node['id']}] floating enable")
+        sway(f"[con_id={node['id']}] resize set width 900 px height 650 px")
+        sway(f"[con_id={node['id']}] move position 80 px 80 px")
+        shell("stty size > /home/operator/acceptance/resized-grid", "grid-after")
+        assert user(f"cat {ARTIFACTS}/original-grid") != user(
+            f"cat {ARTIFACTS}/resized-grid"
+        )
+        capture("resized")
+        sway(f"[con_id={node['id']}] floating disable")
+        # Fixtures use shell escapes, not compositor keyboard-layout assumptions.
+        specimen = "ASCII 0123456789 | bold italic\n中文 日本語 한글\nEmoji: 😀 🚀 🌈\n"
+        user(f"printf %s {shlex.quote(specimen)} > {ARTIFACTS}/specimen.txt")
+        shell(
+            "printf '\\033[2J\\033[H'; cat /home/operator/acceptance/specimen.txt",
+            "fonts-ready",
+        )
+        desktop.wait_for_text("ASCII 0123456789", timeout=3)
+        capture("fonts-scale-1")
+        target()
+        sway("output * scale 1.5")
+        assert all(o["scale"] == 1.5 for o in sway("", "get_outputs") if o["active"])
+        shell(
+            "printf '\\033[2J\\033[H'; cat /home/operator/acceptance/specimen.txt",
+            "fonts-scaled-ready",
+        )
+        desktop.wait_for_text("ASCII 0123456789", timeout=3)
+        capture("fonts-scale-1-5")
+        target()
+        sway("output * scale 1")
+        shell(
+            "printf '\\033[2J\\033[H'; cat /home/operator/acceptance/specimen.txt",
+            "fonts-restored-ready",
+        )
+        desktop.wait_for_text("ASCII 0123456789", timeout=3)
+
+        user("printf %s CLIPBOARD-PASTE | wl-copy")
+        target()
+        user("wtype -- \"printf '%s' '\"")
+        keys("-M ctrl -M shift -k v -m shift -m ctrl")
+        user('wtype -- "\' > /home/operator/acceptance/pasted"')
+        keys("-k Return")
+        desktop.wait_for_file(f"{ARTIFACTS}/pasted", timeout=30)
+        assert user(f"cat {ARTIFACTS}/pasted") == "CLIPBOARD-PASTE"
+        shell("printf '\\033[2J\\033[HCLIPBOARD-COPY\\n'", "copy-ready")
+        desktop.wait_for_text("CLIPBOARD-COPY", timeout=3)
+        left, top, width, height = text_bounds("CLIPBOARD-COPY", "copy-bounds")
+        pointer(left + 1, top + height // 2, "press")
+        # Sway cursor warp/rebase does not dispatch grabbed drag motion.
+        # Use real virtual-pointer motion on the same isolated guest seat.
+        target()
+        user(f"wlrctl pointer move {width - 2} 0")
+        pointer(left + width - 1, top + height // 2, "release")
+        keys("-M ctrl -M shift -k c -m shift -m ctrl")
+        copied = user("timeout 5 wl-paste --no-newline")
+        assert copied == "CLIPBOARD-COPY", repr(copied)
+        capture("clipboard-copy")
+        user("xdg-mime default splinterm-vm-url.desktop x-scheme-handler/http")
+        shell("printf '\\033[2J\\033[Hhttp://127.0.0.1/splinterm-vm\\n'", "url-ready")
+        desktop.wait_for_text(r"127\.0\.0\.1", timeout=3)
+        left, top, width, height = text_bounds("127.0.0.1", "url-bounds")
+        pointer(left + width // 2, top + height // 2)
+        target()
+        # Modifier exists only in this guest virtual keyboard's bounded lifetime.
+        user(
+            "wtype -M ctrl -s 1000 -m ctrl & keyboard=$!; sleep 0.2; "
+            "swaymsg 'seat seat0 cursor press button1'; "
+            "swaymsg 'seat seat0 cursor release button1'; wait $keyboard"
+        )
+        target()
+        desktop.wait_for_file(f"{ARTIFACTS}/url-opened", timeout=30)
+        assert user(f"cat {ARTIFACTS}/url-opened") == "http://127.0.0.1/splinterm-vm"
+        capture("local-url")
+        user("wl-copy --clear")
+        cleanup("rendering-clipboard-url")
+
+    with subtest("Reopen desktop action reattaches the live shell after window detach"):
+        launch("New")
+        shell("echo $$ > /home/operator/acceptance/reopen-pid", "reopen-before")
+        shell_pid = user(f"cat {ARTIFACTS}/reopen-pid")
+        detach()
+        desktop.succeed(f"kill -0 {shell_pid}")
+        launch("Reopen")
+        shell("echo $$ > /home/operator/acceptance/reopened-pid", "reopen-after")
+        assert user(f"cat {ARTIFACTS}/reopened-pid") == shell_pid
+        capture("reopened")
+        cleanup("reopened")
+
+    with subtest("Dojos desktop action opens the native picker"):
+        launch("Dojos")
+        desktop.wait_for_text("(?i)RECENT DOJOS", timeout=3)
+        capture("dojos-action")
+        cleanup("dojos-action")
+
+assert not windows()
+desktop.copy_from_vm(ARTIFACTS)

--- a/nix/headless-test.nix
+++ b/nix/headless-test.nix
@@ -1,0 +1,92 @@
+{ self, pkgs }:
+let
+  package = self.packages.${pkgs.stdenv.hostPlatform.system}.splinterm;
+  withMcp = self.packages.${pkgs.stdenv.hostPlatform.system}.splinterm-with-mcp;
+  # Public, deliberately insecure fixture keys, confined to the disposable VLAN.
+  keys = import (pkgs.path + "/nixos/tests/ssh-keys.nix") pkgs;
+  workload = pkgs.writeShellScript "splinterm-headless-workload" ''
+    set -eu
+    output="$1"
+    printf '%s\n' "$$" > "$output/pid"
+    id -u > "$output/uid"
+    printf '%s\n' "$HOME" > "$output/home"
+    printf '%s\n' "$SHELL" > "$output/shell"
+    printf '%s\n' "$SPLINTERM_TEST_MARKER" > "$output/environment"
+    pwd > "$output/cwd"
+    readlink /proc/$$/fd/0 > "$output/tty"
+    cat /proc/$$/cgroup > "$output/cgroup"
+    cat /proc/sys/kernel/random/boot_id > "$output/ready"
+    exec sleep 600
+  '';
+in
+pkgs.testers.runNixOSTest {
+  name = "splinterm-headless";
+  globalTimeout = 900;
+
+  defaults = {
+    imports = [ self.nixosModules.default ];
+    programs.splinterm = {
+      enable = true;
+      desktopIntegration = false;
+    };
+    virtualisation = {
+      graphics = false;
+      memorySize = 1536;
+      cores = 2;
+    };
+    users.groups.operator.gid = 1000;
+    users.users.operator = {
+      isNormalUser = true;
+      uid = 1000;
+      group = "operator";
+      shell = pkgs.bashInteractive;
+      openssh.authorizedKeys.keys = [ keys.snakeOilEd25519PublicKey ];
+    };
+    services.openssh = {
+      enable = true;
+      settings = {
+        PasswordAuthentication = false;
+        KbdInteractiveAuthentication = false;
+        PermitRootLogin = "no";
+      };
+    };
+    environment.systemPackages = [
+      pkgs.procps
+      pkgs.util-linux
+    ];
+    environment.etc."splinterm-test-key" = {
+      source = keys.snakeOilEd25519PrivateKey;
+      mode = "0600";
+    };
+    system.activationScripts.splinterm-test-config = {
+      deps = [ "users" ];
+      text = ''
+        install -d -m700 -o operator -g operator /home/operator/.config/splinterm
+        printf '%s\n' \
+          'SHELL=${pkgs.bashInteractive}/bin/bash' \
+          'SPLINTERM_TEST_MARKER=owner-environment' \
+          'SPLINTERM_ENABLE_DEV_ATTACH=1' \
+          > /home/operator/.config/splinterm/daemon.env
+        chown operator:operator /home/operator/.config/splinterm/daemon.env
+        chmod 600 /home/operator/.config/splinterm/daemon.env
+      '';
+    };
+  };
+
+  nodes = {
+    ondemand = { };
+    automatic = {
+      programs.splinterm.startAtLogin = true;
+      users.users.operator.linger = true;
+      specialisation.with-mcp.configuration.programs.splinterm.package = pkgs.lib.mkForce withMcp;
+    };
+  };
+
+  testScript = ''
+    PACKAGE = "${package}"
+    WITH_MCP = "${withMcp}"
+    WORKLOAD = "${workload}"
+    SHELL = "${pkgs.bashInteractive}/bin/bash"
+  ''
+  + builtins.readFile ./headless-test.py;
+}

--- a/nix/headless-test.py
+++ b/nix/headless-test.py
@@ -67,9 +67,12 @@ def create_workload(machine: Machine, label: str) -> tuple[str, str]:
     assert "splinterd.service" not in cgroup
     scope = cgroup.rsplit("/", 1)[-1]
     dojo = cgroup.rsplit("/", 2)[-2]
-    assert property_value(machine, scope, "TasksMax") == "512"
-    assert property_value(machine, dojo, "TasksMax") == "1024"
+    # The 0.1 daemon has nested memory limits, not 0.2's per-Dojo/Splint
+    # task policy. Both descendants must inherit the module's aggregate cap.
     assert property_value(machine, "app-splinterm.slice", "TasksMax") == "2048"
+    for unit in (scope, dojo):
+        effective_tasks = int(property_value(machine, unit, "EffectiveTasksMax"))
+        assert 0 < effective_tasks <= 2048
     assert "splinterd.service" in property_value(machine, dojo, "PartOf").split()
     limits = [
         int(property_value(machine, unit, "MemoryHigh"))

--- a/nix/headless-test.py
+++ b/nix/headless-test.py
@@ -1,0 +1,266 @@
+# Executed by the NixOS test driver, with constants supplied by headless-test.nix.
+import shlex
+
+from test_driver.machine import Machine
+
+
+def as_user(command: str) -> str:
+    # No PAM session: probes must not create logins or accidentally enable linger.
+    return (
+        "setpriv --reuid=1000 --regid=1000 --init-groups env -i "
+        "HOME=/home/operator USER=operator LOGNAME=operator "
+        "PATH=/run/current-system/sw/bin XDG_RUNTIME_DIR=/run/user/1000 "
+        "DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/1000/bus "
+        f"SHELL={SHELL} {SHELL} -c {shlex.quote(command)}"
+    )
+
+
+def user(machine: Machine, command: str) -> str:
+    return machine.succeed(as_user(command), timeout=30).strip()
+
+
+def assert_unauthorized(machine: Machine, command: str) -> None:
+    status, output = machine.execute(as_user(command) + " 2>&1", timeout=30)
+    assert status != 0, output
+    assert "[unauthorized]" in output, output
+
+
+def property_value(machine: Machine, unit: str, name: str) -> str:
+    return user(machine, f"systemctl --user show {shlex.quote(unit)} -p {name} --value")
+
+
+def wait_for_daemon(machine: Machine, package: str = PACKAGE) -> str:
+    machine.wait_for_unit("user@1000.service", timeout=60)
+    machine.wait_until_succeeds(
+        as_user("systemctl --user is-active splinterd.service"), timeout=60
+    )
+    machine.wait_until_succeeds(as_user("splinterm list"), timeout=30)
+    pid = property_value(machine, "splinterd.service", "MainPID")
+    assert (
+        machine.succeed(f"readlink /proc/{pid}/exe").strip()
+        == f"{package}/bin/splinterd"
+    )
+    environment = machine.succeed(f"tr '\\0' '\\n' < /proc/{pid}/environ")
+    assert "DISPLAY=" not in environment
+    assert "WAYLAND_DISPLAY=" not in environment
+    assert "SPLINTERM_ENABLE_DEV_ATTACH=" not in environment
+    return pid
+
+
+def create_workload(machine: Machine, label: str) -> tuple[str, str]:
+    directory = f"/home/operator/{label}"
+    user(machine, f"mkdir -p {directory}")
+    user(machine, f"splinterm new {label} --cwd {directory} -- {WORKLOAD} {directory}")
+    machine.wait_for_file(f"{directory}/ready", timeout=30)
+    pid = machine.succeed(f"cat {directory}/pid").strip()
+    assert machine.succeed(f"cat {directory}/uid").strip() == "1000"
+    assert machine.succeed(f"cat {directory}/home").strip() == "/home/operator"
+    assert machine.succeed(f"cat {directory}/shell").strip() == SHELL
+    assert (
+        machine.succeed(f"cat {directory}/environment").strip() == "owner-environment"
+    )
+    assert machine.succeed(f"cat {directory}/cwd").strip() == directory
+    assert machine.succeed(f"cat {directory}/tty").strip().startswith("/dev/pts/")
+    cgroup = machine.succeed(f"cat /proc/{pid}/cgroup").strip().removeprefix("0::")
+    assert "/app-splinterm.slice/app-splinterm-dojo" in cgroup
+    assert cgroup.endswith(".scope")
+    assert "splinterd.service" not in cgroup
+    scope = cgroup.rsplit("/", 1)[-1]
+    dojo = cgroup.rsplit("/", 2)[-2]
+    assert property_value(machine, scope, "TasksMax") == "512"
+    assert property_value(machine, dojo, "TasksMax") == "1024"
+    assert property_value(machine, "app-splinterm.slice", "TasksMax") == "2048"
+    assert "splinterd.service" in property_value(machine, dojo, "PartOf").split()
+    limits = [
+        int(property_value(machine, unit, "MemoryHigh"))
+        for unit in (scope, dojo, "app-splinterm.slice")
+    ]
+    assert 0 < limits[0] < limits[1] < limits[2]
+    return pid, cgroup
+
+
+def wait_for_cleanup(machine: Machine, pid: str, cgroup: str) -> None:
+    machine.wait_until_fails(f"test -e /proc/{pid}", timeout=60)
+    machine.wait_until_fails(f"test -d /sys/fs/cgroup{cgroup}", timeout=60)
+    machine.wait_until_fails(
+        f"test -d /sys/fs/cgroup{cgroup.rsplit('/', 1)[0]}", timeout=60
+    )
+
+
+ondemand.start()
+automatic.start(allow_reboot=True)
+ondemand.wait_for_unit("multi-user.target", timeout=60)
+automatic.wait_for_unit("multi-user.target", timeout=60)
+
+with subtest("on-demand defaults do not enable service or lingering"):
+    ondemand.fail("test -e /var/lib/systemd/linger/operator")
+    ondemand.fail("systemctl is-active user@1000.service")
+    ondemand.succeed("systemctl start user@1000.service")
+    ondemand.wait_for_unit("user@1000.service", timeout=60)
+    # Nix-generated units may be static/linked: is-enabled's exit code is not
+    # an autostart assertion. Check the actual target dependency instead.
+    assert (
+        "default.target"
+        not in property_value(ondemand, "splinterd.service", "WantedBy").split()
+    )
+    ondemand.fail(as_user("systemctl --user is-active splinterd.service"))
+    user(ondemand, "systemctl --user start splinterd.service")
+    wait_for_daemon(ondemand)
+    assert property_value(ondemand, "splinterd.service", "TasksMax") == "2048"
+    assert "--require-workload-cgroups" in property_value(
+        ondemand, "splinterd.service", "ExecStart"
+    )
+    user(ondemand, "systemctl --user stop splinterd.service")
+    ondemand.wait_until_fails(
+        "test -S /run/user/1000/splinterm/splinterd.sock", timeout=30
+    )
+    ondemand.succeed("systemctl stop user@1000.service")
+
+with subtest("automatic service starts headlessly under explicit lingering"):
+    automatic.succeed("test -e /var/lib/systemd/linger/operator")
+    daemon_pid = wait_for_daemon(automatic)
+    assert (
+        "default.target"
+        in property_value(automatic, "splinterd.service", "WantedBy").split()
+    )
+    assert_unauthorized(automatic, "splinterm --output json list")
+    # A valid client from the other complete derivation must not gain local UI authority.
+    assert_unauthorized(automatic, f"{WITH_MCP}/bin/splinterm list")
+
+with subtest("workload scopes use real delegated cgroups and are collected on exit"):
+    pid, cgroup = create_workload(automatic, "exiting-workload")
+    automatic.succeed(f"kill -TERM {pid}")
+    wait_for_cleanup(automatic, pid, cgroup)
+    assert property_value(automatic, "splinterd.service", "MainPID") == daemon_pid
+    user(automatic, "splinterm list")
+
+with subtest("configured default shell gets a PTY and the requested working directory"):
+    user(automatic, "mkdir -p /home/operator/default-shell")
+    user(automatic, "splinterm new default-shell --cwd /home/operator/default-shell")
+    automatic.wait_until_succeeds(f"pgrep -P {daemon_pid}", timeout=30)
+    children = automatic.succeed(f"pgrep -P {daemon_pid}").split()
+    assert len(children) == 1, children
+    shell_pid = children[0]
+    # pgrep can observe the short-lived PTY helper before it execs the shell.
+    automatic.wait_until_succeeds(
+        f'test "$(readlink /proc/{shell_pid}/exe)" = {SHELL}', timeout=30
+    )
+    assert (
+        automatic.succeed(f"readlink /proc/{shell_pid}/cwd").strip()
+        == "/home/operator/default-shell"
+    )
+    assert (
+        automatic.succeed(f"readlink /proc/{shell_pid}/fd/0")
+        .strip()
+        .startswith("/dev/pts/")
+    )
+    user(automatic, "systemctl --user stop splinterd.service")
+    automatic.wait_until_fails(f"test -e /proc/{shell_pid}", timeout=60)
+    user(automatic, "systemctl --user start splinterd.service")
+    daemon_pid = wait_for_daemon(automatic)
+
+with subtest("SSH logout and native remote reconnect do not kill lingering workloads"):
+    automatic.wait_for_unit("sshd.service", timeout=60)
+    host_key = automatic.succeed("cat /etc/ssh/ssh_host_ed25519_key.pub").strip()
+    ondemand.succeed("install -d -m700 -o operator -g operator /home/operator/.ssh")
+    ondemand.succeed(
+        "install -m600 -o operator -g operator /etc/splinterm-test-key /home/operator/.ssh/test-key"
+    )
+    known_hosts = shlex.quote(f"automatic {host_key}\n")
+    ondemand.succeed(f"printf %s {known_hosts} > /home/operator/.ssh/known_hosts")
+    ondemand.succeed(
+        "chown operator:operator /home/operator/.ssh/known_hosts; chmod 600 /home/operator/.ssh/known_hosts"
+    )
+    ssh = (
+        "ssh -T -i /home/operator/.ssh/test-key -o IdentitiesOnly=yes "
+        "-o BatchMode=yes -o StrictHostKeyChecking=yes -o ConnectTimeout=5 "
+        "-o UserKnownHostsFile=/home/operator/.ssh/known_hosts operator@automatic "
+    )
+    user(ondemand, ssh + shlex.quote("splinterm list"))
+    remote_config = (
+        'version = 1\n[remotes.vm]\nhost = "automatic"\nuser = "operator"\n'
+        'executable = "/run/current-system/sw/bin/splinterm"\n'
+        'identity_files = ["/home/operator/.ssh/test-key"]\n'
+        'known_hosts_file = "/home/operator/.ssh/known_hosts"\n'
+    )
+    user(
+        ondemand,
+        f"printf %s {shlex.quote(remote_config)} > /home/operator/.config/splinterm/remotes.toml",
+    )
+    user(ondemand, "splinterm remote check vm")
+    directory = "/home/operator/ssh-workload"
+    user(
+        ondemand,
+        ssh
+        + shlex.quote(
+            f"mkdir -p {directory}; splinterm new ssh-workload --cwd {directory} -- {WORKLOAD} {directory}"
+        ),
+    )
+    automatic.wait_for_file(f"{directory}/ready", timeout=30)
+    pid = automatic.succeed(f"cat {directory}/pid").strip()
+    cgroup = automatic.succeed(f"cat /proc/{pid}/cgroup").strip().removeprefix("0::")
+    # systemd 258 also lists the lingering user manager as a session. Require
+    # every human SSH session to be gone, without rejecting that manager.
+    automatic.wait_until_succeeds(
+        "for session in $(loginctl show-user operator -p Sessions --value); do "
+        'test "$(loginctl show-session "$session" -p Class --value)" = manager || exit 1; done',
+        timeout=60,
+    )
+    automatic.succeed(f"kill -0 {pid}")
+    assert property_value(automatic, "splinterd.service", "MainPID") == daemon_pid
+    assert "ssh-workload" in user(ondemand, "splinterm --remote vm list")
+    user(ondemand, "splinterm remote check vm")
+    automatic.succeed(f"kill -0 {pid}")
+
+with subtest("stopping the service reaps workloads and removes socket and scopes"):
+    user(automatic, "systemctl --user stop splinterd.service")
+    wait_for_cleanup(automatic, pid, cgroup)
+    automatic.wait_until_fails(
+        "test -S /run/user/1000/splinterm/splinterd.sock", timeout=30
+    )
+    automatic.wait_until_fails("pgrep -u operator -x splinterm-pty-c", timeout=30)
+
+with subtest(
+    "switch complete package generations and roll back without relaxing identity"
+):
+    base_system = automatic.succeed("readlink -f /run/current-system").strip()
+    automatic.succeed(
+        f"{base_system}/specialisation/with-mcp/bin/switch-to-configuration test",
+        timeout=120,
+    )
+    user(
+        automatic,
+        "systemctl --user daemon-reload; systemctl --user start splinterd.service",
+    )
+    wait_for_daemon(automatic, WITH_MCP)
+    automatic.succeed("test -x /run/current-system/sw/bin/splinterm-mcp")
+    assert_unauthorized(automatic, f"{PACKAGE}/bin/splinterm list")
+    pid, cgroup = create_workload(automatic, "alternate-generation")
+    user(automatic, "systemctl --user stop splinterd.service")
+    wait_for_cleanup(automatic, pid, cgroup)
+    automatic.succeed(f"{base_system}/bin/switch-to-configuration test", timeout=120)
+    user(
+        automatic,
+        "systemctl --user daemon-reload; systemctl --user start splinterd.service",
+    )
+    wait_for_daemon(automatic)
+    automatic.fail("test -e /run/current-system/sw/bin/splinterm-mcp")
+    assert_unauthorized(automatic, f"{WITH_MCP}/bin/splinterm list")
+
+with subtest("reboot restarts the service but never automatically restores commands"):
+    pid, cgroup = create_workload(automatic, "reboot-workload")
+    before = automatic.succeed("cat /home/operator/reboot-workload/ready").strip()
+    assert "reboot-workload" in user(automatic, "splinterm list --all")
+    automatic.reboot()
+    daemon_pid = wait_for_daemon(automatic)
+    assert automatic.succeed("cat /proc/sys/kernel/random/boot_id").strip() != before
+    assert (
+        automatic.succeed("cat /home/operator/reboot-workload/ready").strip() == before
+    )
+    automatic.fail(f"pgrep -P {daemon_pid}")
+    assert "reboot-workload" in user(automatic, "splinterm list --all")
+    automatic.fail(f"test -d /sys/fs/cgroup{cgroup}")
+    user(automatic, "systemctl --user stop splinterd.service")
+    automatic.wait_until_fails(
+        "test -S /run/user/1000/splinterm/splinterd.sock", timeout=30
+    )

--- a/nix/module-check.nix
+++ b/nix/module-check.nix
@@ -1,0 +1,43 @@
+{
+  self,
+  nixpkgs,
+  pkgs,
+  system,
+}:
+let
+  evaluate =
+    settings:
+    (nixpkgs.lib.nixosSystem {
+      inherit system;
+      modules = [
+        self.nixosModules.default
+        {
+          system.stateVersion = "25.11";
+          programs.splinterm = settings;
+        }
+      ];
+    }).config;
+  desktop = evaluate { enable = true; };
+  headless = evaluate {
+    enable = true;
+    desktopIntegration = false;
+    startAtLogin = true;
+  };
+  disabled = evaluate { enable = false; };
+  service = desktop.systemd.user.services.splinterd;
+in
+assert
+  service.serviceConfig.ExecStart
+  == "${self.packages.${system}.splinterm}/bin/splinterd --require-workload-cgroups";
+assert service.wantedBy == [ ];
+assert headless.systemd.user.services.splinterd.wantedBy == [ "default.target" ];
+assert desktop.fonts.fontconfig.enable;
+assert builtins.elem pkgs.nerd-fonts.jetbrains-mono desktop.fonts.packages;
+assert !(builtins.elem pkgs.nerd-fonts.jetbrains-mono headless.fonts.packages);
+assert !(disabled.systemd.user.services ? splinterd);
+assert desktop.systemd.user.slices.app-splinterm.sliceConfig.TasksMax == 2048;
+pkgs.runCommand "splinterm-nixos-module-check" { } ''
+  # Force generated unit evaluation, not only option declarations.
+  test -n '${desktop.systemd.user.units."splinterd.service".text}'
+  touch "$out"
+''

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -1,0 +1,68 @@
+{ self }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.programs.splinterm;
+in
+{
+  options.programs.splinterm = {
+    enable = lib.mkEnableOption "Splinterm's Wayland terminal, CLI, and systemd user daemon";
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = self.packages.${pkgs.stdenv.hostPlatform.system}.splinterm;
+      description = "The complete package; client, daemon, relay and PTY helper must remain together.";
+    };
+    desktopIntegration = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = "Enable Fontconfig and install terminal/CJK/emoji fonts. The GUI and desktop entry are always in the package; this does not enable a compositor or change the default terminal.";
+    };
+    startAtLogin = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Start the user daemon at default.target instead of only on demand. Applies to all user managers; lingering is a separate per-user choice.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+    fonts.fontconfig.enable = lib.mkIf cfg.desktopIntegration true;
+    fonts.packages = lib.mkIf cfg.desktopIntegration [
+      pkgs.nerd-fonts.jetbrains-mono
+      pkgs.noto-fonts-cjk-sans
+      pkgs.noto-fonts-color-emoji
+    ];
+
+    systemd.user.services.splinterd = {
+      description = "Splinterm persistent terminal daemon";
+      documentation = [ "file://${cfg.package}/share/doc/splinterm/headless.md" ];
+      wantedBy = lib.optionals cfg.startAtLogin [ "default.target" ];
+      serviceConfig = {
+        Type = "simple";
+        EnvironmentFile = "-%h/.config/splinterm/daemon.env";
+        UnsetEnvironment = "SPLINTERM_ENABLE_DEV_ATTACH";
+        ExecStart = "${cfg.package}/bin/splinterd --require-workload-cgroups";
+        ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
+        Restart = "on-failure";
+        RestartSec = 1;
+        TasksMax = 2048;
+        MemoryHigh = "75%";
+        KillSignal = "SIGINT";
+        KillMode = "mixed";
+        TimeoutStopSec = 90;
+      };
+    };
+    systemd.user.slices.app-splinterm = {
+      description = "Splinterm terminal workloads";
+      unitConfig.StopWhenUnneeded = true;
+      sliceConfig = {
+        TasksMax = 2048;
+        MemoryHigh = "75%";
+      };
+    };
+  };
+}

--- a/nix/package-smoke.py
+++ b/nix/package-smoke.py
@@ -1,0 +1,79 @@
+"""Non-graphical installed-package check; never touches a live user daemon."""
+
+import os
+from pathlib import Path
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+
+
+def main():
+    package = Path(sys.argv[1])
+    with tempfile.TemporaryDirectory(prefix="splinterm-nix-") as directory:
+        root = Path(directory)
+        runtime = root / "runtime"
+        runtime.mkdir(mode=0o700)
+        environment = {
+            **{key: value for key, value in os.environ.items()
+               if not key.startswith("SPLINTERM_") and key not in ("WAYLAND_DISPLAY", "DISPLAY")},
+            "HOME": str(root),
+            "XDG_CONFIG_HOME": str(root / "config"),
+            "XDG_STATE_HOME": str(root / "state"),
+            "XDG_CACHE_HOME": str(root / "cache"),
+            "XDG_RUNTIME_DIR": str(runtime),
+            "SPLINTERM_SOCKET": str(runtime / "daemon.sock"),
+        }
+        with (root / "daemon.log").open("w+") as log:
+            daemon = subprocess.Popen([str(package / "bin/splinterd")], env=environment,
+                                      stdout=log, stderr=log)
+            try:
+                deadline = time.monotonic() + 10
+                while not (runtime / "daemon.sock").exists():
+                    if daemon.poll() is not None or time.monotonic() >= deadline:
+                        log.seek(0)
+                        raise RuntimeError(f"private daemon did not start: {log.read()}")
+                    time.sleep(0.05)
+                # Human mode deliberately exercises trusted sibling authentication.
+                for command in ("ping", "list"):
+                    result = subprocess.run([str(package / "bin/splinterm"), command],
+                                            env=environment, capture_output=True, text=True,
+                                            timeout=10, check=False)
+                    if result.returncode:
+                        raise RuntimeError(f"{command}: {result.stdout}\n{result.stderr}")
+                marker = root / "pty-ready"
+                result = subprocess.run(
+                    [str(package / "bin/splinterm"), "new", "package-smoke",
+                     "--cwd", str(root), "--", sys.argv[2], "-c",
+                     'printf ready > "$1"', "smoke", str(marker)],
+                    env=environment, capture_output=True, text=True, timeout=10, check=False,
+                )
+                if result.returncode:
+                    raise RuntimeError(f"PTY launch: {result.stdout}\n{result.stderr}")
+                deadline = time.monotonic() + 10
+                while not marker.exists():
+                    if time.monotonic() >= deadline:
+                        raise RuntimeError("installed PTY helper did not execute its command")
+                    time.sleep(0.05)
+                if marker.read_text() != "ready":
+                    raise RuntimeError("installed PTY command produced unexpected output")
+            finally:
+                if daemon.poll() is None:
+                    daemon.send_signal(signal.SIGINT)
+                    try:
+                        daemon.wait(timeout=10)
+                    except subprocess.TimeoutExpired:
+                        daemon.kill()
+                        daemon.wait()
+                        raise RuntimeError("private daemon did not stop cleanly") from None
+            if daemon.returncode != 0:
+                log.seek(0)
+                raise RuntimeError(f"private daemon failed: {log.read()}")
+            if (runtime / "daemon.sock").exists():
+                raise RuntimeError("private daemon left its socket behind")
+    print("Installed package: trusted sibling CLI, PTY helper, and clean private daemon shutdown passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,178 @@
+{
+  lib,
+  rustPlatform,
+  pkg-config,
+  freetype,
+  pixman,
+  fontconfig,
+  libxkbcommon,
+  wayland,
+  systemd,
+  coreutils,
+  openssh,
+  python3,
+  desktop-file-utils,
+  runtimeShell,
+  xdg-utils,
+  src,
+  sourceRevision ? null,
+  withMcp ? false,
+}:
+
+assert lib.assertMsg
+  (sourceRevision != null && builtins.match "[0-9a-f]{40}" sourceRevision != null)
+  "Splinterm requires an exact sourceRevision; build from a Git flake, or pass the source commit when calling package.nix.";
+
+rustPlatform.buildRustPackage {
+  pname = if withMcp then "splinterm-with-mcp" else "splinterm";
+  version = (builtins.fromTOML (builtins.readFile ../Cargo.toml)).workspace.package.version;
+  src = lib.fileset.toSource {
+    root = src;
+    fileset = lib.fileset.unions (
+      map (name: src + "/${name}") [
+        "Cargo.toml"
+        "Cargo.lock"
+        "crates"
+        "config"
+        "dist"
+        "docs"
+        "fixtures"
+        "tests"
+        "tools"
+        "nix"
+        "README.md"
+        "LICENSE"
+        "THIRD_PARTY.md"
+      ]
+    );
+  };
+  cargoLock.lockFile = ../Cargo.lock;
+  SPLINTERM_BUILD_COMMIT = sourceRevision;
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [
+    freetype
+    pixman
+    fontconfig
+    libxkbcommon
+    wayland
+  ];
+  nativeInstallCheckInputs = [
+    desktop-file-utils
+    python3
+  ];
+
+  cargoBuildFlags = [
+    "-p"
+    "splinterm"
+    "-p"
+    "splinterd"
+    "-p"
+    "splinterm-relay"
+    "-p"
+    "splinterm-pty"
+    "--bin"
+    "splinterm"
+    "--bin"
+    "splinterd"
+    "--bin"
+    "splinterm-relay"
+    "--bin"
+    "splinterm-pty-child"
+  ]
+  ++ lib.optionals withMcp [
+    "-p"
+    "splinterm-mcp"
+    "--bin"
+    "splinterm-mcp"
+  ];
+
+  # The complete upstream suite also requires fonts, /bin/sh, and a live user
+  # manager. Keep sandbox checks bounded to the portable remote-profile contract.
+  cargoTestFlags = [
+    "-p"
+    "splinterm"
+    "--lib"
+    "remote::tests"
+  ];
+  checkFlags = [ "--test-threads=1" ];
+
+  postPatch = ''
+    # Do not wrap/rename the ELF binaries: /proc/self/exe sibling lookup is part
+    # of trusted UI authentication and PTY/relay discovery.
+    substituteInPlace crates/splinterm/src/renderer/fonts.rs \
+      --replace-fail 'Command::new("fc-match")' 'Command::new("${fontconfig}/bin/fc-match")'
+    substituteInPlace crates/splinterm/src/wayland.rs \
+      --replace-fail 'Command::new("xdg-open")' 'Command::new("${xdg-utils}/bin/xdg-open")'
+    substituteInPlace crates/splinterm/src/app/local_service.rs \
+      --replace-fail 'ProcessCommand::new("systemctl")' 'ProcessCommand::new("${systemd}/bin/systemctl")'
+    substituteInPlace crates/splinterm/src/remote.rs \
+      --replace-fail 'program: OsString::from("ssh")' 'program: OsString::from("${openssh}/bin/ssh")' \
+      --replace-fail 'OsStr::new("ssh")' 'OsStr::new("${openssh}/bin/ssh")'
+  '';
+
+  postInstall = ''
+    install -Dm755 dist/bin/splinterm-xdg-terminal-exec "$out/bin/splinterm-xdg-terminal-exec"
+    substituteInPlace "$out/bin/splinterm-xdg-terminal-exec" \
+      --replace-fail '#!/bin/sh' '#!${runtimeShell}' \
+      --replace-fail 'splinterm ping' "$out/bin/splinterm ping" \
+      --replace-fail 'exec splinterm ' "exec $out/bin/splinterm " \
+      --replace-fail 'command -v systemctl' 'command -v ${systemd}/bin/systemctl' \
+      --replace-fail 'systemctl --user' '${systemd}/bin/systemctl --user' \
+      --replace-fail 'sleep 0.05' '${coreutils}/bin/sleep 0.05'
+    for alias in splinterm-dojos splinterm-sessions splinterm-reopen; do
+      ln -s splinterm-xdg-terminal-exec "$out/bin/$alias"
+    done
+    install -Dm755 tools/automation/splinterm-dojo-picker.py "$out/bin/splinterm-dojo-picker"
+    substituteInPlace "$out/bin/splinterm-dojo-picker" \
+      --replace-fail '#!/usr/bin/env python3' '#!${python3}/bin/python3' \
+      --replace-fail 'os.environ.get("SPLINTERM_CLI", "splinterm")' "os.environ.get(\"SPLINTERM_CLI\", \"$out/bin/splinterm\")"
+    ln -s splinterm-dojo-picker "$out/bin/splinterm-session-picker"
+
+    install -Dm644 dist/applications/com.oldjobobo.splinterm.desktop \
+      "$out/share/applications/com.oldjobobo.splinterm.desktop"
+    substituteInPlace "$out/share/applications/com.oldjobobo.splinterm.desktop" \
+      --replace-fail 'Exec=splinterm' "Exec=$out/bin/splinterm"
+    install -Dm644 dist/icons/com.oldjobobo.splinterm.svg \
+      "$out/share/icons/hicolor/scalable/apps/com.oldjobobo.splinterm.svg"
+    install -Dm644 dist/metainfo/com.oldjobobo.splinterm.metainfo.xml \
+      "$out/share/metainfo/com.oldjobobo.splinterm.metainfo.xml"
+    mkdir -p "$out/share/doc/splinterm" "$out/share/licenses/splinterm"
+    cp README.md docs/*.md config/splinterm/config.ini "$out/share/doc/splinterm/"
+    cp config/splinterm/presets.toml "$out/share/doc/splinterm/presets.example.toml"
+    cp LICENSE THIRD_PARTY.md "$out/share/licenses/splinterm/"
+
+    install -Dm644 dist/systemd/user/splinterd.service "$out/lib/systemd/user/splinterd.service"
+    install -Dm644 dist/systemd/user/app-splinterm.slice "$out/lib/systemd/user/app-splinterm.slice"
+    substituteInPlace "$out/lib/systemd/user/splinterd.service" \
+      --replace-fail '/usr/bin/splinterd' "$out/bin/splinterd" \
+      --replace-fail '/usr/bin/kill' '${coreutils}/bin/kill' \
+      --replace-fail '/usr/share/doc/splinterm' "$out/share/doc/splinterm"
+    substituteInPlace "$out/lib/systemd/user/app-splinterm.slice" \
+      --replace-fail '/usr/share/doc/splinterm' "$out/share/doc/splinterm"
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    runHook preInstallCheck
+    for binary in splinterm splinterd splinterm-relay splinterm-pty-child; do
+      test -x "$out/bin/$binary"
+      test ! -L "$out/bin/$binary"
+      test ! -e "$out/bin/.$binary-wrapped"
+    done
+    test "$(head -n 1 "$out/bin/splinterm-xdg-terminal-exec")" = '#!${runtimeShell}'
+    ${if withMcp then "test -x \"$out/bin/splinterm-mcp\"" else "test ! -e \"$out/bin/splinterm-mcp\""}
+    "$out/bin/splinterm" --help >/dev/null
+    python3 nix/package-smoke.py "$out" '${runtimeShell}'
+    desktop-file-validate "$out/share/applications/com.oldjobobo.splinterm.desktop"
+    runHook postInstallCheck
+  '';
+
+  meta = {
+    description = "Persistent Wayland terminal with a headless session daemon and SSH relay";
+    homepage = "https://github.com/OldJobobo/splinterm";
+    license = lib.licenses.mit;
+    platforms = [ "x86_64-linux" ];
+    mainProgram = "splinterm";
+  };
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -39,7 +39,8 @@ rustPlatform.buildRustPackage {
         "fixtures"
         "tests"
         "tools"
-        "nix"
+        # Only this script is a package input; VM harness edits must not rebuild Rust.
+        "nix/package-smoke.py"
         "README.md"
         "LICENSE"
         "THIRD_PARTY.md"

--- a/tools/release/test_nix_ci_workflow.py
+++ b/tools/release/test_nix_ci_workflow.py
@@ -1,0 +1,31 @@
+"""Keep Nix validation inside the existing required CI boundary."""
+
+import unittest
+from pathlib import Path
+
+WORKFLOW = Path(__file__).resolve().parents[2] / ".github/workflows/ci.yml"
+
+
+class NixCiWorkflowTests(unittest.TestCase):
+    def test_required_check_depends_on_nix(self):
+        text = WORKFLOW.read_text()
+        self.assertRegex(text, r"(?m)^  check:\n    needs: nix\n")
+        nix_job = text.split("\n  nix:\n", 1)[1].split("\n  check:\n", 1)[0]
+        self.assertNotIn("continue-on-error", nix_job)
+        self.assertNotRegex(nix_job, r"(?m)^\s+if:")
+        self.assertIn("run: test -r /dev/kvm && test -w /dev/kvm", nix_job)
+        self.assertIn("run: nix flake check --print-build-logs --max-jobs 2 --cores 4", nix_job)
+        self.assertRegex(nix_job, r"cachix/install-nix-action@[0-9a-f]{40}\b")
+        self.assertIn("persist-credentials: false", nix_job)
+        self.assertNotRegex(nix_job, r"desktop-(smoke|test)")
+
+    def test_pull_requests_and_maintenance_pushes_run_validation(self):
+        text = WORKFLOW.read_text()
+        self.assertIn('branches: [main, "maint/0.1"]', text)
+        self.assertRegex(text, r"(?m)^  pull_request:")
+        self.assertNotRegex(text, r"(?m)^\s+paths(?:-ignore)?:")
+        self.assertIn("tools/release/test_nix_ci_workflow.py", text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Add source-built NixOS packaging to the 0.1 maintenance line without bringing in unrelated 0.2 changes.

- Pinned x86_64-linux flake: complete Wayland/CLI/daemon package and optional matching MCP variant.
- NixOS module with desktop fonts/launcher, on-demand user service, optional login startup, and workload cgroup limits. Authenticated binaries remain unwrapped siblings.
- Strictly validated remote executable paths for NixOS SSH hosts; Arch default unchanged.
- Native window titles retain “Splinterm” alongside shell titles.
- Headless VM lifecycle/identity/SSH/upgrade/rollback checks, opt-in desktop fixtures, and Nix CI gating through the existing required check job.
- Preserve 0.1's inherited aggregate task limits and nested memory policy; document installation and limitations.

## Validation — head 10a12dc

- `nix flake check --max-jobs 2 --cores 4`: passed; default/MCP packages, module assertions, and booted headless VM suite.
- `cargo clippy --frozen --workspace --all-targets -- -D warnings`: passed.
- `cargo fmt --all --check` and `git diff origin/maint/0.1 --check`: passed.
- Existing CI Python unittest boundary plus Nix workflow regressions: 62 passed.
- Rust workspace: 1,223 passed, 9 ignored, with `cargo test --frozen --workspace -- --test-threads=1 --skip diagnostics::tests::journal_transport_is_exact_and_unavailability_is_bounded`.
- The one excluded diagnostics test passed separately using `cargo test --frozen -p splinterm --lib diagnostics::tests::journal_transport_is_exact_and_unavailability_is_bounded -- --exact --test-threads=1`. Total: 1,224 passing tests. Its generated Unix socket requires a shorter path than the rest of the suite: this case used an inherited directory FD alias; security tests used a real nonsymlink temporary path. No source assertions were disabled or weakened.
- Fresh independent read-only review: approved, no blockers or fixes requested.

## Remaining release boundaries

- Hosted GitHub KVM, disk usage, and CI runtime still need confirmation from this PR's checks.
- Exact-0.1 graphical NixOS acceptance has not been rerun. Earlier original-branch Sway/Plasma results are not claimed as exact-0.1 evidence; graphical fixtures remain opt-in.
- Source-built x86_64-linux support only; no binary cache or nixpkgs submission.
- No version bump, release tag, release publication, or machine deployment in this PR. Original v0.1.0 predates these changes.
